### PR TITLE
fix(chatgpt): persistent memory + TUI duplicate + auto-fallback (d.25)

### DIFF
--- a/src/agent/codebuddy-agent.ts
+++ b/src/agent/codebuddy-agent.ts
@@ -195,10 +195,31 @@ export class CodeBuddyAgent extends BaseAgent {
     this.repairCoordinator.on('repair:error', this.repairListeners.error);
 
     // Initialize StreamingHandler
+    //
+    // `extractToolCalls` parses streamed content for embedded "commentary
+    // tool calls" — useful for small Ollama models that hallucinate JSON
+    // tool-call shapes inside their text. But for backends with native
+    // structured tool_calls (ChatGPT Codex, Anthropic, Gemini, Grok...),
+    // it triggers false positives when the LLM legitimately mentions tool
+    // names in markdown backticks (e.g. "use `view_file` to read"), which
+    // splits the response into duplicate TUI entries (Phase d.25 fix).
+    //
+    // Heuristic: enable only for local/small models that can't emit
+    // structured tool_calls. Everything else uses the native API path.
+    const lower = modelToUse.toLowerCase();
+    const isLocalOrSmall =
+      lower.startsWith('qwen') ||
+      lower.startsWith('llama') ||
+      lower.startsWith('deepseek') ||
+      lower.startsWith('gemma') ||
+      lower.startsWith('mistral') ||
+      lower.startsWith('ollama/') ||
+      lower.includes(':') /* Ollama tag form like `qwen2.5-coder:7b` */;
     this.streamingHandler = new StreamingHandler({
       model: modelToUse,
       trackTokens: true,
-      sanitizeOutput: true
+      sanitizeOutput: true,
+      extractToolCalls: isLocalOrSmall,
     });
 
     // Initialize ToolHandler

--- a/src/agent/streaming/streaming-handler.ts
+++ b/src/agent/streaming/streaming-handler.ts
@@ -275,21 +275,37 @@ export class StreamingHandler {
       }
     }
 
-    // Calculate token count if enabled
+    // Calculate token count if enabled.
+    //
+    // Trigger on ANY token-relevant delta — not just `displayContent`.
+    // Bug caught by gpt-5.5 audit (Phase d.25): a turn that emits only
+    // tool_calls (no text content) or only reasoning chunks would never
+    // update the running token count, so the per-turn token usage line
+    // shown in the TUI was wrong for those turns. Now we also recount
+    // when reasoning streams in or when tool_calls accumulate.
     let tokenCount: number | undefined;
     let shouldEmitTokenCount = false;
 
-    if (this.config.trackTokens && this.tokenCounter && displayContent) {
+    const hasTokenRelevantDelta =
+      !!displayContent ||
+      !!reasoningDelta ||
+      (Array.isArray(this.accumulatedMessage.tool_calls) &&
+        this.accumulatedMessage.tool_calls.length > 0);
+
+    if (this.config.trackTokens && this.tokenCounter && hasTokenRelevantDelta) {
       const contentTokens = this.tokenCounter.estimateStreamingTokens(
         this.accumulatedRawContent
       );
+      const reasoningTokens = this.accumulatedReasoningContent
+        ? this.tokenCounter.estimateStreamingTokens(this.accumulatedReasoningContent)
+        : 0;
       const toolCallTokens = this.accumulatedMessage.tool_calls
         ? this.tokenCounter.countTokens(
             JSON.stringify(this.accumulatedMessage.tool_calls)
           )
         : 0;
 
-      tokenCount = contentTokens + toolCallTokens;
+      tokenCount = contentTokens + reasoningTokens + toolCallTokens;
 
       // Check if we should emit a token count update
       const now = Date.now();

--- a/src/codebuddy/providers/provider-chatgpt-responses.ts
+++ b/src/codebuddy/providers/provider-chatgpt-responses.ts
@@ -66,6 +66,21 @@ export interface ChatGptResponsesProviderOptions {
   refreshAuth?: () => Promise<ChatGptAuth | null>;
   model: string;
   defaultMaxTokens: number;
+  /**
+   * If true, skip auto-fallback when the backend rejects a model with
+   * `model_not_supported` / `model_not_found`. Default: false (i.e.
+   * auto-fallback is ON when the user did not pin `--model`). Useful
+   * for tests, or when the user genuinely wants to see the raw error.
+   */
+  disableModelFallback?: boolean;
+}
+
+/** Pick the next viable model after `current` from FALLBACK_MODELS.
+ *  Returns null if `current` is already the last entry or absent. */
+function pickFallbackModel(current: string): string | null {
+  const idx = FALLBACK_MODELS.indexOf(current);
+  if (idx < 0) return FALLBACK_MODELS[0]; // current not in list → start from top
+  return FALLBACK_MODELS[idx + 1] ?? null;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -156,6 +171,7 @@ export class ChatGptResponsesProvider implements Provider {
    * restart, so no asymmetry is introduced).
    */
   private lastTurnReasoningItems: ResponsesReasoningItem[] = [];
+  private disableModelFallback: boolean;
 
   constructor(opts: ChatGptResponsesProviderOptions) {
     this.authProvider = opts.authProvider;
@@ -163,6 +179,7 @@ export class ChatGptResponsesProvider implements Provider {
     this.currentModel = opts.model;
     this.defaultMaxTokens = opts.defaultMaxTokens;
     this.promptCacheKey = `cb-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    this.disableModelFallback = opts.disableModelFallback ?? false;
   }
 
   setModel(model: string): void {
@@ -264,6 +281,30 @@ export class ChatGptResponsesProvider implements Provider {
         );
       }
       response = await this.postResponses(body, auth);
+    }
+
+    // 400 / 404 with `model_not_supported` (or `model_not_found`) →
+    // auto-fallback to the first FALLBACK_MODELS entry the user hasn't
+    // already tried. Saves them from copy-pasting `--model gpt-5.1-codex`
+    // when the backend rotates available slugs. Capped at one retry.
+    if (
+      !response.ok &&
+      (response.status === 400 || response.status === 404) &&
+      !this.disableModelFallback &&
+      !opts.model // only auto-switch when user didn't explicitly pin a model
+    ) {
+      const errorText = await response.clone().text().catch(() => '');
+      if (/model.*(not.{0,5}supported|not.{0,5}found)/i.test(errorText)) {
+        const fallback = pickFallbackModel(model);
+        if (fallback) {
+          logger.warn(
+            `[chatgpt-responses] Model "${model}" rejected by backend. Auto-falling back to "${fallback}". Set --model explicitly to override.`,
+          );
+          body.model = fallback;
+          this.currentModel = fallback;
+          response = await this.postResponses(body, auth);
+        }
+      }
     }
 
     if (!response.ok) {

--- a/src/codebuddy/providers/provider-chatgpt-responses.ts
+++ b/src/codebuddy/providers/provider-chatgpt-responses.ts
@@ -309,7 +309,11 @@ export class ChatGptResponsesProvider implements Provider {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => '');
-      throw enrichError(response.status, errorText, model);
+      // Report the model that was ACTUALLY rejected by the final
+      // request — `body.model` may have been mutated by the auto-fallback
+      // branch above. The local `model` variable is the original
+      // request, which is misleading after a fallback.
+      throw enrichError(response.status, errorText, body.model);
     }
 
     if (!response.body) {
@@ -319,9 +323,11 @@ export class ChatGptResponsesProvider implements Provider {
     // Reset capture buffer for THIS response — only successful new
     // reasoning blobs should populate `lastTurnReasoningItems`. We swap
     // in a fresh array so the SSE parser can push without races.
+    // Pass `body.model` (post-fallback) so streaming chunks are labelled
+    // with the model that actually served the response.
     const capturedReasoning: ResponsesReasoningItem[] = [];
     try {
-      yield* parseSseStream(response.body, model, (item) => {
+      yield* parseSseStream(response.body, body.model, (item) => {
         capturedReasoning.push(item);
       });
     } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,16 +283,14 @@ async function ensureUserSettingsDirectory(): Promise<void> {
   }
 }
 
-// Detected provider configuration
-interface DetectedProvider {
-  provider: 'gemini' | 'grok' | 'openai' | 'anthropic' | 'ollama' | 'chatgpt' | 'unknown';
-  apiKey: string;
-  baseURL: string;
-  defaultModel: string;
-}
+// Detected provider configuration — moved to `src/utils/provider-detector.ts`
+// (Phase d.25) so it can be unit-tested in isolation. Re-exported here
+// for the rest of this file's call sites.
+import { detectProviderFromEnv, type DetectedProvider } from './utils/provider-detector.js';
 
-// Detect provider from environment variables
-function detectProviderFromEnv(): DetectedProvider | null {
+// Legacy inline implementation kept commented for git-archaeology only.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _detectProviderFromEnvLegacy(): DetectedProvider | null {
   // Priority order (mirror of src/fleet/peer-chat-client-factory.ts —
   // explicit user intent first, then local, then cloud env keys):
   //   0. CODEBUDDY_PROVIDER override (always wins when set + valid)

--- a/src/services/prompt-builder.ts
+++ b/src/services/prompt-builder.ts
@@ -137,6 +137,16 @@ export class PromptBuilder {
         let persistentMemoryContext = "";
         if (this.persistentMemory) {
           try {
+            // CodeBuddyAgent fires `initializeMemory()` without awaiting,
+            // so the in-memory Maps may still be empty when this builder
+            // runs on the user's first message after launch. Force-await
+            // initialize() (idempotent — the manager has its own initPromise
+            // gate) so the user-scoped persistent memory is actually loaded
+            // from ~/.codebuddy/memory.md before we read it.
+            const pmAny = this.persistentMemory as unknown as { initialize?: () => Promise<void> };
+            if (typeof pmAny.initialize === 'function') {
+              await pmAny.initialize();
+            }
             persistentMemoryContext = this.persistentMemory.getContextForPrompt();
           } catch (err) {
             logger.warn("Failed to build persistent memory context", { error: getErrorMessage(err) });
@@ -201,6 +211,24 @@ export class PromptBuilder {
           this.config.cwd,
           customInstructions || undefined
         );
+      }
+
+      // Inject persistent memory context for paths that don't already
+      // pass it to a PromptManager (legacy + chat-only). Without this,
+      // the user's `remember`-stored facts (~/.codebuddy/memory.md)
+      // never reach the LLM on session restart, so e.g. the saved
+      // first name appears written to disk but the next session asks
+      // "what's your name?" anyway. The `if (systemPromptId ...)` and
+      // `else if (systemPromptId === 'auto')` branches above already
+      // forward `memoryContext` via `promptManager.buildSystemPrompt({
+      // memoryContext })`, so we skip injection there.
+      const wentThroughPromptManager =
+        (systemPromptId && systemPromptId !== 'auto') || systemPromptId === 'auto';
+      if (memoryContext && !wentThroughPromptManager) {
+        systemPrompt += `\n\n<persistent_memory>\n${memoryContext}\n</persistent_memory>`;
+        logger.debug('Injected persistent memory context into system prompt', {
+          chars: memoryContext.length,
+        });
       }
 
       // Prepend intro hook content if available (Moltbot-style role injection)

--- a/src/services/prompt-builder.ts
+++ b/src/services/prompt-builder.ts
@@ -414,8 +414,10 @@ Four categories — pick the right one:
 
 When to call \`lessons_add\`:
 - After the user corrects your approach — extract the rule/pattern that would have prevented the mistake
+- **After completing a bug-finding / audit / code-review task** — capture the underlying pattern as a RULE or INSIGHT so the same class of bug is detectable next time (e.g. "After mutating a request body field, prefer body.* as source of truth over the original local variable")
 - When you discover a project convention or gotcha not derivable from code or git log
 - When you find a successful pattern you would re-apply on similar tasks
+- After resolving a non-trivial debugging session — extract what was non-obvious about the root cause
 
 When to call \`lessons_search\` (BEFORE acting on a related task):
 - Before implementing a feature similar to one the user previously corrected

--- a/src/utils/provider-detector.ts
+++ b/src/utils/provider-detector.ts
@@ -1,0 +1,113 @@
+/**
+ * Provider auto-detection — extracted from src/index.ts (Phase d.25).
+ *
+ * Reads env vars + filesystem state to pick the active LLM provider for
+ * a Code Buddy session. Pure function (no side effects beyond stat/read
+ * on the OAuth file) so it's unit-testable.
+ *
+ * Priority order:
+ *   0. CODEBUDDY_PROVIDER override (always wins when set + valid)
+ *   1. ChatGPT OAuth credentials present (~/.codebuddy/codex-auth.json)
+ *      → explicit "I logged in" act beats ambient env vars
+ *   2. OLLAMA_HOST    → ollama (local, free, unlimited)
+ *   3. GROK_API_KEY   → grok / OpenAI-compat (incl. xAI)
+ *   4. GEMINI/GOOGLE  → gemini
+ *   5. OPENAI         → openai
+ *   6. ANTHROPIC      → anthropic
+ *   else null (no provider available)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface DetectedProvider {
+  provider: 'gemini' | 'grok' | 'openai' | 'anthropic' | 'ollama' | 'chatgpt' | 'unknown';
+  apiKey: string;
+  baseURL: string;
+  defaultModel: string;
+}
+
+export function detectProviderFromEnv(): DetectedProvider | null {
+  const override = process.env.CODEBUDDY_PROVIDER?.toLowerCase();
+
+  // ChatGPT subscription auth — explicit login wins over ambient
+  // env-detected providers. User who ran `buddy login chatgpt` recently
+  // expects subsequent calls to route through their ChatGPT plan, not
+  // get hijacked by an OLLAMA_HOST set in their shell rc weeks ago.
+  if (override === 'chatgpt' || !override) {
+    try {
+      const authPath = path.join(os.homedir(), '.codebuddy', 'codex-auth.json');
+      if (fs.existsSync(authPath)) {
+        const raw = fs.readFileSync(authPath, 'utf-8').trim();
+        const parsed = raw ? JSON.parse(raw) : null;
+        if (parsed?.tokens?.access_token) {
+          return {
+            provider: 'chatgpt',
+            apiKey: 'oauth-chatgpt',
+            baseURL: 'https://chatgpt.com/backend-api/codex',
+            defaultModel: process.env.CHATGPT_MODEL || 'gpt-5.5',
+          };
+        }
+      }
+    } catch {
+      // Malformed auth file or unexpected — fall through.
+    }
+  }
+
+  if (override === 'ollama' || (!override && process.env.OLLAMA_HOST)) {
+    let host = process.env.OLLAMA_HOST || 'http://localhost:11434';
+    if (!/^https?:\/\//i.test(host)) host = `http://${host}`;
+    if (!host.endsWith('/v1')) host = host.replace(/\/+$/, '') + '/v1';
+    return {
+      provider: 'ollama',
+      apiKey: 'ollama',
+      baseURL: host,
+      defaultModel: process.env.GROK_MODEL || process.env.OLLAMA_MODEL || 'qwen2.5-coder:7b',
+    };
+  }
+
+  if (
+    (override === 'grok' || override === 'xai') ||
+    (!override && (process.env.GROK_API_KEY || process.env.XAI_API_KEY))
+  ) {
+    return {
+      provider: 'grok',
+      apiKey: process.env.GROK_API_KEY || process.env.XAI_API_KEY || '',
+      baseURL: process.env.GROK_BASE_URL || 'https://api.x.ai/v1',
+      defaultModel: process.env.GROK_MODEL || 'grok-3-fast',
+    };
+  }
+
+  if (
+    (override === 'gemini' || override === 'google') ||
+    (!override && (process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY))
+  ) {
+    return {
+      provider: 'gemini',
+      apiKey: process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY || '',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      defaultModel: process.env.GEMINI_MODEL || 'gemini-2.5-flash',
+    };
+  }
+
+  if (override === 'openai' || (!override && process.env.OPENAI_API_KEY)) {
+    return {
+      provider: 'openai',
+      apiKey: process.env.OPENAI_API_KEY || '',
+      baseURL: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
+      defaultModel: process.env.OPENAI_MODEL || 'gpt-4o',
+    };
+  }
+
+  if (override === 'anthropic' || (!override && process.env.ANTHROPIC_API_KEY)) {
+    return {
+      provider: 'anthropic',
+      apiKey: process.env.ANTHROPIC_API_KEY || '',
+      baseURL: 'https://api.anthropic.com/v1',
+      defaultModel: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514',
+    };
+  }
+
+  return null;
+}

--- a/tests/codebuddy/providers/provider-chatgpt-responses.test.ts
+++ b/tests/codebuddy/providers/provider-chatgpt-responses.test.ts
@@ -661,6 +661,104 @@ describe('ChatGptResponsesProvider — chatStream wiring', () => {
     expect(body.reasoning).toBeUndefined();
   });
 
+  it('auto-fallback: model_not_supported triggers retry with next FALLBACK_MODELS entry', async () => {
+    const responses: Response[] = [
+      // Round 1 with the user's chosen model → 400 model_not_supported
+      new Response(
+        JSON.stringify({ detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account." }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      ),
+      // Round 2 with the auto-fallback → success
+      streamingResponse([
+        'data: {"type":"response.output_text.delta","delta":"OK"}\n\n',
+        'data: {"type":"response.completed"}\n\n',
+      ]),
+    ];
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return responses.shift() ?? new Response('', { status: 500 });
+    });
+
+    const provider = new ChatGptResponsesProvider({
+      authProvider: async () => authBundle(),
+      model: 'gpt-5.5', // first FALLBACK_MODELS entry is 'gpt-5.1-codex'
+      defaultMaxTokens: 1000,
+    });
+
+    const out: string[] = [];
+    for await (const chunk of provider.chatStream(
+      [{ role: 'user', content: 'X' } as CodeBuddyMessage],
+      [],
+      {}, // no `model` override → auto-fallback enabled
+    )) {
+      const c = chunk.choices[0]?.delta?.content;
+      if (c) out.push(c);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(out.join('')).toBe('OK');
+    // 2nd request used the fallback model (first entry of FALLBACK_MODELS).
+    const body2 = JSON.parse((fetchMock.mock.calls[1]![1] as RequestInit).body as string);
+    expect(body2.model).toBe('gpt-5.1-codex');
+  });
+
+  it('auto-fallback: skipped when caller pinned --model explicitly', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: "The 'gpt-5.5' model is not supported." }),
+        { status: 400 },
+      ),
+    );
+
+    const provider = new ChatGptResponsesProvider({
+      authProvider: async () => authBundle(),
+      model: 'fallback-model',
+      defaultMaxTokens: 1000,
+    });
+
+    let caught: Error | null = null;
+    try {
+      const gen = provider.chatStream(
+        [{ role: 'user', content: 'X' } as CodeBuddyMessage],
+        [],
+        { model: 'gpt-5.5' }, // explicit pin → no fallback
+      );
+      for await (const _ of gen) { /* drain */ }
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeTruthy();
+    expect(caught!.message).toContain('gpt-5.5');
+  });
+
+  it('auto-fallback: skipped when disableModelFallback=true', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: "The 'gpt-5.5' model is not supported." }),
+        { status: 400 },
+      ),
+    );
+
+    const provider = new ChatGptResponsesProvider({
+      authProvider: async () => authBundle(),
+      model: 'gpt-5.5',
+      defaultMaxTokens: 1000,
+      disableModelFallback: true,
+    });
+
+    let caught: Error | null = null;
+    try {
+      const gen = provider.chatStream(
+        [{ role: 'user', content: 'X' } as CodeBuddyMessage],
+        [],
+        {},
+      );
+      for await (const _ of gen) { /* drain */ }
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeTruthy();
+  });
+
   it('surfaces model_not_found errors with suggested fallbacks', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ error: { code: 'model_not_found', message: 'not allowed' } }), {

--- a/tests/codebuddy/providers/provider-chatgpt-responses.test.ts
+++ b/tests/codebuddy/providers/provider-chatgpt-responses.test.ts
@@ -770,6 +770,9 @@ describe('ChatGptResponsesProvider — chatStream wiring', () => {
       authProvider: async () => authBundle(),
       model: 'gpt-5.5',
       defaultMaxTokens: 1000,
+      // Disable auto-fallback so the rejection message references the
+      // exact model the caller used, not the post-fallback retry slug.
+      disableModelFallback: true,
     });
 
     let caught: Error | null = null;

--- a/tests/services/prompt-builder.test.ts
+++ b/tests/services/prompt-builder.test.ts
@@ -379,6 +379,10 @@ describe('PromptBuilder — Phase T4', () => {
       expect(finalPrompt).toContain('`lessons_search`');
       expect(finalPrompt).toContain('Manus AI');
       expect(finalPrompt).toMatch(/After the user corrects your approach/i);
+      // Phase d.25: lessons_add should also fire after a bug-finding /
+      // audit / code-review task, so the LLM captures the underlying
+      // pattern as an actionable rule for next time.
+      expect(finalPrompt).toMatch(/bug-finding|audit|code-review/i);
     });
 
     it('injects BOTH directives (presence; order is intentionally shuffled by varySystemPrompt)', async () => {

--- a/tests/utils/cost-chatgpt-subscription.test.ts
+++ b/tests/utils/cost-chatgpt-subscription.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Phase d.25 — tests for cost=0 on ChatGPT subscription models.
+ *
+ * The Codex backend (chatgpt.com/backend-api/codex/responses) bills
+ * against the user's flat-fee Plus/Pro plan, NOT per token. Reporting
+ * USD spend would be misleading. Both `cost-tracker.calculateCost()`
+ * and `token-display.estimateCost()` zero out for matching slugs.
+ *
+ * The detection is intentionally conservative — only slugs the OpenAI
+ * Platform API does NOT also expose are zeroed out. `gpt-5` and
+ * `gpt-5.1` (without `-codex`) keep normal pricing because they're also
+ * billable via API key auth.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CostTracker } from '../../src/utils/cost-tracker.js';
+import { estimateCost } from '../../src/utils/token-display.js';
+
+describe('CostTracker.calculateCost — ChatGPT subscription zeroing', () => {
+  // Use disabled-tracking config so the test doesn't write to disk.
+  const tracker = new CostTracker({ trackHistory: false });
+
+  it('returns 0 for gpt-5.5 (Codex-backend exclusive)', () => {
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.5')).toBe(0);
+  });
+
+  it('returns 0 for any *-codex model variant', () => {
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.1-codex')).toBe(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-5-codex')).toBe(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.1-codex-max')).toBe(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.3-codex')).toBe(0);
+  });
+
+  it('returns 0 for codex-1 and codex-mini families', () => {
+    expect(tracker.calculateCost(1000, 500, 'codex-1')).toBe(0);
+    expect(tracker.calculateCost(1000, 500, 'codex-mini-latest')).toBe(0);
+  });
+
+  it('returns NON-zero for gpt-5 and gpt-5.1 (also billable via API key)', () => {
+    expect(tracker.calculateCost(1000, 500, 'gpt-5')).toBeGreaterThan(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.1')).toBeGreaterThan(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-5.4')).toBeGreaterThan(0);
+  });
+
+  it('returns NON-zero for unrelated models (grok, claude, gemini)', () => {
+    expect(tracker.calculateCost(1000, 500, 'grok-3-fast')).toBeGreaterThan(0);
+    expect(tracker.calculateCost(1000, 500, 'claude-opus-4-6')).toBeGreaterThan(0);
+    expect(tracker.calculateCost(1000, 500, 'gpt-4o')).toBeGreaterThan(0);
+  });
+
+  it('case-insensitive matching', () => {
+    expect(tracker.calculateCost(1000, 500, 'GPT-5.5')).toBe(0);
+    expect(tracker.calculateCost(1000, 500, 'Gpt-5-Codex')).toBe(0);
+  });
+});
+
+describe('estimateCost (token-display) — same zeroing as CostTracker', () => {
+  it('returns 0 for gpt-5.5 when model is passed', () => {
+    expect(estimateCost(1000, 500, undefined, undefined, 'gpt-5.5')).toBe(0);
+  });
+
+  it('returns 0 for *-codex models when model is passed', () => {
+    expect(estimateCost(1000, 500, undefined, undefined, 'gpt-5.1-codex')).toBe(0);
+    expect(estimateCost(1000, 500, undefined, undefined, 'gpt-5-codex')).toBe(0);
+  });
+
+  it('returns NON-zero when no model passed (back-compat)', () => {
+    expect(estimateCost(1000, 500)).toBeGreaterThan(0);
+  });
+
+  it('returns NON-zero for billable models even with model param', () => {
+    expect(estimateCost(1000, 500, undefined, undefined, 'grok-3-fast')).toBeGreaterThan(0);
+    expect(estimateCost(1000, 500, undefined, undefined, 'gpt-4o')).toBeGreaterThan(0);
+  });
+});

--- a/tests/utils/provider-detector.test.ts
+++ b/tests/utils/provider-detector.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Phase d.25 — tests for src/utils/provider-detector.ts.
+ *
+ * Verifies the priority chain: chatgpt OAuth > ollama > grok > gemini >
+ * openai > anthropic > null. The chatgpt-vs-ollama priority is the
+ * critical one Patrice asked for: an explicit `buddy login chatgpt`
+ * should NOT be hijacked by a stale OLLAMA_HOST in the user's shell rc.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { vi } from 'vitest';
+
+let tmpHome: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof os>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+// Snapshot env so tests can clobber and restore cleanly.
+const envKeysToReset = [
+  'CODEBUDDY_PROVIDER',
+  'OLLAMA_HOST',
+  'OLLAMA_MODEL',
+  'GROK_API_KEY',
+  'GROK_BASE_URL',
+  'GROK_MODEL',
+  'XAI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GEMINI_API_KEY',
+  'GEMINI_MODEL',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_MODEL',
+  'CHATGPT_MODEL',
+];
+const envBackup: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  // Fresh isolated HOME so codex-auth.json is per-test.
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-detector-'));
+  // Clear all relevant env keys.
+  for (const k of envKeysToReset) {
+    envBackup[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const k of envKeysToReset) {
+    if (envBackup[k] !== undefined) {
+      process.env[k] = envBackup[k];
+    } else {
+      delete process.env[k];
+    }
+  }
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function writeAuth(content: unknown = { tokens: { access_token: 'tok' } }): void {
+  const dir = path.join(tmpHome, '.codebuddy');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'codex-auth.json'),
+    typeof content === 'string' ? content : JSON.stringify(content),
+  );
+}
+
+describe('detectProviderFromEnv — priority chain', () => {
+  it('returns null when nothing is configured', async () => {
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()).toBeNull();
+  });
+
+  it('chatgpt OAuth credentials beat ambient OLLAMA_HOST', async () => {
+    writeAuth();
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    process.env.GROK_API_KEY = 'should-not-be-used';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    const detected = detectProviderFromEnv();
+    expect(detected?.provider).toBe('chatgpt');
+    expect(detected?.apiKey).toBe('oauth-chatgpt');
+    expect(detected?.baseURL).toBe('https://chatgpt.com/backend-api/codex');
+    expect(detected?.defaultModel).toBe('gpt-5.5');
+  });
+
+  it('CODEBUDDY_PROVIDER override always wins (forces ollama even if chatgpt OAuth file exists)', async () => {
+    writeAuth();
+    process.env.CODEBUDDY_PROVIDER = 'ollama';
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    const detected = detectProviderFromEnv();
+    expect(detected?.provider).toBe('ollama');
+  });
+
+  it('falls back to ollama when no chatgpt OAuth + OLLAMA_HOST set', async () => {
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    process.env.GROK_API_KEY = 'should-not-be-used';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.provider).toBe('ollama');
+  });
+
+  it('ollama auto-prepends http:// and appends /v1 to OLLAMA_HOST', async () => {
+    process.env.OLLAMA_HOST = 'localhost:11434';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.baseURL).toBe('http://localhost:11434/v1');
+  });
+
+  it('falls back to grok when no chatgpt + no ollama + GROK_API_KEY set', async () => {
+    process.env.GROK_API_KEY = 'xai-key';
+    process.env.GEMINI_API_KEY = 'should-not-be-used';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    const detected = detectProviderFromEnv();
+    expect(detected?.provider).toBe('grok');
+    expect(detected?.apiKey).toBe('xai-key');
+  });
+
+  it('falls back to gemini when only GEMINI_API_KEY is set', async () => {
+    process.env.GEMINI_API_KEY = 'aiza-key';
+    process.env.OPENAI_API_KEY = 'should-not-be-used';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.provider).toBe('gemini');
+  });
+
+  it('falls back to openai when only OPENAI_API_KEY is set', async () => {
+    process.env.OPENAI_API_KEY = 'sk-key';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    const detected = detectProviderFromEnv();
+    expect(detected?.provider).toBe('openai');
+    expect(detected?.defaultModel).toBe('gpt-4o');
+  });
+
+  it('falls back to anthropic when only ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-key';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.provider).toBe('anthropic');
+  });
+
+  it('skips chatgpt path when codex-auth.json exists but has no access_token', async () => {
+    writeAuth({ tokens: {} });
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.provider).toBe('ollama');
+  });
+
+  it('skips chatgpt path when codex-auth.json is malformed JSON', async () => {
+    writeAuth('not-json{{{');
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.provider).toBe('ollama');
+  });
+
+  it('CHATGPT_MODEL env overrides default gpt-5.5', async () => {
+    writeAuth();
+    process.env.CHATGPT_MODEL = 'gpt-5.1-codex';
+    const { detectProviderFromEnv } = await import('../../src/utils/provider-detector.js');
+    expect(detectProviderFromEnv()?.defaultModel).toBe('gpt-5.1-codex');
+  });
+});


### PR DESCRIPTION
## Summary

Phase d.25 — five real-world fixes after shipping ChatGPT Codex OAuth in d.23/d.24. All caught while testing on Patrice's pro account during a live session.

### Phase 0 (CRITICAL) — Persistent memory not loaded on session restart
The \`remember\` tool wrote to \`~/.codebuddy/memory.md\` correctly, but the next \`buddy\` session asked \"what's your name?\" anyway. Two combined bugs:
1. \`CodeBuddyAgent\` fires \`initializeMemory()\` without awaiting → race where \`PromptBuilder\` reads \`userMemories\` Map before \`loadMemories()\` finishes
2. \`memoryContext\` was computed but only forwarded to \`PromptManager\` paths (\`systemPromptId === 'auto'\` / external id) — legacy + chat-only paths dropped it

Fix: force-await \`initialize()\` in prompt-builder + explicit \`<persistent_memory>\` block injection in those paths too.

### Phase 1 — TUI duplicate response
When gpt-5.5 mentions tool names in markdown backticks (\`view_file\`, \`bash\`, etc.), \`extractCommentaryToolCalls\` interprets them as embedded tool calls → fake \`tool_calls\` event → finalizes the streaming entry → rest of response creates a second entry. Fix: enable commentary extraction ONLY for local/small models (Ollama qwen/llama/deepseek/gemma/mistral). Backends with native structured tool_calls (ChatGPT, Claude, Gemini, Grok) skip it.

### Phase 4 — Auto-fallback on \`model_not_supported\`
When the backend rejects the user's model AND \`--model\` wasn't pinned, retry once with the next \`FALLBACK_MODELS\` slug. Saves \`--model gpt-5.1-codex\` copy-pasting when OpenAI rotates available slugs. Disable via \`disableModelFallback\`.

### Phases 2 + 3 — Test coverage
- **+12 tests** for \`detectProviderFromEnv\` priority chain (chatgpt > ollama > grok > gemini > openai > anthropic) including edge cases. Required extracting it from \`index.ts\` to \`src/utils/provider-detector.ts\`.
- **+10 tests** for cost=0 logic across CostTracker + token-display.
- **+3 tests** for auto-fallback flow.

## Test plan

- [x] \`npm run typecheck\` (root) — clean
- [x] \`npm run typecheck\` (cowork/) — clean
- [x] \`npm run build\` — clean
- [x] **499 tests** pass (+25 from d.24's 474)
- [x] Manual E2E: \`buddy\` → \`mets mon prénom Patrice\` → exit → \`buddy\` → \`quel est mon prénom ?\` returns Patrice
- [x] Manual E2E: response with \`view_file\`, \`bash\`, \`code_graph\` mentions in backticks renders as ONE entry
- [ ] Reviewer to validate auto-fallback flow on a fresh login (would only trigger if backend changes available slugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)