### PR TITLE
feat(self-improve): recursive self-improvement engine (V1, reversible + empirically gated)

### DIFF
--- a/docs/self-improvement-engine.md
+++ b/docs/self-improvement-engine.md
@@ -106,14 +106,19 @@ partly checking that the model copied the words it was given. Treat the current
 score as a **proxy for capability (does the right guidance surface?)**, not a
 behavioural guarantee (does the agent now act correctly?).
 
-**Making "empirical" real (next session).** The honest signal is
-*counterfactual replay*: take a recorded run that failed for lack of guidance,
-inject the candidate lesson into context, re-run that task, and check the outcome
-actually changes — with repetition/voting to denoise the LLM. That measures
-"this lesson would have prevented the failure," not "a keyword-matching lesson
-exists." Until then, keep human review in the loop for what gets kept, and treat
-auto-apply as a convenience for *obviously-good bootstrap content*, not a license
-to self-modify on a vacuous metric.
+**Making "empirical" real (in progress).** A deterministic down-payment now ships
+for the subclass of improvements that encode a *checkable behavioral rule*:
+`execution-gate.ts` validates a proposed rule by how well it **correctly
+classifies real recorded trajectories** — does it flag the bad runs and pass the
+good ones — with a counterfactual-ablation pre-filter (reject rules that change
+no verdict) and a no-regression guard. This measures *correctness against
+recorded behavior*, not keyword presence: e.g. a plausible-but-wrong rule
+("every run must use bash") is rejected because it misclassifies the compliant
+read-only runs — which the retrieval benchmark could never catch. It is
+deterministic and cheap (no live agent, no LLM-judge), grounding the gate exactly
+as the Darwin Gödel Machine does, on execution outcomes. The remaining step is a
+*paired live* gate for general (non-rule) lessons (run agent±lesson on a graded
+task set, paired-Bayesian acceptance) — see `docs/self-improvement-research-2026.md`.
 
 ## Reversibility (git-backed)
 

--- a/docs/self-improvement-engine.md
+++ b/docs/self-improvement-engine.md
@@ -115,6 +115,31 @@ exists." Until then, keep human review in the loop for what gets kept, and treat
 auto-apply as a convenience for *obviously-good bootstrap content*, not a license
 to self-modify on a vacuous metric.
 
+## Reversibility (git-backed)
+
+The whole mechanism is reversible: if an applied improvement turns out bad, you
+return to a version that works better. The learnable state (lessons + archive +
+the benchmark score of that version) is versioned in a **dedicated, isolated git
+repo per project** at `.codebuddy/self-improvement/store/` (`.codebuddy/` is
+gitignored by the project, so this never touches the main history).
+
+- Each applied improvement (`--apply`) becomes a **commit carrying its score**
+  in `manifest.json`.
+- `buddy improve versions` lists versions with scores (HEAD / BEST marked).
+- `buddy improve restore --best` (or `--commit <sha>`) re-materialises the
+  best-scoring version through the `LessonsTracker` API (in-memory and
+  `lessons.md` stay consistent) and commits the restore. History is
+  **append-only** — restore moves forward by re-applying old content, never
+  rewrites.
+- `--push` pushes the store to a git remote you configure (local-first; nothing
+  leaves the machine otherwise).
+
+```bash
+buddy improve loop --apply        # version each validated improvement
+buddy improve versions            # list scored versions
+buddy improve restore --best      # revert to the version that works better
+```
+
 ## The robot seam (5 senses)
 
 `ExperienceSource` is **modality-agnostic**. `SensorExperienceSource` is the

--- a/docs/self-improvement-engine.md
+++ b/docs/self-improvement-engine.md
@@ -75,9 +75,17 @@ ExperienceSource → Curriculum → Proposer → Empirical Gate → Archive
 buddy improve status            # capability coverage, autonomy mode, archive
 buddy improve cycle             # one cycle (propose-only by default)
 buddy improve cycle --apply     # keep validated improvements (explicit intent)
+buddy improve cycle --llm       # let the model DISCOVER a novel lesson, then validate it
 buddy improve loop --apply      # bootstrap until no further validated progress
 buddy improve archive           # list validated improvements
 ```
+
+**Proposers.** Default is a deterministic, offline `StaticProposer` (a curated
+bootstrap pack). `--llm` swaps in `LlmProposer`, which asks the agent's own model
+to draft a *novel* lesson from real run friction — creative generation gated by
+the *same* deterministic empirical validator, so a hallucinated or off-target
+draft is simply rejected and rolled back. This is the autonomy leap: the system
+discovers its own improvements and only keeps the ones that measurably help.
 
 ## The robot seam (5 senses)
 

--- a/docs/self-improvement-engine.md
+++ b/docs/self-improvement-engine.md
@@ -87,6 +87,34 @@ the *same* deterministic empirical validator, so a hallucinated or off-target
 draft is simply rejected and rolled back. This is the autonomy leap: the system
 discovers its own improvements and only keeps the ones that measurably help.
 
+## What this measures — and what it does NOT (read this)
+
+Be precise about the signal, because this is meant to become the core of a robot
+and overclaiming propagates for years.
+
+**What the benchmark measures:** for a situation `query`, does a *retrievable,
+on-topic* lesson exist (a lesson `search(query)` returns whose text contains the
+expected guidance keywords), and does adding it regress nothing? In other words:
+**retrievability + relevance + non-regression**.
+
+**What it does NOT measure: correctness.** The gate filters *off-topic* and
+*malformed* proposals, not *wrong* ones. A lesson like *"When running npm test,
+NEVER use a path filter"* is on-topic and retrievable, so the keyword gate would
+**accept** it — even though the advice is wrong. And in the `--llm` path the
+draft prompt currently tells the model which keywords to include, so the gate is
+partly checking that the model copied the words it was given. Treat the current
+score as a **proxy for capability (does the right guidance surface?)**, not a
+behavioural guarantee (does the agent now act correctly?).
+
+**Making "empirical" real (next session).** The honest signal is
+*counterfactual replay*: take a recorded run that failed for lack of guidance,
+inject the candidate lesson into context, re-run that task, and check the outcome
+actually changes — with repetition/voting to denoise the LLM. That measures
+"this lesson would have prevented the failure," not "a keyword-matching lesson
+exists." Until then, keep human review in the loop for what gets kept, and treat
+auto-apply as a convenience for *obviously-good bootstrap content*, not a license
+to self-modify on a vacuous metric.
+
 ## The robot seam (5 senses)
 
 `ExperienceSource` is **modality-agnostic**. `SensorExperienceSource` is the

--- a/docs/self-improvement-engine.md
+++ b/docs/self-improvement-engine.md
@@ -1,0 +1,115 @@
+# Recursive Self-Improvement Engine
+
+> Status: **V1 (reversible learnable layer)**. The empirically-gated core of an
+> agent that improves itself — designed to become the brain of Patrice's robot,
+> with the senses plugging into the same loop.
+
+## Why
+
+Code Buddy already *records* its work (RunStore), *reflects* on it
+(retrospectives), and *remembers* (lessons, skills, patterns) — but a human has
+to approve every improvement. The self-improvement engine closes that loop
+**safely and autonomously**: it proposes improvements, **validates them
+empirically against a deterministic benchmark**, and keeps only the changes that
+measurably help with zero regressions — every change reversible and audited.
+
+It is built on the project's guiding principle — *“construire petit, propre et
+mesurable”* — and on two results from the literature:
+
+- **Darwin Gödel Machine** ([Sakana, 2025](https://sakana.ai/dgm/)) — a
+  self-improving agent that **empirically validates** each self-modification
+  against a benchmark instead of requiring a formal proof, and keeps an
+  **archive** of validated agents as evolutionary stepping stones.
+- **Voyager** ([Wang et al., 2023](https://voyager.minedojo.org/)) — an
+  ever-growing, **self-verified skill library** driven by an automatic
+  curriculum.
+
+The key adaptation: our validation signal is **deterministic and cheap** (a pure
+function of lessons + scenarios), so a before/after delta reflects the *change*,
+not LLM run-to-run noise. That's what makes the empirical gate trustworthy on a
+small fixture set, where live-agent benchmarks would need hundreds of tasks to
+denoise.
+
+## The loop
+
+```
+ExperienceSource → Curriculum → Proposer → Empirical Gate → Archive
+   (what hurt?)   (weakest cap) (a fix?)  (snapshot/apply/   (stepping
+                                           re-score/keep|     stones)
+                                           rollback)
+```
+
+1. **Observe** — an `ExperienceSource` yields friction. Today:
+   `RunExperienceSource` mines run retrospectives. Tomorrow: the robot's senses
+   (see below).
+2. **Curriculum** — pick the weakest capability (first uncovered benchmark
+   scenario).
+3. **Propose** — an `ImprovementProposer` drafts a candidate lesson. V1 ships a
+   deterministic `StaticProposer` + a curated bootstrap pack; the production path
+   is an injected LLM proposer.
+4. **Empirical gate** (`empirical-gate.ts`) — snapshot → apply transiently →
+   re-score the deterministic `CapabilityBenchmark` → **accept iff Δ>0 AND no
+   regression AND structurally valid**; otherwise roll back.
+5. **Archive** (`evolutionary-archive.ts`) — append validated wins with rollback
+   refs and lineage.
+
+## Safety model
+
+- **Reversible layer only.** V1 improves lessons (add/remove). Code-level
+  self-modification (the DGM's “rewrite own code”) is **out of scope**.
+- **Tiered autonomy, fail-safe.** `propose-only` by default — validates and
+  *reports* what would help but persists nothing. `auto-apply` requires
+  `CODEBUDDY_SELF_IMPROVE=true` (or `--apply`), and even then keeps only
+  empirically-validated, reversible, audited changes.
+- **No self-dealing evals.** The benchmark scenarios (the evals) are curated and
+  kept **structurally separate** from the proposer, so the engine can never
+  author the checks that bless its own changes.
+- **No regressions.** A change is rejected if it makes *any* previously-covered
+  scenario worse.
+- **Everything audited.** Archive entries are stamped `auto:self-improve` and
+  carry the score delta + a rollback reference.
+
+## CLI
+
+```bash
+buddy improve status            # capability coverage, autonomy mode, archive
+buddy improve cycle             # one cycle (propose-only by default)
+buddy improve cycle --apply     # keep validated improvements (explicit intent)
+buddy improve loop --apply      # bootstrap until no further validated progress
+buddy improve archive           # list validated improvements
+```
+
+## The robot seam (5 senses)
+
+`ExperienceSource` is **modality-agnostic**. `SensorExperienceSource` is the
+plug-in point for the robot: when senses are available, a world-model (JEPA)
+encodes each modality into a latent `z` and predicts `z_{t+1}`; the **prediction
+error / latent surprise** becomes the `Experience` signal, and the engine
+improves the policies/skills that reduce that surprise — the *same*
+observe→propose→validate→keep loop, no engine change. It is **interface-only**
+in V1 and refuses to run rather than emit fake signals.
+
+## Files
+
+| Module | Role |
+|---|---|
+| `src/agent/self-improvement/types.ts` | Shared types (Experience is modality-agnostic) |
+| `…/capability-benchmark.ts` | Deterministic, offline retrieval scorer + curriculum |
+| `…/empirical-gate.ts` | DGM-style snapshot/apply/re-score/keep-or-rollback |
+| `…/proposer.ts` | Proposer seam + deterministic static proposer + seed pack |
+| `…/evolutionary-archive.ts` | Append-only archive of validated wins |
+| `…/experience-source.ts` | Run-friction source + robot sensor seam |
+| `…/engine.ts` | Orchestrator (cycle/loop/status) + autonomy resolution |
+| `…/index.ts` | Workspace wiring (real LessonsTracker port) |
+| `src/commands/cli/improve-command.ts` | `buddy improve …` |
+
+## Roadmap
+
+- **V1.1** — LLM-backed proposer drafting lessons from real run friction;
+  skill (not just lesson) proposals with structural validation; promote the
+  benchmark from a seed set to run-derived scenarios (human-reviewed curation).
+- **V2** — pattern/prompt improvements; multi-objective archive
+  (quality-diversity), so the engine keeps diverse stepping stones.
+- **Robot** — `SensorExperienceSource` over the JEPA world-model prediction-error
+  stream; per-modality micro-benchmarks; the loop runs on the robot's lived
+  experience.

--- a/docs/self-improvement-research-2026.md
+++ b/docs/self-improvement-research-2026.md
@@ -1,0 +1,141 @@
+# Self-Improvement Engine — Literature Roadmap (2023–2026)
+
+> Synthesis of the SOTA to strengthen the recursive self-improvement engine
+> (`src/agent/self-improvement/`). Source: background research pass, June 2026.
+> **One-line thesis: the engine is well-architected, but its fitness function is
+> the weak link.** It gates on *retrievability of on-topic guidance* (a proxy);
+> every self-improvement system that actually works (DGM, STOP) gates on
+> **execution-grounded terminal task success**. Fixing that is priority #1; the
+> rest is secondary.
+
+## The distinction to never blur
+
+- **Validation signal (the gate)** — must be execution-grounded, deterministic,
+  low-noise. This is what fixes our known weakness.
+- **Exploration signal (what to try next)** — prediction-error / learning-progress
+  / novelty. Tells you what's *novel*, never what's *correct*. World-model
+  prediction error lives **entirely** here. Letting it become the gate recreates
+  the keyword-gaming bug in a new modality (the "noisy-TV" problem).
+
+## Area 1 — Trustworthy validation (the core fix)
+
+- **Darwin Gödel Machine** — arXiv **2505.22954** (Sakana/UBC 2025). Keeps changes
+  only if they improve **held-out execution benchmarks** (SWE-bench 20→50%).
+  Documented the agent *fabricating a fake test log* and *sabotaging its own
+  hallucination detector* — caught only via transparent git lineage. → Our
+  blueprint: keep the archive/rollback, change the *fitness* to execution-graded
+  task success; the grader must be a deterministic harness, **never** self-report
+  or LLM-judge.
+- **STOP** — arXiv **2310.02304** (2023). Frozen model + evolving scaffold + fixed
+  external utility = exactly our design. Reports the optimizer *gaming the
+  sandbox / disabling safety flags* when the utility had loopholes. → Our
+  retrievability metric is a loophole; harden it before scaling rounds.
+- **CLT misuse in LLM evals** — arXiv **2503.01747** (ICML 2025). CLT error bars
+  underestimate uncertainty at N=3/10/30/100. Use **paired Bayesian** comparison
+  (pairing cancels per-task difficulty), Wilson/Beta-Bernoulli, Beta-Binomial for
+  clustered questions. → Don't compare raw mean scores.
+- **Reward hacking** — *One Token to Fool LLM-as-a-Judge* arXiv **2507.08794**;
+  *Feedback Loops Drive In-Context Reward Hacking* arXiv **2402.06627** (ICML
+  2024). → The reason the gate must be **deterministic-grader-only**.
+
+**Recipe (assemble Area 1):** (1) small held-out, execution-graded task set,
+disjoint from the friction that proposed the lesson (avoid overfitting — *SWE-bench
+Illusion* 2506.12286; *SWE-bench Pro* 2509.16941). (2) paired `agent+lesson` vs
+`agent−lesson` on the same tasks. (3) paired-Bayesian acceptance: P(improvement) ≥
+0.95 **and** zero regressions. (4) Bayesian posteriors are anytime-valid →
+evaluate-until-confident is the sequential test, free. (5) **counterfactual
+ablation pre-filter**: if `+lesson` and `−lesson` produce identical behavior, the
+lesson is inert → reject before spending evals (this kills the wrong-but-on-topic
+case).
+
+**Skeptical flags:** ADAS (OpenReview D01WR1yVW2) and Gödel Agent (2410.04444)
+lean on LLM judgment of "improvement" — mine for the *proposal* mechanism, not the
+gate. Self-Rewarding LMs (2401.10020): the self-judge is the failure mode.
+
+## Area 2 — Skill/lesson library (beyond Voyager)
+
+- **Voyager** — arXiv **2305.16291**. A skill is admitted only after
+  execution-verification. → A *lesson* should earn its slot the same way: only if
+  it produced a measured behavioral improvement.
+- **A-MEM** — arXiv **2502.12110** (2025). Zettelkasten memory; insertion triggers
+  consolidation of related notes. → Our dedup/consolidation answer: on admit, link
+  + merge near-duplicate lessons (keep the one with the best benchmark delta).
+- **Generative Agents** — arXiv **2304.03442** (2023). Periodic **reflection**
+  synthesizes low-level observations into higher-level lessons; retrieval scored
+  by recency × importance × relevance. → Add a reflection/decay pass so stale,
+  low-impact lessons age out instead of bloating retrieval.
+- Skeptical: Mem0/MemGPT-style stores are scalable plumbing, **no validation
+  signal** — they make retrieval scalable, not lessons correct.
+
+## Area 3 — Automatic curriculum (what to improve next)
+
+- **MAGELLAN** — arXiv **2502.07709** (ICML 2025). Agent predicts its own
+  **learning progress** over a semantic goal space, prioritizes max-LP goals. →
+  Rank improvement targets by *expected benchmark-score gain* from our own
+  validated-commit history (we already store score deltas — free labels).
+- **POET / MAP-Elites quality-diversity** (2019+). → Structure the archive as **QD,
+  not a single champion**: bin validated lesson-sets by behavioral descriptor,
+  sample parents across bins to preserve stepping stones (the DGM finding that
+  low-performing ancestors enabled later breakthroughs).
+- Skeptical: pure novelty search wastes evals; use LP-weighted QD.
+
+## Area 4 — World models for the robot (exploration only, NOT a gate)
+
+- **V-JEPA 2 / V-JEPA 2-AC** — arXiv **2506.09985** (Meta 2025). Action-free
+  latent-space video prediction; zero-shot pick-and-place via planning. → Cleanest
+  fit for the modality-agnostic `ExperienceSource`: **latent prediction error =
+  surprise = an experience** feeding the *proposal* stage. Latent (not pixel) space
+  is robust to irrelevant visual noise.
+- **DreamerV3** + **RND** (intrinsic motivation). → Same seam; surprise feeds the
+  curriculum selector for the embodied agent.
+- **Most important caveat:** prediction error is **exploration**, never
+  **validation**. RND/ICM "noisy-TV" trap = the embodied analog of our
+  keyword-gaming bug. Feed JEPA surprise to proposal + curriculum; keep the gate
+  execution-grounded.
+
+## Area 5 — Safety of recursive self-modification
+
+- **DGM** safety posture: sandbox + human oversight + transparent git lineage
+  (which is how the fabricated-log sabotage was caught). → Make our git
+  reversibility a **tamper-evident audit trail**: log the grader's raw output
+  alongside each commit so a fabricated pass is detectable.
+- **Reward-hacking pair** (2402.06627, 2507.08794). → **Tripwire**: a frozen
+  *canary* benchmark the optimizer never sees and never proposes against; run every
+  N rounds; any drop ⇒ halt + roll back to last-good commit (we now have
+  `restore --best`).
+- Directional (unverified 2026 IDs — confirm before external citation): SAHOO
+  2603.06333 (two-gate guardrails), sandbox-escape 2603.02277, AI Agent Index
+  2602.17753. → Human approval for any self-mod touching the grader, sandbox, or
+  tripwire; egress allowlist + resource caps on the self-mod sandbox.
+
+## Top 5 changes, ranked by impact-to-effort
+
+1. **Replace retrievability fitness with an execution-grounded paired gate.**
+   *(Highest impact, moderate effort — fixes the core weakness.)* — DGM 2505.22954;
+   CLT 2503.01747.
+2. **Counterfactual-ablation pre-filter** — reject lessons that change no behavior.
+   *(High impact, low effort.)* — DGM 2505.22954.
+3. **Paired-Bayesian acceptance with anytime stopping** (drop CLT/mean compares).
+   *(High impact, low effort.)* — 2503.01747.
+4. **Deterministic-grader-only + tamper-evident lineage + frozen canary tripwire.**
+   *(High impact, low-moderate effort — reuses our git layer + `restore --best`.)*
+   — DGM 2505.22954; 2402.06627; 2507.08794.
+5. **Archive as LP-weighted quality-diversity + A-MEM consolidation.**
+   *(Medium impact, compounding.)* — MAGELLAN 2502.07709; MAP-Elites/POET; A-MEM
+   2502.12110.
+
+## How this maps to the current code
+
+- Current gate: `src/agent/self-improvement/empirical-gate.ts` (retrieval delta).
+  → #1 replaces the `score()` with an execution harness; #2 adds an ablation
+  pre-filter; #3 replaces the strict `delta>0` with a paired-Bayesian accept.
+- Reversibility already done: `learning-store.ts` (git versions + `restore --best`)
+  — extend with raw-grader logging (#4) and a frozen canary set (#4).
+- Curriculum: `capability-benchmark.ts:selectNextScenario` → #3/#5 (LP-weighted).
+- Robot seam: `experience-source.ts:SensorExperienceSource` → Area 4 (V-JEPA
+  surprise as experiences), exploration only.
+
+**Verified arXiv IDs:** DGM 2505.22954, CLT 2503.01747, A-MEM 2502.12110, MAGELLAN
+2502.07709, V-JEPA 2 2506.09985, STOP 2310.02304, Generative Agents 2304.03442,
+ICRH 2402.06627, One Token to Fool 2507.08794, Gödel Agent 2410.04444, SWE-bench
+Illusion 2506.12286, SWE-bench Pro 2509.16941.

--- a/src/agent/self-improvement/capability-benchmark.ts
+++ b/src/agent/self-improvement/capability-benchmark.ts
@@ -1,0 +1,105 @@
+/**
+ * Deterministic capability benchmark for the self-improvement engine.
+ *
+ * The benchmark measures a single, REPRODUCIBLE behavioural primitive: for a
+ * given situation (`query`), does the agent's learnable state surface relevant
+ * guidance? It is a pure function of (scenarios, lessons) — no LLM, no network,
+ * no clock — so a before/after score delta reflects the CHANGE, not run-to-run
+ * noise. This is what makes the empirical gate trustworthy on a small fixture
+ * set (unlike live-agent benchmarks, which need hundreds of tasks to denoise).
+ *
+ * @module agent/self-improvement/capability-benchmark
+ */
+
+import type { BenchmarkScenario, BenchmarkScore, BenchmarkScenarioResult } from './types.js';
+
+/**
+ * Minimal port over the lessons store. The real `LessonsTracker.search` (pure,
+ * offline substring match over in-memory lessons) satisfies this, and tests can
+ * supply a fake.
+ */
+export interface LessonSearchPort {
+  search(query: string, category?: string): Array<{ id: string; content: string; context?: string }>;
+}
+
+function scenarioCovered(
+  scenario: BenchmarkScenario,
+  port: LessonSearchPort,
+): BenchmarkScenarioResult {
+  const expect = scenario.expectIncludes.map((s) => s.toLowerCase()).filter(Boolean);
+  const matchedLessonIds: string[] = [];
+  // Retrieval (search by the situation query) ∧ relevance (lesson carries the
+  // expected guidance). A scenario is covered when at least one retrieved
+  // lesson contains an expected substring.
+  for (const lesson of port.search(scenario.query)) {
+    const hay = `${lesson.content} ${lesson.context ?? ''}`.toLowerCase();
+    if (expect.length === 0 || expect.some((term) => hay.includes(term))) {
+      matchedLessonIds.push(lesson.id);
+    }
+  }
+  return {
+    scenarioId: scenario.id,
+    covered: matchedLessonIds.length > 0,
+    matchedLessonIds,
+  };
+}
+
+/** Score the full scenario set against the current lessons state. Deterministic. */
+export function scoreBenchmark(
+  scenarios: BenchmarkScenario[],
+  port: LessonSearchPort,
+): BenchmarkScore {
+  const results = scenarios.map((scenario) => scenarioCovered(scenario, port));
+  const covered = results.filter((r) => r.covered).length;
+  const total = scenarios.length;
+  return {
+    total,
+    covered,
+    ratio: total === 0 ? 1 : covered / total,
+    results,
+  };
+}
+
+/** Scenario ids that went from covered → uncovered between two scores. */
+export function findRegressions(before: BenchmarkScore, after: BenchmarkScore): string[] {
+  const afterCovered = new Map(after.results.map((r) => [r.scenarioId, r.covered]));
+  return before.results
+    .filter((r) => r.covered && afterCovered.get(r.scenarioId) === false)
+    .map((r) => r.scenarioId);
+}
+
+/** Scenario the curriculum should work on next: first uncovered, else null. */
+export function selectNextScenario(
+  scenarios: BenchmarkScenario[],
+  score: BenchmarkScore,
+): BenchmarkScenario | null {
+  const uncovered = new Set(score.results.filter((r) => !r.covered).map((r) => r.scenarioId));
+  return scenarios.find((s) => uncovered.has(s.id)) ?? null;
+}
+
+/**
+ * Seed scenarios — CURATED, and structurally separate from the proposer (the
+ * engine must never author the evals that bless its own changes). Each encodes
+ * a recurring friction the agent should have retrievable guidance for. This set
+ * is meant to grow via a human-reviewed process, never auto-written by the loop.
+ */
+export const SEED_BENCHMARK_SCENARIOS: BenchmarkScenario[] = [
+  {
+    id: 'npm-test-path-filter',
+    query: 'npm test',
+    expectIncludes: ['path filter', 'path/to', '--'],
+    description: 'Running the full test suite is slow; guidance should prefer a path filter.',
+  },
+  {
+    id: 'esm-js-extension-imports',
+    query: 'import',
+    expectIncludes: ['.js extension', 'esm', 'extension'],
+    description: 'ESM project needs .js extensions on relative imports even from .ts sources.',
+  },
+  {
+    id: 'logger-not-console',
+    query: 'console.log',
+    expectIncludes: ['logger', 'not console'],
+    description: 'Production code should use logger, not console.*, because tests spy on logger.',
+  },
+];

--- a/src/agent/self-improvement/empirical-gate.ts
+++ b/src/agent/self-improvement/empirical-gate.ts
@@ -1,0 +1,145 @@
+/**
+ * Empirical gate — the safety + recursion core of the self-improvement engine.
+ *
+ * Inspired by the Darwin Gödel Machine: a self-modification is kept ONLY if it
+ * empirically improves a benchmark and breaks nothing — but here the benchmark
+ * is deterministic and cheap, so the signal is trustworthy on a small fixture
+ * set. The gate snapshots state, applies the proposal, re-measures, and rolls
+ * back on no-improvement / regression / policy violation. Nothing is ever kept
+ * without a positive, reproducible score delta and zero regressions.
+ *
+ * @module agent/self-improvement/empirical-gate
+ */
+
+import { scoreBenchmark, findRegressions, type LessonSearchPort } from './capability-benchmark.js';
+import type { BenchmarkScenario, GateOutcome, ImprovementProposal } from './types.js';
+
+/** Mutator port: apply a lesson proposal and be able to revert it. */
+export interface LessonMutatorPort extends LessonSearchPort {
+  add(
+    category: 'PATTERN' | 'RULE' | 'CONTEXT' | 'INSIGHT',
+    content: string,
+    context?: string,
+  ): { id: string };
+  remove(id: string): boolean;
+}
+
+/** Omission placeholders that must never enter a stored lesson. */
+const OMISSION_RE = /\.\.\.\s*(rest|remaining|other|more|etc)\b/i;
+/** Obvious secret shapes — refuse to persist these into the learnable layer. */
+const SECRET_RE = /(sk-[a-z0-9]{16,}|api[_-]?key\s*[:=]\s*\S+|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+
+function structuralProblem(proposal: ImprovementProposal): string | null {
+  const content = proposal.lesson.content?.trim() ?? '';
+  if (content.length < 12) return 'lesson content too short to be useful';
+  if (OMISSION_RE.test(content)) return 'lesson content contains an omission placeholder';
+  if (SECRET_RE.test(content) || SECRET_RE.test(proposal.lesson.context ?? '')) {
+    return 'lesson content looks like it contains a secret';
+  }
+  return null;
+}
+
+export interface GateResult {
+  outcome: GateOutcome;
+  /** Id of the lesson left applied (only when accepted and kept). */
+  appliedRef?: string;
+}
+
+export interface ValidateOptions {
+  /**
+   * When true (auto-apply autonomy), an accepted proposal stays applied and its
+   * lesson id is returned. When false (propose-only, the default), even an
+   * accepted proposal is rolled back — the engine only REPORTS it would help.
+   */
+  keepOnAccept: boolean;
+}
+
+/**
+ * Validate a proposal against the deterministic benchmark with snapshot/rollback.
+ * Pure-ish: it mutates the lessons store transiently, but always restores it
+ * unless the caller opted to keep an accepted change.
+ */
+export function validateProposal(
+  proposal: ImprovementProposal,
+  scenarios: BenchmarkScenario[],
+  port: LessonMutatorPort,
+  options: ValidateOptions,
+): GateResult {
+  const notes: string[] = [];
+  const before = scoreBenchmark(scenarios, port);
+
+  // Gate 1 — structural / policy validity (no apply on a malformed proposal).
+  const structural = structuralProblem(proposal);
+  if (structural) {
+    return {
+      outcome: {
+        accepted: false,
+        proposalId: proposal.id,
+        scoreBefore: before.covered,
+        scoreAfter: before.covered,
+        delta: 0,
+        regressions: [],
+        rejectionReason: 'structural-invalid',
+        rolledBack: false,
+        notes: [structural],
+      },
+    };
+  }
+
+  // Apply transiently and re-measure.
+  const applied = port.add(proposal.lesson.category, proposal.lesson.content, proposal.lesson.context);
+  const after = scoreBenchmark(scenarios, port);
+  const delta = after.covered - before.covered;
+  const regressions = findRegressions(before, after);
+
+  const rollback = (): boolean => port.remove(applied.id);
+
+  // Gate 2 — no regression anywhere (a new lesson must not bury existing guidance).
+  if (regressions.length > 0) {
+    rollback();
+    return {
+      outcome: {
+        accepted: false, proposalId: proposal.id,
+        scoreBefore: before.covered, scoreAfter: after.covered, delta,
+        regressions, rejectionReason: 'regression', rolledBack: true,
+        notes: [`reverted: ${regressions.length} scenario(s) regressed`],
+      },
+    };
+  }
+
+  // Gate 3 — must empirically improve (strict positive delta).
+  if (delta <= 0) {
+    rollback();
+    return {
+      outcome: {
+        accepted: false, proposalId: proposal.id,
+        scoreBefore: before.covered, scoreAfter: after.covered, delta,
+        regressions: [], rejectionReason: 'no-improvement', rolledBack: true,
+        notes: ['reverted: no measurable improvement'],
+      },
+    };
+  }
+
+  // Accepted. Keep or revert based on autonomy.
+  if (!options.keepOnAccept) {
+    rollback();
+    notes.push('accepted but reverted (propose-only): would improve, pending approval');
+    return {
+      outcome: {
+        accepted: true, proposalId: proposal.id,
+        scoreBefore: before.covered, scoreAfter: after.covered, delta,
+        regressions: [], rolledBack: true, notes,
+      },
+    };
+  }
+
+  notes.push('accepted and kept (auto-apply): empirically validated, no regression');
+  return {
+    appliedRef: applied.id,
+    outcome: {
+      accepted: true, proposalId: proposal.id,
+      scoreBefore: before.covered, scoreAfter: after.covered, delta,
+      regressions: [], rolledBack: false, notes,
+    },
+  };
+}

--- a/src/agent/self-improvement/engine.ts
+++ b/src/agent/self-improvement/engine.ts
@@ -61,7 +61,7 @@ export class SelfImprovementEngine {
   }
 
   /** Run exactly one improvement cycle. */
-  runCycle(experiences: Experience[] = []): SelfImprovementCycleResult {
+  async runCycle(experiences: Experience[] = []): Promise<SelfImprovementCycleResult> {
     const startedAt = this.now().toISOString();
     const scoreBefore = scoreBenchmark(this.scenarios, this.port);
     const base = {
@@ -81,7 +81,7 @@ export class SelfImprovementEngine {
       };
     }
 
-    const proposal = this.proposer.propose(target, experiences);
+    const proposal = await this.proposer.propose(target, experiences);
     if (!proposal) {
       return {
         ...base, selectedScenarioId: target.id, proposalId: null, gate: null,
@@ -131,11 +131,11 @@ export class SelfImprovementEngine {
    * rising) or maxCycles is reached. In propose-only mode this performs a single
    * cycle, since nothing is persisted to uncover the next target.
    */
-  runLoop(options: { maxCycles?: number; experiences?: Experience[] } = {}): SelfImprovementCycleResult[] {
+  async runLoop(options: { maxCycles?: number; experiences?: Experience[] } = {}): Promise<SelfImprovementCycleResult[]> {
     const maxCycles = Math.max(1, options.maxCycles ?? this.scenarios.length + 1);
     const results: SelfImprovementCycleResult[] = [];
     for (let i = 0; i < maxCycles; i++) {
-      const result = this.runCycle(options.experiences ?? []);
+      const result = await this.runCycle(options.experiences ?? []);
       results.push(result);
       // Stop unless this cycle made real, persisted progress.
       if (!result.applied) break;

--- a/src/agent/self-improvement/engine.ts
+++ b/src/agent/self-improvement/engine.ts
@@ -1,0 +1,158 @@
+/**
+ * SelfImprovementEngine — orchestrates one recursive-improvement cycle:
+ *   curriculum (pick the weakest capability) → propose → empirical gate
+ *   (snapshot/apply/re-score) → keep or roll back → archive → audit.
+ *
+ * Autonomy is tiered and fail-safe: 'propose-only' (default) validates and
+ * REPORTS what would help but persists nothing; 'auto-apply'
+ * (CODEBUDDY_SELF_IMPROVE=true) keeps only changes that empirically improve the
+ * deterministic benchmark with zero regressions. Even then, every kept change
+ * is reversible (a lesson that can be removed) and archived for audit — code
+ * self-modification is out of scope.
+ *
+ * @module agent/self-improvement/engine
+ */
+
+import {
+  scoreBenchmark,
+  selectNextScenario,
+} from './capability-benchmark.js';
+import { validateProposal, type LessonMutatorPort } from './empirical-gate.js';
+import { EvolutionaryArchive } from './evolutionary-archive.js';
+import type { ImprovementProposer } from './proposer.js';
+import {
+  SELF_IMPROVEMENT_SCHEMA_VERSION,
+  type BenchmarkScenario,
+  type Experience,
+  type SelfImprovementCycleResult,
+} from './types.js';
+
+export type Autonomy = 'propose-only' | 'auto-apply';
+
+/** Resolve autonomy from the environment (fail-safe to propose-only). */
+export function resolveAutonomy(env: NodeJS.ProcessEnv = process.env): Autonomy {
+  return env.CODEBUDDY_SELF_IMPROVE === 'true' ? 'auto-apply' : 'propose-only';
+}
+
+export interface SelfImprovementEngineOptions {
+  scenarios: BenchmarkScenario[];
+  port: LessonMutatorPort;
+  proposer: ImprovementProposer;
+  archive?: EvolutionaryArchive;
+  autonomy?: Autonomy;
+  now?: () => Date;
+}
+
+export class SelfImprovementEngine {
+  private readonly scenarios: BenchmarkScenario[];
+  private readonly port: LessonMutatorPort;
+  private readonly proposer: ImprovementProposer;
+  private readonly archive: EvolutionaryArchive;
+  private readonly autonomy: Autonomy;
+  private readonly now: () => Date;
+
+  constructor(options: SelfImprovementEngineOptions) {
+    this.scenarios = options.scenarios;
+    this.port = options.port;
+    this.proposer = options.proposer;
+    this.archive = options.archive ?? new EvolutionaryArchive();
+    this.autonomy = options.autonomy ?? resolveAutonomy();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /** Run exactly one improvement cycle. */
+  runCycle(experiences: Experience[] = []): SelfImprovementCycleResult {
+    const startedAt = this.now().toISOString();
+    const scoreBefore = scoreBenchmark(this.scenarios, this.port);
+    const base = {
+      schemaVersion: SELF_IMPROVEMENT_SCHEMA_VERSION as typeof SELF_IMPROVEMENT_SCHEMA_VERSION,
+      kind: 'self_improvement_cycle' as const,
+      startedAt,
+      autonomy: this.autonomy,
+      scoreBefore,
+    };
+
+    const target = selectNextScenario(this.scenarios, scoreBefore);
+    if (!target) {
+      return {
+        ...base, selectedScenarioId: null, proposalId: null, gate: null,
+        scoreAfter: scoreBefore, applied: false,
+        notes: ['all benchmark scenarios are already covered — nothing to improve'],
+      };
+    }
+
+    const proposal = this.proposer.propose(target, experiences);
+    if (!proposal) {
+      return {
+        ...base, selectedScenarioId: target.id, proposalId: null, gate: null,
+        scoreAfter: scoreBefore, applied: false,
+        notes: [`no proposal available for scenario "${target.id}"`],
+      };
+    }
+
+    const gate = validateProposal(proposal, this.scenarios, this.port, {
+      keepOnAccept: this.autonomy === 'auto-apply',
+    }).outcome;
+
+    // We must re-read appliedRef from a fresh validate call? No — validateProposal
+    // already left the change applied (auto-apply + accepted). Re-derive applied.
+    const applied = gate.accepted && !gate.rolledBack;
+
+    if (applied) {
+      // Find the lesson we just kept so we can store a rollback reference.
+      const kept = this.port
+        .search(target.query)
+        .find((l) => l.content === proposal.lesson.content);
+      this.archive.append({
+        proposalId: proposal.id,
+        kind: proposal.kind,
+        targetScenarioId: target.id,
+        experienceId: proposal.experienceId,
+        delta: gate.delta,
+        scoreAfter: gate.scoreAfter,
+        appliedRef: kept?.id,
+      });
+    }
+
+    const scoreAfter = scoreBenchmark(this.scenarios, this.port);
+    return {
+      ...base,
+      selectedScenarioId: target.id,
+      proposalId: proposal.id,
+      gate,
+      scoreAfter,
+      applied,
+      notes: gate.notes,
+    };
+  }
+
+  /**
+   * Run cycles until no further PERSISTED progress is made (the score stops
+   * rising) or maxCycles is reached. In propose-only mode this performs a single
+   * cycle, since nothing is persisted to uncover the next target.
+   */
+  runLoop(options: { maxCycles?: number; experiences?: Experience[] } = {}): SelfImprovementCycleResult[] {
+    const maxCycles = Math.max(1, options.maxCycles ?? this.scenarios.length + 1);
+    const results: SelfImprovementCycleResult[] = [];
+    for (let i = 0; i < maxCycles; i++) {
+      const result = this.runCycle(options.experiences ?? []);
+      results.push(result);
+      // Stop unless this cycle made real, persisted progress.
+      if (!result.applied) break;
+    }
+    return results;
+  }
+
+  /** Read-only status snapshot for `improve status`. */
+  status(): {
+    autonomy: Autonomy;
+    score: ReturnType<typeof scoreBenchmark>;
+    archive: ReturnType<EvolutionaryArchive['summary']>;
+  } {
+    return {
+      autonomy: this.autonomy,
+      score: scoreBenchmark(this.scenarios, this.port),
+      archive: this.archive.summary(),
+    };
+  }
+}

--- a/src/agent/self-improvement/evolutionary-archive.ts
+++ b/src/agent/self-improvement/evolutionary-archive.ts
@@ -1,0 +1,84 @@
+/**
+ * Evolutionary archive — keeps every empirically-validated improvement as a
+ * stepping stone (Darwin Gödel Machine's open-ended archive). Future cycles can
+ * build on past wins rather than hill-climbing a single best agent. V1 stores a
+ * flat, append-only JSON log; the lineage fields support later genealogy.
+ *
+ * @module agent/self-improvement/evolutionary-archive
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import type { ArchiveEntry } from './types.js';
+
+export const SELF_IMPROVEMENT_ARCHIVE_SCHEMA_VERSION = 1;
+
+interface ArchiveFile {
+  schemaVersion: number;
+  entries: ArchiveEntry[];
+}
+
+export interface EvolutionaryArchiveOptions {
+  workDir?: string;
+  now?: () => Date;
+}
+
+export class EvolutionaryArchive {
+  private readonly filePath: string;
+  private readonly now: () => Date;
+
+  constructor(options: EvolutionaryArchiveOptions = {}) {
+    const root = options.workDir ?? process.cwd();
+    this.filePath = path.join(root, '.codebuddy', 'self-improvement', 'archive.json');
+    this.now = options.now ?? (() => new Date());
+  }
+
+  get path(): string {
+    return this.filePath;
+  }
+
+  private read(): ArchiveFile {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as Partial<ArchiveFile>;
+      if (Array.isArray(parsed.entries)) {
+        return { schemaVersion: SELF_IMPROVEMENT_ARCHIVE_SCHEMA_VERSION, entries: parsed.entries };
+      }
+    } catch {
+      /* no archive yet */
+    }
+    return { schemaVersion: SELF_IMPROVEMENT_ARCHIVE_SCHEMA_VERSION, entries: [] };
+  }
+
+  private write(file: ArchiveFile): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify(file, null, 2), 'utf-8');
+  }
+
+  list(): ArchiveEntry[] {
+    return this.read().entries;
+  }
+
+  /** Append a validated improvement. Returns the stored entry. */
+  append(entry: Omit<ArchiveEntry, 'createdAt' | 'reviewedBy'> & { reviewedBy?: string }): ArchiveEntry {
+    const file = this.read();
+    const stored: ArchiveEntry = {
+      ...entry,
+      createdAt: this.now().toISOString(),
+      reviewedBy: entry.reviewedBy ?? 'auto:self-improve',
+    };
+    file.entries.push(stored);
+    this.write(file);
+    return stored;
+  }
+
+  /** Summary stats over the archive (for `status`). */
+  summary(): { count: number; totalDelta: number; lastAt: string | null } {
+    const entries = this.list();
+    return {
+      count: entries.length,
+      totalDelta: entries.reduce((sum, e) => sum + (e.delta ?? 0), 0),
+      lastAt: entries.length > 0 ? entries[entries.length - 1]!.createdAt : null,
+    };
+  }
+}

--- a/src/agent/self-improvement/execution-gate.ts
+++ b/src/agent/self-improvement/execution-gate.ts
@@ -1,0 +1,187 @@
+/**
+ * Execution-grounded validation (deterministic subclass).
+ *
+ * The retrieval benchmark (capability-benchmark.ts) measures whether on-topic
+ * guidance is *retrievable* — a proxy that a wrong-but-on-topic lesson can pass.
+ * This module fixes that for the subclass of improvements that encode a CHECKABLE
+ * BEHAVIORAL RULE (e.g. "a safe-profile run must not call a mutation tool"): it
+ * validates a proposed rule by how well it CORRECTLY CLASSIFIES real recorded
+ * trajectories — does it flag the bad runs and pass the good ones — exactly as
+ * the Darwin Gödel Machine gates on execution outcomes, but deterministic and
+ * cheap (no live agent, no LLM-judge, reproducible).
+ *
+ * It is grounded in the recorded behavior the agent actually produced
+ * (RunStore trajectories / golden+policy eval fixtures), so a "+1" reflects real
+ * correctness on held-out runs, not keyword presence. A counterfactual-ablation
+ * pre-filter rejects rules that change no verdict (inert), and a no-regression
+ * guard rejects rules that misclassify an already-correct run.
+ *
+ * @module agent/self-improvement/execution-gate
+ */
+
+/** A compact, deterministic view of a recorded run (adapt from RunTrajectoryExport). */
+export interface TrajectorySummary {
+  /** Tool names invoked, in order. */
+  toolNames: string[];
+  /** Concatenated text surface (final answer + notable outputs), lowercased on check. */
+  text: string;
+  /** Optional profile/scope signal (e.g. 'safe', 'review'). */
+  profile?: string;
+}
+
+/** A deterministic predicate over a trajectory — mirrors the golden/policy eval vocab. */
+export type BehavioralCheck =
+  | { kind: 'forbid_tool'; pattern: string }
+  | { kind: 'require_tool'; pattern: string }
+  | { kind: 'forbid_text'; pattern: string }
+  | { kind: 'require_text'; pattern: string };
+
+/** A labeled example: should this trajectory be considered compliant? */
+export interface LabeledTrajectory {
+  id: string;
+  trajectory: TrajectorySummary;
+  shouldPass: boolean;
+}
+
+/** A proposed behavioral rule to add to the active rule set. */
+export interface BehavioralRuleProposal {
+  id: string;
+  /** Human-readable statement (the lesson text). */
+  statement: string;
+  check: BehavioralCheck;
+}
+
+function compile(pattern: string): RegExp {
+  // Escape nothing — patterns are author-controlled, but anchor on word-ish match.
+  try {
+    return new RegExp(pattern, 'i');
+  } catch {
+    return new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+  }
+}
+
+/** True when the trajectory satisfies the check (i.e. the check "passes"). */
+export function evaluateCheck(check: BehavioralCheck, t: TrajectorySummary): boolean {
+  const re = compile(check.pattern);
+  switch (check.kind) {
+    case 'forbid_tool':
+      return !t.toolNames.some((n) => re.test(n));
+    case 'require_tool':
+      return t.toolNames.some((n) => re.test(n));
+    case 'forbid_text':
+      return !re.test(t.text);
+    case 'require_text':
+      return re.test(t.text);
+  }
+}
+
+/** A trajectory is compliant under a rule set iff EVERY rule passes. */
+export function verdict(rules: BehavioralCheck[], t: TrajectorySummary): boolean {
+  return rules.every((r) => evaluateCheck(r, t));
+}
+
+export interface CorpusScore {
+  total: number;
+  correct: number;
+  accuracy: number;
+  /** Per-trajectory: was the verdict correct vs its label? */
+  results: Array<{ id: string; verdict: boolean; shouldPass: boolean; correct: boolean }>;
+}
+
+/** Classification accuracy of a rule set over the labeled corpus. Deterministic. */
+export function scoreCorpus(rules: BehavioralCheck[], corpus: LabeledTrajectory[]): CorpusScore {
+  const results = corpus.map((c) => {
+    const v = verdict(rules, c.trajectory);
+    return { id: c.id, verdict: v, shouldPass: c.shouldPass, correct: v === c.shouldPass };
+  });
+  const correct = results.filter((r) => r.correct).length;
+  const total = corpus.length;
+  return { total, correct, accuracy: total === 0 ? 1 : correct / total, results };
+}
+
+export type ExecutionRejectionReason = 'inert' | 'no-improvement' | 'regression';
+
+export interface ExecutionGateOutcome {
+  accepted: boolean;
+  proposalId: string;
+  accuracyBefore: number;
+  accuracyAfter: number;
+  delta: number;
+  /** Trajectory ids that were correct before and wrong after (any ⇒ reject). */
+  regressions: string[];
+  /** Trajectory ids whose verdict the rule changed (empty ⇒ inert). */
+  changed: string[];
+  rejectionReason?: ExecutionRejectionReason;
+  notes: string[];
+}
+
+/**
+ * Validate a behavioral-rule proposal against the recorded-trajectory corpus.
+ * Accept iff it (a) changes at least one verdict (not inert), (b) raises
+ * classification accuracy, and (c) regresses no already-correct trajectory.
+ */
+export function validateBehavioralRule(
+  proposal: BehavioralRuleProposal,
+  currentRules: BehavioralCheck[],
+  corpus: LabeledTrajectory[],
+): ExecutionGateOutcome {
+  const before = scoreCorpus(currentRules, corpus);
+  const after = scoreCorpus([...currentRules, proposal.check], corpus);
+
+  // Counterfactual ablation: which verdicts did the new rule actually change?
+  const changed = corpus
+    .filter((c) => verdict(currentRules, c.trajectory) !== verdict([...currentRules, proposal.check], c.trajectory))
+    .map((c) => c.id);
+
+  if (changed.length === 0) {
+    return {
+      accepted: false, proposalId: proposal.id,
+      accuracyBefore: before.accuracy, accuracyAfter: after.accuracy, delta: 0,
+      regressions: [], changed: [], rejectionReason: 'inert',
+      notes: ['rule changes no recorded behavior — inert, rejected before scoring'],
+    };
+  }
+
+  // No-regression: a trajectory correct before must not become wrong.
+  const afterById = new Map(after.results.map((r) => [r.id, r.correct]));
+  const regressions = before.results
+    .filter((r) => r.correct && afterById.get(r.id) === false)
+    .map((r) => r.id);
+
+  const delta = after.correct - before.correct;
+  if (regressions.length > 0) {
+    return {
+      accepted: false, proposalId: proposal.id,
+      accuracyBefore: before.accuracy, accuracyAfter: after.accuracy, delta,
+      regressions, changed, rejectionReason: 'regression',
+      notes: [`misclassifies ${regressions.length} previously-correct run(s)`],
+    };
+  }
+  if (delta <= 0) {
+    return {
+      accepted: false, proposalId: proposal.id,
+      accuracyBefore: before.accuracy, accuracyAfter: after.accuracy, delta,
+      regressions: [], changed, rejectionReason: 'no-improvement',
+      notes: ['changes behavior but does not improve classification accuracy'],
+    };
+  }
+
+  return {
+    accepted: true, proposalId: proposal.id,
+    accuracyBefore: before.accuracy, accuracyAfter: after.accuracy, delta,
+    regressions: [], changed,
+    notes: [`correctly reclassifies ${delta} recorded run(s) with no regression`],
+  };
+}
+
+/** Adapt a full run-trajectory export (shape-tolerant) into a TrajectorySummary. */
+export function summarizeTrajectory(exported: {
+  toolCalls?: Array<{ toolName?: string }>;
+  finalAnswer?: string | null;
+  selectedContext?: { profileSignal?: string };
+}): TrajectorySummary {
+  const toolNames = (exported.toolCalls ?? []).map((c) => c.toolName ?? '').filter(Boolean);
+  const text = (exported.finalAnswer ?? '').toString();
+  const profile = exported.selectedContext?.profileSignal;
+  return { toolNames, text, ...(profile ? { profile } : {}) };
+}

--- a/src/agent/self-improvement/execution-gate.ts
+++ b/src/agent/self-improvement/execution-gate.ts
@@ -175,13 +175,14 @@ export function validateBehavioralRule(
 }
 
 /** Adapt a full run-trajectory export (shape-tolerant) into a TrajectorySummary. */
-export function summarizeTrajectory(exported: {
-  toolCalls?: Array<{ toolName?: string }>;
-  finalAnswer?: string | null;
-  selectedContext?: { profileSignal?: string };
-}): TrajectorySummary {
-  const toolNames = (exported.toolCalls ?? []).map((c) => c.toolName ?? '').filter(Boolean);
-  const text = (exported.finalAnswer ?? '').toString();
-  const profile = exported.selectedContext?.profileSignal;
+export function summarizeTrajectory(exported: unknown): TrajectorySummary {
+  const e = (exported ?? {}) as {
+    toolCalls?: Array<{ toolName?: string }>;
+    finalAnswer?: string | null;
+    selectedContext?: { profileSignal?: string };
+  };
+  const toolNames = (e.toolCalls ?? []).map((c) => c.toolName ?? '').filter(Boolean);
+  const text = (e.finalAnswer ?? '').toString();
+  const profile = e.selectedContext?.profileSignal;
   return { toolNames, text, ...(profile ? { profile } : {}) };
 }

--- a/src/agent/self-improvement/experience-source.ts
+++ b/src/agent/self-improvement/experience-source.ts
@@ -1,0 +1,124 @@
+/**
+ * Experience sources — the modality-agnostic seam.
+ *
+ * An ExperienceSource yields units of feedback the engine learns from. Today the
+ * only source is code-run friction (RunExperienceSource, built on the existing
+ * learning retrospectives). The SAME interface is the plug-in point for the
+ * robot's senses: a future SensorExperienceSource turns world-model (JEPA)
+ * prediction error / latent-state surprise from vision, audio, touch, etc. into
+ * Experiences — without changing the engine. That is deliberately interface-only
+ * here; the 10-year robot horizon is not built in V1.
+ *
+ * @module agent/self-improvement/experience-source
+ */
+
+import type { Experience } from './types.js';
+
+export interface ExperienceSource {
+  readonly id: string;
+  collect(): Promise<Experience[]>;
+}
+
+const SEVERITY_SCORE: Record<'low' | 'medium' | 'high', number> = {
+  low: 0.3,
+  medium: 0.6,
+  high: 1,
+};
+
+interface RetroFrictionPoint {
+  detail: string;
+  evidence: string;
+  severity: 'low' | 'medium' | 'high';
+  toolName?: string;
+}
+
+export interface RunExperienceSourceDeps {
+  /** Recent run ids, newest first. */
+  listRunIds: () => string[];
+  /** Build a retrospective for a run (null if not eligible). */
+  buildRetrospective: (runId: string) => { frictionPoints: RetroFrictionPoint[] } | null;
+}
+
+/**
+ * Mines recent runs' retrospectives for friction and turns each friction point
+ * into an Experience. Dependencies are injected so it stays unit-testable and
+ * decoupled from RunStore singletons; `createDefaultRunExperienceSource` wires
+ * the real learning infrastructure.
+ */
+export class RunExperienceSource implements ExperienceSource {
+  readonly id = 'run-friction';
+
+  constructor(
+    private readonly deps: RunExperienceSourceDeps,
+    private readonly options: { limit?: number } = {},
+  ) {}
+
+  async collect(): Promise<Experience[]> {
+    const limit = Math.max(1, this.options.limit ?? 10);
+    const runIds = this.deps.listRunIds().slice(0, limit);
+    const experiences: Experience[] = [];
+    for (const runId of runIds) {
+      const retro = this.deps.buildRetrospective(runId);
+      if (!retro) continue;
+      retro.frictionPoints.forEach((point, index) => {
+        experiences.push({
+          id: `run:${runId}:${index}`,
+          source: 'run',
+          kind: point.toolName ?? 'friction',
+          detail: point.detail,
+          context: point.evidence,
+          severity: SEVERITY_SCORE[point.severity],
+        });
+      });
+    }
+    return experiences;
+  }
+}
+
+/**
+ * Wire RunExperienceSource to the real learning infrastructure. The heavy
+ * RunStore/learning-agent modules are dynamically imported inside collect() (ESM
+ * lazy load), then delegated to the testable RunExperienceSource class.
+ */
+export function createDefaultRunExperienceSource(
+  options: { workDir?: string; limit?: number } = {},
+): ExperienceSource {
+  return {
+    id: 'run-friction',
+    async collect(): Promise<Experience[]> {
+      const [{ RunStore }, { buildLearningRetrospective }] = await Promise.all([
+        import('../../observability/run-store.js'),
+        import('../learning-agent.js'),
+      ]);
+      const store = RunStore.getInstance();
+      const source = new RunExperienceSource(
+        {
+          listRunIds: () => store.listRuns().map((r: { runId: string }) => r.runId),
+          buildRetrospective: (runId: string) =>
+            buildLearningRetrospective(runId, { workDir: options.workDir }) ?? null,
+        },
+        { limit: options.limit },
+      );
+      return source.collect();
+    },
+  };
+}
+
+/**
+ * SENSOR SEAM (robot future, interface-only). When the robot grants senses, a
+ * world-model (JEPA) encodes each modality into a latent z and predicts z_{t+1};
+ * the prediction error / latent surprise becomes the Experience signal here, and
+ * the engine improves the policies/skills that reduce that surprise — the exact
+ * same observe→propose→validate→keep loop, no engine change. NOT implemented in
+ * V1: it must not silently emit experiences.
+ */
+export class SensorExperienceSource implements ExperienceSource {
+  readonly id = 'sensor-surprise';
+
+  async collect(): Promise<Experience[]> {
+    throw new Error(
+      'SensorExperienceSource is the robot 5-senses seam and is not implemented in V1. ' +
+        'Wire a world-model (JEPA) latent prediction-error stream here when sensors are available.',
+    );
+  }
+}

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -9,7 +9,8 @@ import { SEED_BENCHMARK_SCENARIOS } from './capability-benchmark.js';
 import type { LessonMutatorPort } from './empirical-gate.js';
 import { EvolutionaryArchive } from './evolutionary-archive.js';
 import { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
-import { StaticProposer, SEED_LESSON_DRAFTS } from './proposer.js';
+import { StaticProposer, LlmProposer, SEED_LESSON_DRAFTS, type ImprovementProposer } from './proposer.js';
+import { createLlmDrafter } from './llm-drafter.js';
 
 export * from './types.js';
 export * from './capability-benchmark.js';
@@ -39,13 +40,19 @@ export function createLessonMutatorPort(workDir: string = process.cwd()): Lesson
  * archive. Autonomy resolves from CODEBUDDY_SELF_IMPROVE unless overridden.
  */
 export function createWorkspaceEngine(
-  options: { workDir?: string; autonomy?: Autonomy } = {},
+  options: { workDir?: string; autonomy?: Autonomy; useLlm?: boolean; proposer?: ImprovementProposer } = {},
 ): SelfImprovementEngine {
   const workDir = options.workDir ?? process.cwd();
+  // Default proposer is the deterministic, offline bootstrap pack. `useLlm`
+  // swaps in the model-backed proposer that discovers novel lessons from
+  // friction — still gated by the same deterministic empirical validator.
+  const proposer =
+    options.proposer ??
+    (options.useLlm ? new LlmProposer(createLlmDrafter()) : new StaticProposer(SEED_LESSON_DRAFTS));
   return new SelfImprovementEngine({
     scenarios: SEED_BENCHMARK_SCENARIOS,
     port: createLessonMutatorPort(workDir),
-    proposer: new StaticProposer(SEED_LESSON_DRAFTS),
+    proposer,
     archive: new EvolutionaryArchive({ workDir }),
     autonomy: options.autonomy ?? resolveAutonomy(),
   });

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -20,6 +20,7 @@ export * from './evolutionary-archive.js';
 export * from './proposer.js';
 export * from './experience-source.js';
 export * from './learning-store.js';
+export * from './execution-gate.js';
 export { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
 
 /** Adapt the real (offline, deterministic) LessonsTracker to the mutator port. */

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -73,6 +73,7 @@ export function createWorkspaceEngine(
 export function createWorkspaceLearningStore(options: { workDir?: string } = {}): LearningStore {
   const workDir = options.workDir ?? process.cwd();
   const tracker = getLessonsTracker(workDir);
+  const ruleStore = new RuleStore({ workDir });
   const port: LearnableStatePort = {
     listLessons: () =>
       tracker.search('').map((l) => ({
@@ -86,6 +87,8 @@ export function createWorkspaceLearningStore(options: { workDir?: string } = {})
     },
     archive: () => new EvolutionaryArchive({ workDir }).list(),
     score: () => scoreBenchmark(SEED_BENCHMARK_SCENARIOS, createLessonMutatorPort(workDir)),
+    listRules: () => ruleStore.list(),
+    setRules: (rules) => ruleStore.setAll(rules as ReturnType<RuleStore['list']>),
   };
   return new LearningStore({ workDir, port });
 }

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -5,9 +5,10 @@
  */
 
 import { getLessonsTracker } from '../lessons-tracker.js';
-import { SEED_BENCHMARK_SCENARIOS } from './capability-benchmark.js';
+import { SEED_BENCHMARK_SCENARIOS, scoreBenchmark } from './capability-benchmark.js';
 import type { LessonMutatorPort } from './empirical-gate.js';
 import { EvolutionaryArchive } from './evolutionary-archive.js';
+import { LearningStore, type LearnableStatePort } from './learning-store.js';
 import { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
 import { StaticProposer, LlmProposer, SEED_LESSON_DRAFTS, type ImprovementProposer } from './proposer.js';
 import { createLlmDrafter } from './llm-drafter.js';
@@ -18,6 +19,7 @@ export * from './empirical-gate.js';
 export * from './evolutionary-archive.js';
 export * from './proposer.js';
 export * from './experience-source.js';
+export * from './learning-store.js';
 export { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
 
 /** Adapt the real (offline, deterministic) LessonsTracker to the mutator port. */
@@ -56,4 +58,31 @@ export function createWorkspaceEngine(
     archive: new EvolutionaryArchive({ workDir }),
     autonomy: options.autonomy ?? resolveAutonomy(),
   });
+}
+
+/**
+ * Build a git-backed LearningStore wired to the workspace: it versions the live
+ * lessons + archive + benchmark score so any applied improvement is reversible
+ * (restore to the best-scoring version). Snapshot/restore go through the real
+ * LessonsTracker API so in-memory state and `.codebuddy/lessons.md` stay
+ * consistent.
+ */
+export function createWorkspaceLearningStore(options: { workDir?: string } = {}): LearningStore {
+  const workDir = options.workDir ?? process.cwd();
+  const tracker = getLessonsTracker(workDir);
+  const port: LearnableStatePort = {
+    listLessons: () =>
+      tracker.search('').map((l) => ({
+        category: l.category,
+        content: l.content,
+        ...(l.context ? { context: l.context } : {}),
+      })),
+    setLessons: (lessons) => {
+      tracker.clearByCategory(); // clear all
+      for (const l of lessons) tracker.add(l.category, l.content, 'manual', l.context);
+    },
+    archive: () => new EvolutionaryArchive({ workDir }).list(),
+    score: () => scoreBenchmark(SEED_BENCHMARK_SCENARIOS, createLessonMutatorPort(workDir)),
+  };
+  return new LearningStore({ workDir, port });
 }

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -9,6 +9,8 @@ import { SEED_BENCHMARK_SCENARIOS, scoreBenchmark } from './capability-benchmark
 import type { LessonMutatorPort } from './empirical-gate.js';
 import { EvolutionaryArchive } from './evolutionary-archive.js';
 import { LearningStore, type LearnableStatePort } from './learning-store.js';
+import { RuleLearningEngine, HeuristicRuleProposer } from './rule-engine.js';
+import { RuleStore, loadTrajectoryCorpus } from './rule-store.js';
 import { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
 import { StaticProposer, LlmProposer, SEED_LESSON_DRAFTS, type ImprovementProposer } from './proposer.js';
 import { createLlmDrafter } from './llm-drafter.js';
@@ -86,4 +88,26 @@ export function createWorkspaceLearningStore(options: { workDir?: string } = {})
     score: () => scoreBenchmark(SEED_BENCHMARK_SCENARIOS, createLessonMutatorPort(workDir)),
   };
   return new LearningStore({ workDir, port });
+}
+
+/**
+ * Build the execution-grounded RuleLearningEngine wired to the workspace: it
+ * learns behavioral rules validated against a labeled trajectory corpus
+ * (corpus.json or seed). Each accepted rule is also written as a retrievable RULE
+ * lesson, so it influences the agent's context AND is captured in the git-versioned
+ * lessons snapshot (reversible like everything else).
+ */
+export function createWorkspaceRuleEngine(
+  options: { workDir?: string; autonomy?: Autonomy } = {},
+): RuleLearningEngine {
+  const workDir = options.workDir ?? process.cwd();
+  const tracker = getLessonsTracker(workDir);
+  return new RuleLearningEngine({
+    corpus: loadTrajectoryCorpus(workDir),
+    proposer: new HeuristicRuleProposer(),
+    ruleStore: new RuleStore({ workDir }),
+    archive: new EvolutionaryArchive({ workDir }),
+    autonomy: options.autonomy ?? resolveAutonomy(),
+    onAccept: (proposal) => tracker.add('RULE', proposal.statement, 'manual'),
+  });
 }

--- a/src/agent/self-improvement/index.ts
+++ b/src/agent/self-improvement/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Self-improvement engine — public surface + workspace wiring.
+ *
+ * @module agent/self-improvement
+ */
+
+import { getLessonsTracker } from '../lessons-tracker.js';
+import { SEED_BENCHMARK_SCENARIOS } from './capability-benchmark.js';
+import type { LessonMutatorPort } from './empirical-gate.js';
+import { EvolutionaryArchive } from './evolutionary-archive.js';
+import { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
+import { StaticProposer, SEED_LESSON_DRAFTS } from './proposer.js';
+
+export * from './types.js';
+export * from './capability-benchmark.js';
+export * from './empirical-gate.js';
+export * from './evolutionary-archive.js';
+export * from './proposer.js';
+export * from './experience-source.js';
+export { SelfImprovementEngine, resolveAutonomy, type Autonomy } from './engine.js';
+
+/** Adapt the real (offline, deterministic) LessonsTracker to the mutator port. */
+export function createLessonMutatorPort(workDir: string = process.cwd()): LessonMutatorPort {
+  const tracker = getLessonsTracker(workDir);
+  return {
+    search: (query) =>
+      tracker.search(query).map((l) => ({ id: l.id, content: l.content, context: l.context })),
+    add: (category, content, context) => {
+      const item = tracker.add(category, content, 'manual', context);
+      return { id: item.id };
+    },
+    remove: (id) => tracker.remove(id),
+  };
+}
+
+/**
+ * Build a SelfImprovementEngine wired to the workspace: the real lessons store,
+ * the curated seed benchmark + bootstrap proposer, and a persisted evolutionary
+ * archive. Autonomy resolves from CODEBUDDY_SELF_IMPROVE unless overridden.
+ */
+export function createWorkspaceEngine(
+  options: { workDir?: string; autonomy?: Autonomy } = {},
+): SelfImprovementEngine {
+  const workDir = options.workDir ?? process.cwd();
+  return new SelfImprovementEngine({
+    scenarios: SEED_BENCHMARK_SCENARIOS,
+    port: createLessonMutatorPort(workDir),
+    proposer: new StaticProposer(SEED_LESSON_DRAFTS),
+    archive: new EvolutionaryArchive({ workDir }),
+    autonomy: options.autonomy ?? resolveAutonomy(),
+  });
+}

--- a/src/agent/self-improvement/learning-store.ts
+++ b/src/agent/self-improvement/learning-store.ts
@@ -44,6 +44,9 @@ export interface LearnableStatePort {
   archive(): unknown[];
   /** Deterministic benchmark score of the CURRENT state. */
   score(): BenchmarkScore;
+  /** Learned behavioral rules (optional — versioned + restored when present). */
+  listRules?(): unknown[];
+  setRules?(rules: unknown[]): void;
 }
 
 interface VersionManifest {
@@ -123,6 +126,7 @@ export class LearningStore {
       fs.writeFileSync(path.join(this.storeDir, name), JSON.stringify(value, null, 2), 'utf-8');
     write('lessons.json', this.port.listLessons());
     write('archive.json', this.port.archive());
+    if (this.port.listRules) write('rules.json', this.port.listRules());
     write('manifest.json', manifest);
   }
 
@@ -217,6 +221,17 @@ export class LearningStore {
       return null;
     }
     this.port.setLessons(lessons);
+    // Re-materialise learned rules too, when they were versioned.
+    if (this.port.setRules) {
+      const rulesShow = await this.runGit(['show', `${sha}:rules.json`]);
+      if (rulesShow.code === 0) {
+        try {
+          this.port.setRules(JSON.parse(rulesShow.stdout) as unknown[]);
+        } catch {
+          /* leave rules unchanged if the snapshot is unreadable */
+        }
+      }
+    }
     const { score } = await this.commitVersion({ reason: `restore to ${sha.slice(0, 8)}` });
     return { restoredFrom: sha, score };
   }

--- a/src/agent/self-improvement/learning-store.ts
+++ b/src/agent/self-improvement/learning-store.ts
@@ -1,0 +1,246 @@
+/**
+ * LearningStore — git-backed reversibility for the self-improvement engine.
+ *
+ * The whole point: if an applied improvement turns out bad, we can return to a
+ * version that works better. The learnable state (lessons + the evolutionary
+ * archive + the benchmark score of that version) is versioned in a DEDICATED,
+ * ISOLATED git repo inside `.codebuddy/self-improvement/store/`. `.codebuddy/` is
+ * gitignored by the project, so this nested repo never touches the main history.
+ *
+ * Each applied improvement becomes a commit carrying its benchmark score in
+ * `manifest.json`; `restore({best:true})` deterministically returns to the
+ * highest-scoring version. History is append-only — restore moves *forward* by
+ * re-applying old content (git-revert semantics), never rewrites history.
+ *
+ * The store is decoupled from the concrete lessons/benchmark via LearnableStatePort
+ * so it is fully unit-testable; the git layer runs against a real repo.
+ *
+ * @module agent/self-improvement/learning-store
+ */
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import type { BenchmarkScore } from './types.js';
+
+export const LEARNING_STORE_SCHEMA_VERSION = 1;
+
+export type LessonCategory = 'PATTERN' | 'RULE' | 'CONTEXT' | 'INSIGHT';
+
+export interface LessonSnapshot {
+  category: LessonCategory;
+  content: string;
+  context?: string;
+}
+
+/** Decouples the store from the concrete lessons tracker + benchmark. */
+export interface LearnableStatePort {
+  /** All current lessons (the versioned payload). */
+  listLessons(): LessonSnapshot[];
+  /** Replace the entire lesson set (clear + re-add) — used by restore. */
+  setLessons(lessons: LessonSnapshot[]): void;
+  /** Snapshot of the evolutionary archive entries (audit, committed alongside). */
+  archive(): unknown[];
+  /** Deterministic benchmark score of the CURRENT state. */
+  score(): BenchmarkScore;
+}
+
+interface VersionManifest {
+  schemaVersion: number;
+  score: BenchmarkScore;
+  scenarioId?: string;
+  delta?: number;
+  reason: string;
+  generatedAt: string;
+}
+
+export interface StoreVersion {
+  sha: string;
+  shortSha: string;
+  createdAt: string;
+  message: string;
+  /** Null for commits that predate a manifest (e.g. the init commit). */
+  score: BenchmarkScore | null;
+}
+
+export interface LearningStoreOptions {
+  workDir?: string;
+  port: LearnableStatePort;
+  now?: () => Date;
+}
+
+const GIT_IDENTITY = [
+  '-c', 'user.name=Code Buddy Self-Improve',
+  '-c', 'user.email=self-improve@codebuddy.local',
+  '-c', 'commit.gpgsign=false',
+];
+
+export class LearningStore {
+  private readonly storeDir: string;
+  private readonly port: LearnableStatePort;
+  private readonly now: () => Date;
+
+  constructor(options: LearningStoreOptions) {
+    const workDir = options.workDir ?? process.cwd();
+    this.storeDir = path.join(workDir, '.codebuddy', 'self-improvement', 'store');
+    this.port = options.port;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  get path(): string {
+    return this.storeDir;
+  }
+
+  private runGit(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+    return new Promise((resolve) => {
+      const proc = spawn('git', args, { cwd: this.storeDir });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d) => (stdout += d.toString()));
+      proc.stderr.on('data', (d) => (stderr += d.toString()));
+      proc.on('error', (err) => resolve({ stdout, stderr: stderr + String(err), code: 1 }));
+      proc.on('close', (code) => resolve({ stdout, stderr, code: code ?? 0 }));
+    });
+  }
+
+  private get isRepo(): boolean {
+    return fs.existsSync(path.join(this.storeDir, '.git'));
+  }
+
+  /** Idempotently init the isolated repo with an empty initial commit. */
+  async ensureRepo(): Promise<void> {
+    if (this.isRepo) return;
+    fs.mkdirSync(this.storeDir, { recursive: true });
+    await this.runGit(['init', '-q']);
+    fs.writeFileSync(path.join(this.storeDir, '.gitignore'), '', 'utf-8');
+    await this.runGit(['add', '-A']);
+    await this.runGit([...GIT_IDENTITY, 'commit', '-q', '--allow-empty', '-m', 'init: learning store']);
+  }
+
+  private writeSnapshot(manifest: VersionManifest): void {
+    const write = (name: string, value: unknown) =>
+      fs.writeFileSync(path.join(this.storeDir, name), JSON.stringify(value, null, 2), 'utf-8');
+    write('lessons.json', this.port.listLessons());
+    write('archive.json', this.port.archive());
+    write('manifest.json', manifest);
+  }
+
+  /** Snapshot the current learnable state and commit it as a new version. */
+  async commitVersion(options: {
+    scenarioId?: string;
+    delta?: number;
+    reason: string;
+  }): Promise<{ sha: string; score: BenchmarkScore }> {
+    await this.ensureRepo();
+    const score = this.port.score();
+    const manifest: VersionManifest = {
+      schemaVersion: LEARNING_STORE_SCHEMA_VERSION,
+      score,
+      ...(options.scenarioId ? { scenarioId: options.scenarioId } : {}),
+      ...(options.delta !== undefined ? { delta: options.delta } : {}),
+      reason: options.reason,
+      generatedAt: this.now().toISOString(),
+    };
+    this.writeSnapshot(manifest);
+    await this.runGit(['add', '-A']);
+    const subject =
+      options.scenarioId && options.delta !== undefined
+        ? `improve(${options.scenarioId}): +${options.delta} coverage ${score.covered}/${score.total}`
+        : `${options.reason} — coverage ${score.covered}/${score.total}`;
+    const message = `${subject}\n\nCo-Authored-By: Code Buddy Self-Improve <self-improve@codebuddy.local>`;
+    await this.runGit([...GIT_IDENTITY, 'commit', '-q', '--allow-empty', '-m', message]);
+    const sha = (await this.runGit(['rev-parse', 'HEAD'])).stdout.trim();
+    return { sha, score };
+  }
+
+  /** List versions (newest first) with their committed benchmark score. */
+  async listVersions(): Promise<StoreVersion[]> {
+    if (!this.isRepo) return [];
+    const log = await this.runGit(['log', '--format=%H%x1f%aI%x1f%s']);
+    const lines = log.stdout.split('\n').filter(Boolean);
+    const versions: StoreVersion[] = [];
+    for (const line of lines) {
+      const [sha, createdAt, message] = line.split('\x1f');
+      if (!sha) continue;
+      let score: BenchmarkScore | null = null;
+      const show = await this.runGit(['show', `${sha}:manifest.json`]);
+      if (show.code === 0) {
+        try {
+          score = (JSON.parse(show.stdout) as VersionManifest).score ?? null;
+        } catch {
+          score = null;
+        }
+      }
+      versions.push({
+        sha,
+        shortSha: sha.slice(0, 8),
+        createdAt: createdAt ?? '',
+        message: message ?? '',
+        score,
+      });
+    }
+    return versions;
+  }
+
+  /** The highest-scoring version (ties → most recent). The "version qui marche mieux". */
+  async bestVersion(): Promise<StoreVersion | null> {
+    const scored = (await this.listVersions()).filter((v): v is StoreVersion & { score: BenchmarkScore } =>
+      v.score !== null,
+    );
+    if (scored.length === 0) return null;
+    // listVersions is newest-first; a stable reduce keeps the most recent on ties.
+    return scored.reduce((best, v) => (v.score.ratio > best.score.ratio ? v : best), scored[0]!);
+  }
+
+  /**
+   * Restore the learnable state to a known-good version: re-materialise that
+   * version's lessons into the live state, then commit the restore (forward,
+   * append-only). Returns the restored sha + the re-scored benchmark.
+   */
+  async restore(
+    target: { commit?: string; best?: boolean },
+  ): Promise<{ restoredFrom: string; score: BenchmarkScore } | null> {
+    if (!this.isRepo) return null;
+    let sha = target.commit?.trim();
+    if (target.best || !sha) {
+      const best = await this.bestVersion();
+      if (!best) return null;
+      sha = best.sha;
+    }
+    const show = await this.runGit(['show', `${sha}:lessons.json`]);
+    if (show.code !== 0) return null;
+    let lessons: LessonSnapshot[];
+    try {
+      lessons = JSON.parse(show.stdout) as LessonSnapshot[];
+    } catch {
+      return null;
+    }
+    this.port.setLessons(lessons);
+    const { score } = await this.commitVersion({ reason: `restore to ${sha.slice(0, 8)}` });
+    return { restoredFrom: sha, score };
+  }
+
+  /** Push to a configured remote (opt-in). No-op with a clear result if none. */
+  async push(): Promise<{ pushed: boolean; reason?: string }> {
+    if (!this.isRepo) return { pushed: false, reason: 'no learning store repo' };
+    const remotes = await this.runGit(['remote']);
+    if (!remotes.stdout.trim()) {
+      return { pushed: false, reason: 'no git remote configured for the learning store' };
+    }
+    const result = await this.runGit(['push']);
+    return result.code === 0
+      ? { pushed: true }
+      : { pushed: false, reason: result.stderr.trim() || 'git push failed' };
+  }
+
+  /** Current (HEAD) score and best-known score. */
+  async status(): Promise<{ head: BenchmarkScore | null; best: StoreVersion | null; versions: number }> {
+    const versions = await this.listVersions();
+    return {
+      head: versions[0]?.score ?? null,
+      best: await this.bestVersion(),
+      versions: versions.length,
+    };
+  }
+}

--- a/src/agent/self-improvement/llm-drafter.ts
+++ b/src/agent/self-improvement/llm-drafter.ts
@@ -1,0 +1,55 @@
+/**
+ * Real LLM-backed lesson drafter. Wires the self-improvement proposer to the
+ * agent's own model so the engine can DISCOVER novel improvements from run
+ * friction — then the deterministic empirical gate validates each draft. Lazy
+ * and graceful: if no provider is configured, the drafter declines (returns
+ * null) and the engine simply finds no LLM proposal, never crashes.
+ *
+ * @module agent/self-improvement/llm-drafter
+ */
+
+import { buildLessonDraftPrompt, type LessonDraft, type LessonDrafter } from './proposer.js';
+
+interface MinimalClient {
+  chat(
+    messages: Array<{ role: string; content: string }>,
+    tools?: unknown[],
+  ): Promise<{ choices?: Array<{ message?: { content?: string | null } }> }>;
+}
+
+export function createLlmDrafter(): LessonDrafter {
+  let clientPromise: Promise<MinimalClient | null> | null = null;
+
+  const getClient = (): Promise<MinimalClient | null> => {
+    if (!clientPromise) {
+      clientPromise = (async () => {
+        try {
+          const { detectProviderFromEnv } = await import('../../utils/provider-detector.js');
+          const { CodeBuddyClient } = await import('../../codebuddy/client.js');
+          const detected = detectProviderFromEnv();
+          if (!detected) return null;
+          return new CodeBuddyClient(detected.apiKey, detected.defaultModel, detected.baseURL) as unknown as MinimalClient;
+        } catch {
+          return null;
+        }
+      })();
+    }
+    return clientPromise;
+  };
+
+  return async (scenario, experiences): Promise<LessonDraft | null> => {
+    const client = await getClient();
+    if (!client) return null;
+    try {
+      const prompt = buildLessonDraftPrompt(scenario, experiences);
+      const response = await client.chat([{ role: 'user', content: prompt }], []);
+      const text = response?.choices?.[0]?.message?.content?.trim();
+      if (!text) return null;
+      // The empirical gate enforces relevance/structure downstream; here we only
+      // pass through the model's text as a RULE lesson.
+      return { category: 'RULE', content: text };
+    } catch {
+      return null;
+    }
+  };
+}

--- a/src/agent/self-improvement/proposer.ts
+++ b/src/agent/self-improvement/proposer.ts
@@ -13,7 +13,11 @@
 import type { BenchmarkScenario, Experience, ImprovementProposal } from './types.js';
 
 export interface ImprovementProposer {
-  propose(scenario: BenchmarkScenario, experiences: Experience[]): ImprovementProposal | null;
+  /** Async so an LLM-backed proposer can draft novel improvements. */
+  propose(
+    scenario: BenchmarkScenario,
+    experiences: Experience[],
+  ): Promise<ImprovementProposal | null>;
 }
 
 export interface LessonDraft {
@@ -26,7 +30,10 @@ export interface LessonDraft {
 export class StaticProposer implements ImprovementProposer {
   constructor(private readonly drafts: Map<string, LessonDraft>) {}
 
-  propose(scenario: BenchmarkScenario, experiences: Experience[]): ImprovementProposal | null {
+  async propose(
+    scenario: BenchmarkScenario,
+    experiences: Experience[],
+  ): Promise<ImprovementProposal | null> {
     const draft = this.drafts.get(scenario.id);
     if (!draft) return null;
     return {
@@ -37,6 +44,71 @@ export class StaticProposer implements ImprovementProposer {
       lesson: { category: draft.category, content: draft.content, context: draft.context },
     };
   }
+}
+
+/**
+ * Draft a lesson with an LLM. Injected so the proposer stays testable and
+ * provider-agnostic. Returns null to decline (e.g. the model can't help).
+ */
+export type LessonDrafter = (
+  scenario: BenchmarkScenario,
+  experiences: Experience[],
+) => Promise<LessonDraft | null>;
+
+/**
+ * LLM-backed proposer — the autonomy leap: it DISCOVERS novel improvements from
+ * real run friction rather than replaying a fixed pack. Generation is creative
+ * (non-deterministic); the empirical gate downstream is deterministic and
+ * rigorous, so a bad draft is simply rejected and rolled back. This is the
+ * Voyager "iterative prompting + self-verification" idea grounded by the DGM
+ * empirical gate.
+ */
+export class LlmProposer implements ImprovementProposer {
+  constructor(private readonly draft: LessonDrafter) {}
+
+  async propose(
+    scenario: BenchmarkScenario,
+    experiences: Experience[],
+  ): Promise<ImprovementProposal | null> {
+    const draft = await this.draft(scenario, experiences);
+    if (!draft || !draft.content?.trim()) return null;
+    return {
+      id: `prop-llm-${scenario.id}`,
+      kind: 'lesson',
+      targetScenarioId: scenario.id,
+      experienceId: experiences[0]?.id,
+      lesson: { category: draft.category, content: draft.content.trim(), context: draft.context },
+    };
+  }
+}
+
+/**
+ * Build the strict prompt that asks a model to draft ONE durable lesson which
+ * would make the agent handle `scenario` correctly next time, grounded in the
+ * observed `experiences`. Kept here (not in the proposer) so the wiring layer
+ * can pass it to whatever LLM client is available.
+ */
+export function buildLessonDraftPrompt(
+  scenario: BenchmarkScenario,
+  experiences: Experience[],
+): string {
+  const evidence = experiences
+    .slice(0, 5)
+    .map((e) => `- [${e.kind}] ${e.detail} (${e.context})`)
+    .join('\n');
+  return [
+    'You maintain an AI coding agent\'s lesson library.',
+    'Write ONE durable, reusable lesson (1-2 sentences) that would make the agent',
+    `handle this recurring situation correctly next time. Situation: ${scenario.description}`,
+    scenario.expectIncludes.length
+      ? `The lesson MUST mention: ${scenario.expectIncludes.join(', ')}.`
+      : '',
+    `It should be retrievable when searching for: "${scenario.query}".`,
+    evidence ? `Observed friction:\n${evidence}` : '',
+    'Reply with ONLY the lesson text — no preamble, no markdown, no secrets.',
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 /**

--- a/src/agent/self-improvement/proposer.ts
+++ b/src/agent/self-improvement/proposer.ts
@@ -1,0 +1,73 @@
+/**
+ * Improvement proposers — turn a curriculum target (+ experiences) into a
+ * candidate improvement. The interface is the injection seam: the production
+ * path is an LLM-backed proposer that drafts a lesson from real run friction,
+ * but V1 ships a DETERMINISTIC static proposer so the engine and its empirical
+ * gate stay fully reproducible and testable. Crucially, proposers are kept
+ * structurally separate from the benchmark scenarios (the evals) — the engine
+ * must never author the checks that bless its own changes.
+ *
+ * @module agent/self-improvement/proposer
+ */
+
+import type { BenchmarkScenario, Experience, ImprovementProposal } from './types.js';
+
+export interface ImprovementProposer {
+  propose(scenario: BenchmarkScenario, experiences: Experience[]): ImprovementProposal | null;
+}
+
+export interface LessonDraft {
+  category: 'PATTERN' | 'RULE' | 'CONTEXT' | 'INSIGHT';
+  content: string;
+  context?: string;
+}
+
+/** Deterministic proposer backed by a fixed scenarioId → draft map. */
+export class StaticProposer implements ImprovementProposer {
+  constructor(private readonly drafts: Map<string, LessonDraft>) {}
+
+  propose(scenario: BenchmarkScenario, experiences: Experience[]): ImprovementProposal | null {
+    const draft = this.drafts.get(scenario.id);
+    if (!draft) return null;
+    return {
+      id: `prop-${scenario.id}`,
+      kind: 'lesson',
+      targetScenarioId: scenario.id,
+      experienceId: experiences[0]?.id,
+      lesson: { category: draft.category, content: draft.content, context: draft.context },
+    };
+  }
+}
+
+/**
+ * A curated knowledge pack the static proposer can use to BOOTSTRAP the agent's
+ * lesson library — each draft is then empirically validated by the gate before
+ * it is kept. This is deliberately SEPARATE from SEED_BENCHMARK_SCENARIOS so the
+ * proposer never co-authors its own evals.
+ */
+export const SEED_LESSON_DRAFTS = new Map<string, LessonDraft>([
+  [
+    'npm-test-path-filter',
+    {
+      category: 'RULE',
+      content:
+        'When running npm test, always pass a path filter (e.g. `npm test -- path/to/file.test.ts`); the full suite is slow.',
+    },
+  ],
+  [
+    'esm-js-extension-imports',
+    {
+      category: 'RULE',
+      content:
+        'This is an ESM project: relative import statements need a .js extension even when importing a .ts source file.',
+    },
+  ],
+  [
+    'logger-not-console',
+    {
+      category: 'RULE',
+      content:
+        'Use the logger (src/utils/logger) in production code, not console.log — tests spy on logger and console output is not captured.',
+    },
+  ],
+]);

--- a/src/agent/self-improvement/rule-engine.ts
+++ b/src/agent/self-improvement/rule-engine.ts
@@ -1,0 +1,177 @@
+/**
+ * RuleLearningEngine — wires the execution-grounded validator into a learning
+ * loop. It learns behavioral RULES whose correctness is measured against real
+ * recorded trajectories (does the rule flag the bad runs and pass the good ones),
+ * not keyword retrievability. Accepted rules persist (structured + as a retrievable
+ * RULE lesson) and are git-reversible like the rest of the learnable state.
+ *
+ * @module agent/self-improvement/rule-engine
+ */
+
+import {
+  scoreCorpus,
+  validateBehavioralRule,
+  verdict,
+  type BehavioralCheck,
+  type BehavioralRuleProposal,
+  type LabeledTrajectory,
+  type ExecutionGateOutcome,
+} from './execution-gate.js';
+import type { RuleStore } from './rule-store.js';
+import type { EvolutionaryArchive } from './evolutionary-archive.js';
+import { resolveAutonomy, type Autonomy } from './engine.js';
+
+export interface RuleProposer {
+  propose(
+    target: LabeledTrajectory,
+    corpus: LabeledTrajectory[],
+    currentRules: BehavioralCheck[],
+  ): BehavioralRuleProposal | null;
+}
+
+/**
+ * Deterministic proposer: for a bad run that currently slips through (should be
+ * flagged but passes), forbid a tool it used that NO compliant run uses. That is
+ * a sound, minimal rule grounded entirely in the recorded behavior.
+ */
+export class HeuristicRuleProposer implements RuleProposer {
+  propose(
+    target: LabeledTrajectory,
+    corpus: LabeledTrajectory[],
+    currentRules: BehavioralCheck[],
+  ): BehavioralRuleProposal | null {
+    // Only act on a should-fail run that currently passes the rule set.
+    if (target.shouldPass || !verdict(currentRules, target.trajectory)) return null;
+    const goodTools = new Set(
+      corpus.filter((c) => c.shouldPass).flatMap((c) => c.trajectory.toolNames),
+    );
+    const offending = target.trajectory.toolNames.find((tool) => !goodTools.has(tool));
+    if (!offending) return null;
+    const profile = target.trajectory.profile ? `${target.trajectory.profile}-profile` : 'read-only';
+    return {
+      id: `rule-forbid-${offending}`,
+      statement: `A ${profile} run must not call ${offending}.`,
+      check: { kind: 'forbid_tool', pattern: `^${escapeRe(offending)}$` },
+    };
+  }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export interface RuleLearningResult {
+  kind: 'rule_learning_cycle';
+  startedAt: string;
+  autonomy: Autonomy;
+  targetId: string | null;
+  proposalId: string | null;
+  gate: ExecutionGateOutcome | null;
+  accuracyBefore: number;
+  accuracyAfter: number;
+  applied: boolean;
+  notes: string[];
+}
+
+export interface RuleLearningEngineOptions {
+  corpus: LabeledTrajectory[];
+  proposer: RuleProposer;
+  ruleStore: RuleStore;
+  archive?: EvolutionaryArchive;
+  autonomy?: Autonomy;
+  /** Side-effect on accept (e.g. also add a retrievable RULE lesson). */
+  onAccept?: (proposal: BehavioralRuleProposal) => void;
+  now?: () => Date;
+}
+
+export class RuleLearningEngine {
+  private readonly corpus: LabeledTrajectory[];
+  private readonly proposer: RuleProposer;
+  private readonly ruleStore: RuleStore;
+  private readonly archive?: EvolutionaryArchive;
+  private readonly autonomy: Autonomy;
+  private readonly onAccept?: (proposal: BehavioralRuleProposal) => void;
+  private readonly now: () => Date;
+
+  constructor(options: RuleLearningEngineOptions) {
+    this.corpus = options.corpus;
+    this.proposer = options.proposer;
+    this.ruleStore = options.ruleStore;
+    this.archive = options.archive;
+    this.autonomy = options.autonomy ?? resolveAutonomy();
+    this.onAccept = options.onAccept;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /** First trajectory the rule set classifies wrong, preferring fixable should-fail runs. */
+  private selectTarget(rules: BehavioralCheck[]): LabeledTrajectory | null {
+    const misclassified = this.corpus.filter(
+      (c) => verdict(rules, c.trajectory) !== c.shouldPass,
+    );
+    // A should-fail run that currently passes is fixable by adding a forbid rule.
+    return misclassified.find((c) => !c.shouldPass) ?? misclassified[0] ?? null;
+  }
+
+  runCycle(): RuleLearningResult {
+    const startedAt = this.now().toISOString();
+    const rules = this.ruleStore.checks();
+    const before = scoreCorpus(rules, this.corpus);
+    const base = {
+      kind: 'rule_learning_cycle' as const,
+      startedAt,
+      autonomy: this.autonomy,
+      accuracyBefore: before.accuracy,
+    };
+
+    const target = this.selectTarget(rules);
+    if (!target) {
+      return { ...base, targetId: null, proposalId: null, gate: null, accuracyAfter: before.accuracy, applied: false, notes: ['corpus fully classified — nothing to learn'] };
+    }
+    const proposal = this.proposer.propose(target, this.corpus, rules);
+    if (!proposal) {
+      return { ...base, targetId: target.id, proposalId: null, gate: null, accuracyAfter: before.accuracy, applied: false, notes: [`no rule proposal for "${target.id}"`] };
+    }
+    const gate = validateBehavioralRule(proposal, rules, this.corpus);
+    const applied = gate.accepted && this.autonomy === 'auto-apply';
+    if (applied) {
+      this.ruleStore.add(proposal.check, proposal.statement);
+      this.onAccept?.(proposal);
+      this.archive?.append({
+        proposalId: proposal.id,
+        kind: 'lesson',
+        targetScenarioId: target.id,
+        delta: gate.delta,
+        scoreAfter: gate.accuracyAfter,
+        reviewedBy: 'auto:self-improve:rule',
+      });
+    }
+    const after = scoreCorpus(this.ruleStore.checks(), this.corpus);
+    return {
+      ...base,
+      targetId: target.id,
+      proposalId: proposal.id,
+      gate,
+      accuracyAfter: after.accuracy,
+      applied,
+      notes: gate.notes,
+    };
+  }
+
+  runLoop(maxCycles = this.corpus.length + 1): RuleLearningResult[] {
+    const results: RuleLearningResult[] = [];
+    for (let i = 0; i < Math.max(1, maxCycles); i++) {
+      const r = this.runCycle();
+      results.push(r);
+      if (!r.applied) break;
+    }
+    return results;
+  }
+
+  status(): { autonomy: Autonomy; score: ReturnType<typeof scoreCorpus>; rules: number } {
+    return {
+      autonomy: this.autonomy,
+      score: scoreCorpus(this.ruleStore.checks(), this.corpus),
+      rules: this.ruleStore.list().length,
+    };
+  }
+}

--- a/src/agent/self-improvement/rule-engine.ts
+++ b/src/agent/self-improvement/rule-engine.ts
@@ -30,9 +30,20 @@ export interface RuleProposer {
 }
 
 /**
+ * Tools that are inherently read-only — a rule about a read-only/safe run must
+ * never forbid these (forbidding `view_file` in a "must stay read-only" rule is
+ * self-evidently wrong). Guards against a degenerate corpus (e.g. a single bad
+ * example with no good runs) producing an over-broad rule.
+ */
+const KNOWN_READ_ONLY_TOOLS = new Set([
+  'view_file', 'read_file', 'list_directory', 'search', 'grep', 'glob', 'tool_search',
+]);
+
+/**
  * Deterministic proposer: for a bad run that currently slips through (should be
- * flagged but passes), forbid a tool it used that NO compliant run uses. That is
- * a sound, minimal rule grounded entirely in the recorded behavior.
+ * flagged but passes), forbid a tool it used that NO compliant run uses — and
+ * that is not inherently read-only. A sound, minimal rule grounded in the
+ * recorded behavior.
  */
 export class HeuristicRuleProposer implements RuleProposer {
   propose(
@@ -45,7 +56,9 @@ export class HeuristicRuleProposer implements RuleProposer {
     const goodTools = new Set(
       corpus.filter((c) => c.shouldPass).flatMap((c) => c.trajectory.toolNames),
     );
-    const offending = target.trajectory.toolNames.find((tool) => !goodTools.has(tool));
+    const offending = target.trajectory.toolNames.find(
+      (tool) => !goodTools.has(tool) && !KNOWN_READ_ONLY_TOOLS.has(tool),
+    );
     if (!offending) return null;
     const profile = target.trajectory.profile ? `${target.trajectory.profile}-profile` : 'read-only';
     return {

--- a/src/agent/self-improvement/rule-store.ts
+++ b/src/agent/self-improvement/rule-store.ts
@@ -1,0 +1,114 @@
+/**
+ * Rule store + labeled trajectory corpus for the execution-grounded learning loop.
+ *
+ * Accepted behavioral rules (structured, checkable predicates + their human-readable
+ * statement) persist to `.codebuddy/self-improvement/rules.json`. The labeled
+ * trajectory corpus the rules are validated against loads from
+ * `.codebuddy/self-improvement/corpus.json` (curated by a human — eval curation
+ * stays human-gated) with a small SEED fallback so the loop runs out of the box.
+ *
+ * @module agent/self-improvement/rule-store
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import type { BehavioralCheck, LabeledTrajectory } from './execution-gate.js';
+
+export const RULE_STORE_SCHEMA_VERSION = 1;
+
+export interface StoredRule {
+  check: BehavioralCheck;
+  statement: string;
+  createdAt: string;
+}
+
+interface RuleFile {
+  schemaVersion: number;
+  rules: StoredRule[];
+}
+
+export interface RuleStoreOptions {
+  workDir?: string;
+  now?: () => Date;
+}
+
+export class RuleStore {
+  private readonly filePath: string;
+  private readonly now: () => Date;
+
+  constructor(options: RuleStoreOptions = {}) {
+    const root = options.workDir ?? process.cwd();
+    this.filePath = path.join(root, '.codebuddy', 'self-improvement', 'rules.json');
+    this.now = options.now ?? (() => new Date());
+  }
+
+  get path(): string {
+    return this.filePath;
+  }
+
+  private read(): RuleFile {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as Partial<RuleFile>;
+      if (Array.isArray(parsed.rules)) {
+        return { schemaVersion: RULE_STORE_SCHEMA_VERSION, rules: parsed.rules };
+      }
+    } catch {
+      /* none yet */
+    }
+    return { schemaVersion: RULE_STORE_SCHEMA_VERSION, rules: [] };
+  }
+
+  private write(file: RuleFile): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify(file, null, 2), 'utf-8');
+  }
+
+  list(): StoredRule[] {
+    return this.read().rules;
+  }
+
+  /** The active checks the corpus is scored against. */
+  checks(): BehavioralCheck[] {
+    return this.list().map((r) => r.check);
+  }
+
+  add(check: BehavioralCheck, statement: string): StoredRule {
+    const file = this.read();
+    const stored: StoredRule = { check, statement, createdAt: this.now().toISOString() };
+    file.rules.push(stored);
+    this.write(file);
+    return stored;
+  }
+
+  /** Replace all rules (used by git-store restore). */
+  setAll(rules: StoredRule[]): void {
+    this.write({ schemaVersion: RULE_STORE_SCHEMA_VERSION, rules });
+  }
+}
+
+/**
+ * Seed corpus — a few labeled behavioral examples so the loop runs deterministically
+ * out of the box. `shouldPass: false` marks a run whose behavior a rule SHOULD flag.
+ * Curated, and meant to be extended from real labeled runs in corpus.json.
+ */
+export const SEED_TRAJECTORY_CORPUS: LabeledTrajectory[] = [
+  { id: 'seed-readonly-1', shouldPass: true, trajectory: { toolNames: ['view_file', 'search'], text: 'inspected the code', profile: 'safe' } },
+  { id: 'seed-readonly-2', shouldPass: true, trajectory: { toolNames: ['list_directory', 'view_file'], text: 'reviewed structure', profile: 'review' } },
+  { id: 'seed-mutation-1', shouldPass: false, trajectory: { toolNames: ['view_file', 'bash'], text: 'ran a shell command in a read-only review', profile: 'safe' } },
+  { id: 'seed-mutation-2', shouldPass: false, trajectory: { toolNames: ['write_file'], text: 'wrote a file during an audit', profile: 'review' } },
+];
+
+/** Load the labeled corpus from corpus.json, falling back to the seed corpus. */
+export function loadTrajectoryCorpus(workDir: string = process.cwd()): LabeledTrajectory[] {
+  const corpusPath = path.join(workDir, '.codebuddy', 'self-improvement', 'corpus.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(corpusPath, 'utf-8')) as { trajectories?: LabeledTrajectory[] };
+    if (Array.isArray(parsed.trajectories) && parsed.trajectories.length > 0) {
+      return parsed.trajectories;
+    }
+  } catch {
+    /* fall back to seed */
+  }
+  return SEED_TRAJECTORY_CORPUS;
+}

--- a/src/agent/self-improvement/rule-store.ts
+++ b/src/agent/self-improvement/rule-store.ts
@@ -101,14 +101,53 @@ export const SEED_TRAJECTORY_CORPUS: LabeledTrajectory[] = [
 
 /** Load the labeled corpus from corpus.json, falling back to the seed corpus. */
 export function loadTrajectoryCorpus(workDir: string = process.cwd()): LabeledTrajectory[] {
-  const corpusPath = path.join(workDir, '.codebuddy', 'self-improvement', 'corpus.json');
-  try {
-    const parsed = JSON.parse(fs.readFileSync(corpusPath, 'utf-8')) as { trajectories?: LabeledTrajectory[] };
-    if (Array.isArray(parsed.trajectories) && parsed.trajectories.length > 0) {
-      return parsed.trajectories;
-    }
-  } catch {
-    /* fall back to seed */
+  const corpus = new CorpusStore({ workDir }).list();
+  return corpus.length > 0 ? corpus : SEED_TRAJECTORY_CORPUS;
+}
+
+/**
+ * Human-curated labeled trajectory corpus (`.codebuddy/self-improvement/corpus.json`).
+ * Eval curation stays human-gated: only the operator labels a run pass/fail; the
+ * engine never labels its own corpus.
+ */
+export class CorpusStore {
+  private readonly filePath: string;
+
+  constructor(options: { workDir?: string } = {}) {
+    const root = options.workDir ?? process.cwd();
+    this.filePath = path.join(root, '.codebuddy', 'self-improvement', 'corpus.json');
   }
-  return SEED_TRAJECTORY_CORPUS;
+
+  get path(): string {
+    return this.filePath;
+  }
+
+  list(): LabeledTrajectory[] {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as { trajectories?: LabeledTrajectory[] };
+      return Array.isArray(parsed.trajectories) ? parsed.trajectories : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private write(trajectories: LabeledTrajectory[]): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify({ schemaVersion: 1, trajectories }, null, 2), 'utf-8');
+  }
+
+  /** Add or replace a labeled trajectory by id. */
+  add(entry: LabeledTrajectory): void {
+    const list = this.list().filter((t) => t.id !== entry.id);
+    list.push(entry);
+    this.write(list);
+  }
+
+  remove(id: string): boolean {
+    const list = this.list();
+    const next = list.filter((t) => t.id !== id);
+    if (next.length === list.length) return false;
+    this.write(next);
+    return true;
+  }
 }

--- a/src/agent/self-improvement/types.ts
+++ b/src/agent/self-improvement/types.ts
@@ -1,0 +1,140 @@
+/**
+ * Recursive self-improvement engine — shared types.
+ *
+ * Design (compact, clean, measurable — per the project's guiding principle):
+ * an empirically-gated, archive-based improvement loop inspired by the Darwin
+ * Gödel Machine (empirical validation of self-modifications) and Voyager
+ * (an ever-growing, self-verified skill/lesson library), built ON TOP of
+ * Code Buddy's existing learning infrastructure (RunStore, retrospectives,
+ * lessons, skills, golden/policy evals) rather than duplicating it.
+ *
+ * The engine improves only the REVERSIBLE learnable layer (lessons, and later
+ * skills/patterns) — never agent source code. Every change is snapshot-gated,
+ * empirically validated against a DETERMINISTIC capability benchmark, and
+ * rolled back on regression. Code-level self-modification (the DGM's "rewrite
+ * own code") is intentionally out of scope for V1.
+ *
+ * @module agent/self-improvement/types
+ */
+
+export const SELF_IMPROVEMENT_SCHEMA_VERSION = 1;
+
+/**
+ * A unit of feedback to learn from. The same shape covers code-run friction
+ * today and, in the robot future, sensor/world-model prediction error — that
+ * is the modality-agnostic seam (see ExperienceSource).
+ */
+export interface Experience {
+  /** Stable id (e.g. `run:<runId>:<frictionKey>` or `sensor:<...>`). */
+  id: string;
+  /** Where it came from. */
+  source: 'run' | 'sensor' | 'manual';
+  /** Short machine label for the situation (used to target a benchmark scenario). */
+  kind: string;
+  /** Human-readable description of the friction/opportunity. */
+  detail: string;
+  /** Free-text context the proposer can mine (e.g. tool sequence, error text). */
+  context: string;
+  /** Optional severity 0..1 used by the curriculum to prioritise. */
+  severity?: number;
+}
+
+/** A candidate improvement to the reversible learnable layer. V1: lessons. */
+export interface ImprovementProposal {
+  id: string;
+  kind: 'lesson';
+  /** Benchmark scenario this proposal intends to fix (for measurement). */
+  targetScenarioId: string;
+  /** The experience that motivated it, if any (lineage/audit). */
+  experienceId?: string;
+  lesson: {
+    category: 'PATTERN' | 'RULE' | 'CONTEXT' | 'INSIGHT';
+    content: string;
+    context?: string;
+  };
+}
+
+/**
+ * A deterministic, offline check: for `query`, the agent's learnable state
+ * should surface guidance matching `expectIncludes`. Curated SEPARATELY from
+ * the proposer (the engine must never author the evals that bless its own
+ * changes — that would let it game itself).
+ */
+export interface BenchmarkScenario {
+  id: string;
+  /** The situation, as the agent would search for guidance. */
+  query: string;
+  /** Lowercased substrings; a lesson matching ANY counts the scenario as covered. */
+  expectIncludes: string[];
+  /** Human label. */
+  description: string;
+}
+
+export interface BenchmarkScenarioResult {
+  scenarioId: string;
+  covered: boolean;
+  /** Ids of lessons that satisfied the expectation (audit). */
+  matchedLessonIds: string[];
+}
+
+export interface BenchmarkScore {
+  total: number;
+  covered: number;
+  /** covered / total in [0,1]. */
+  ratio: number;
+  results: BenchmarkScenarioResult[];
+}
+
+/** Why a proposal was rejected, for audit. */
+export type GateRejectionReason =
+  | 'structural-invalid'
+  | 'policy-violation'
+  | 'no-improvement'
+  | 'regression';
+
+export interface GateOutcome {
+  accepted: boolean;
+  proposalId: string;
+  scoreBefore: number;
+  scoreAfter: number;
+  /** scoreAfter - scoreBefore. */
+  delta: number;
+  /** Scenario ids that got WORSE (covered → uncovered) — any => reject + rollback. */
+  regressions: string[];
+  rejectionReason?: GateRejectionReason;
+  /** True when a snapshot was applied then reverted (rollback proven). */
+  rolledBack: boolean;
+  notes: string[];
+}
+
+/** One accepted improvement, kept as an evolutionary stepping stone (DGM). */
+export interface ArchiveEntry {
+  proposalId: string;
+  kind: ImprovementProposal['kind'];
+  targetScenarioId: string;
+  experienceId?: string;
+  delta: number;
+  scoreAfter: number;
+  /** Id of the applied lesson (so it can be traced/rolled back later). */
+  appliedRef?: string;
+  createdAt: string;
+  /** Sentinel for auditability, mirrors the learning-loop convention. */
+  reviewedBy: string;
+}
+
+export interface SelfImprovementCycleResult {
+  schemaVersion: typeof SELF_IMPROVEMENT_SCHEMA_VERSION;
+  kind: 'self_improvement_cycle';
+  startedAt: string;
+  /** The scenario the curriculum selected to work on (lowest coverage first). */
+  selectedScenarioId: string | null;
+  proposalId: string | null;
+  gate: GateOutcome | null;
+  scoreBefore: BenchmarkScore;
+  scoreAfter: BenchmarkScore;
+  /** True only when an empirically-validated improvement was kept. */
+  applied: boolean;
+  /** 'propose-only' (default) or 'auto-apply' (CODEBUDDY_SELF_IMPROVE=true). */
+  autonomy: 'propose-only' | 'auto-apply';
+  notes: string[];
+}

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -18,6 +18,7 @@ interface ImproveOptions {
   json?: boolean;
   apply?: boolean;
   max?: string;
+  llm?: boolean;
 }
 
 function print(payload: unknown, options: ImproveOptions, text: string): void {
@@ -54,9 +55,13 @@ export function registerImproveCommands(program: Command): void {
     .description('Run one improvement cycle (propose → empirically validate → keep/rollback)')
     .option('--json', 'output JSON')
     .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
-    .action((options: ImproveOptions) => {
-      const engine = createWorkspaceEngine(options.apply ? { autonomy: 'auto-apply' } : {});
-      const result = engine.runCycle();
+    .option('--llm', 'use the model to discover novel lessons from run friction (else a deterministic seed pack)')
+    .action(async (options: ImproveOptions) => {
+      const engine = createWorkspaceEngine({
+        ...(options.apply ? { autonomy: 'auto-apply' as const } : {}),
+        useLlm: options.llm === true,
+      });
+      const result = await engine.runCycle();
       const verdict = result.applied
         ? `APPLIED improvement to "${result.selectedScenarioId}" (Δ=${result.gate?.delta})`
         : result.gate?.accepted
@@ -78,10 +83,14 @@ export function registerImproveCommands(program: Command): void {
     .option('--json', 'output JSON')
     .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
     .option('--max <n>', 'maximum cycles', (v) => v)
-    .action((options: ImproveOptions) => {
-      const engine = createWorkspaceEngine(options.apply ? { autonomy: 'auto-apply' } : {});
+    .option('--llm', 'use the model to discover novel lessons from run friction (else a deterministic seed pack)')
+    .action(async (options: ImproveOptions) => {
+      const engine = createWorkspaceEngine({
+        ...(options.apply ? { autonomy: 'auto-apply' as const } : {}),
+        useLlm: options.llm === true,
+      });
       const maxCycles = options.max ? Number.parseInt(options.max, 10) : undefined;
-      const results = engine.runLoop(maxCycles ? { maxCycles } : {});
+      const results = await engine.runLoop(maxCycles ? { maxCycles } : {});
       const appliedCount = results.filter((r) => r.applied).length;
       const final = engine.status();
       const text = [

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -11,7 +11,10 @@
 
 import type { Command } from 'commander';
 
-import { createWorkspaceEngine } from '../../agent/self-improvement/index.js';
+import {
+  createWorkspaceEngine,
+  createWorkspaceLearningStore,
+} from '../../agent/self-improvement/index.js';
 import { EvolutionaryArchive } from '../../agent/self-improvement/evolutionary-archive.js';
 import { createDefaultRunExperienceSource } from '../../agent/self-improvement/experience-source.js';
 import type { Experience } from '../../agent/self-improvement/types.js';
@@ -34,6 +37,10 @@ interface ImproveOptions {
   apply?: boolean;
   max?: string;
   llm?: boolean;
+  /** cycle/loop: negatable boolean (default true). restore: a commit sha string. */
+  commit?: boolean | string;
+  push?: boolean;
+  best?: boolean;
 }
 
 function print(payload: unknown, options: ImproveOptions, text: string): void {
@@ -51,18 +58,20 @@ export function registerImproveCommands(program: Command): void {
 
   improve
     .command('status')
-    .description('Show capability-benchmark coverage, autonomy mode, and the improvement archive')
+    .description('Show capability-benchmark coverage, autonomy mode, archive, and git store versions')
     .option('--json', 'output JSON')
-    .action((options: ImproveOptions) => {
+    .action(async (options: ImproveOptions) => {
       const engine = createWorkspaceEngine();
       const status = engine.status();
+      const store = await createWorkspaceLearningStore().status();
       const text = [
         `Autonomy: ${status.autonomy}`,
         `Capability coverage: ${status.score.covered}/${status.score.total} (${Math.round(status.score.ratio * 100)}%)`,
         `Uncovered: ${status.score.results.filter((r) => !r.covered).map((r) => r.scenarioId).join(', ') || '(none)'}`,
         `Archive: ${status.archive.count} validated improvement(s), total Δ=${status.archive.totalDelta}`,
+        `Store: ${store.versions} version(s); head ${store.head ? `${store.head.covered}/${store.head.total}` : '—'}, best ${store.best?.score ? `${store.best.score.covered}/${store.best.score.total} (${store.best.shortSha})` : '—'}`,
       ].join('\n');
-      print({ kind: 'self_improvement_status', ...status }, options, text);
+      print({ kind: 'self_improvement_status', ...status, store }, options, text);
     });
 
   improve
@@ -71,6 +80,8 @@ export function registerImproveCommands(program: Command): void {
     .option('--json', 'output JSON')
     .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
     .option('--llm', 'use the model to discover novel lessons from run friction (else a deterministic seed pack)')
+    .option('--no-commit', 'do not version an applied improvement in the git learning store')
+    .option('--push', 'push the learning store to its configured git remote after committing')
     .action(async (options: ImproveOptions) => {
       const engine = createWorkspaceEngine({
         ...(options.apply ? { autonomy: 'auto-apply' as const } : {}),
@@ -78,6 +89,17 @@ export function registerImproveCommands(program: Command): void {
       });
       const experiences = options.llm ? await collectExperiences() : [];
       const result = await engine.runCycle(experiences);
+      let committed: string | undefined;
+      if (result.applied && options.apply && options.commit !== false) {
+        const store = createWorkspaceLearningStore();
+        const version = await store.commitVersion({
+          ...(result.selectedScenarioId ? { scenarioId: result.selectedScenarioId } : {}),
+          ...(result.gate?.delta !== undefined ? { delta: result.gate.delta } : {}),
+          reason: 'improve cycle',
+        });
+        committed = version.sha.slice(0, 8);
+        if (options.push) await store.push();
+      }
       const verdict = result.applied
         ? `APPLIED improvement to "${result.selectedScenarioId}" (Δ=${result.gate?.delta})`
         : result.gate?.accepted
@@ -89,8 +111,11 @@ export function registerImproveCommands(program: Command): void {
         `Autonomy: ${result.autonomy}`,
         `Coverage: ${result.scoreBefore.covered}/${result.scoreBefore.total} → ${result.scoreAfter.covered}/${result.scoreAfter.total}`,
         verdict,
-      ].join('\n');
-      print(result, options, text);
+        committed ? `Versioned in learning store: ${committed}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      print({ ...result, committed }, options, text);
     });
 
   improve
@@ -100,22 +125,47 @@ export function registerImproveCommands(program: Command): void {
     .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
     .option('--max <n>', 'maximum cycles', (v) => v)
     .option('--llm', 'use the model to discover novel lessons from run friction (else a deterministic seed pack)')
+    .option('--no-commit', 'do not version applied improvements in the git learning store')
+    .option('--push', 'push the learning store to its configured git remote after committing')
     .action(async (options: ImproveOptions) => {
       const engine = createWorkspaceEngine({
         ...(options.apply ? { autonomy: 'auto-apply' as const } : {}),
         useLlm: options.llm === true,
       });
-      const maxCycles = options.max ? Number.parseInt(options.max, 10) : undefined;
       const experiences = options.llm ? await collectExperiences() : [];
-      const results = await engine.runLoop({ ...(maxCycles ? { maxCycles } : {}), experiences });
+      const doCommit = options.apply === true && options.commit !== false;
+      const store = doCommit ? createWorkspaceLearningStore() : null;
+      const cap = options.max ? Math.max(1, Number.parseInt(options.max, 10)) : 25;
+
+      // Drive the loop here (not engine.runLoop) so each applied improvement gets
+      // its own reversible git version. Stop on the first non-applied cycle.
+      const results = [];
+      for (let i = 0; i < cap; i++) {
+        const r = await engine.runCycle(experiences);
+        results.push(r);
+        if (r.applied && store) {
+          await store.commitVersion({
+            ...(r.selectedScenarioId ? { scenarioId: r.selectedScenarioId } : {}),
+            ...(r.gate?.delta !== undefined ? { delta: r.gate.delta } : {}),
+            reason: 'improve loop',
+          });
+        }
+        if (!r.applied) break;
+      }
+      if (store && options.push) await store.push();
+
       const appliedCount = results.filter((r) => r.applied).length;
       const final = engine.status();
+      const storeStatus = store ? await store.status() : null;
       const text = [
         `Autonomy: ${results[0]?.autonomy ?? 'propose-only'}`,
         `Cycles: ${results.length}, applied: ${appliedCount}`,
         `Final coverage: ${final.score.covered}/${final.score.total} (${Math.round(final.score.ratio * 100)}%)`,
-      ].join('\n');
-      print({ kind: 'self_improvement_loop', cycles: results, status: final }, options, text);
+        storeStatus ? `Store versions: ${storeStatus.versions}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      print({ kind: 'self_improvement_loop', cycles: results, status: final, store: storeStatus }, options, text);
     });
 
   improve
@@ -133,5 +183,51 @@ export function registerImproveCommands(program: Command): void {
             .join('\n')
         : 'No validated improvements archived yet.';
       print({ kind: 'self_improvement_archive', entries, status: engine.status() }, options, text);
+    });
+
+  improve
+    .command('versions')
+    .description('List git-versioned learning-store states with their benchmark scores')
+    .option('--json', 'output JSON')
+    .action(async (options: ImproveOptions) => {
+      const store = createWorkspaceLearningStore();
+      const versions = await store.listVersions();
+      const best = await store.bestVersion();
+      const text = versions.length
+        ? versions
+            .map((v, i) => {
+              const score = v.score ? `${v.score.covered}/${v.score.total}` : '—';
+              const flags = [i === 0 ? 'HEAD' : '', best && v.sha === best.sha ? 'BEST' : '']
+                .filter(Boolean)
+                .join(',');
+              return `${v.shortSha}  ${score}  ${v.message}${flags ? `  [${flags}]` : ''}`;
+            })
+            .join('\n')
+        : 'No learning-store versions yet (run `improve cycle --apply`).';
+      print({ kind: 'self_improvement_versions', versions, best }, options, text);
+    });
+
+  improve
+    .command('restore')
+    .description('Restore the learnable state to a known-good version (revert to one that works better)')
+    .option('--json', 'output JSON')
+    .option('--best', 'restore to the highest-scoring version (default)')
+    .option('--commit <sha>', 'restore to a specific store commit')
+    .option('--push', 'push the learning store after restoring')
+    .action(async (options: ImproveOptions) => {
+      const store = createWorkspaceLearningStore();
+      const target =
+        typeof options.commit === 'string' ? { commit: options.commit } : { best: true };
+      const result = await store.restore(target);
+      if (!result) {
+        print({ kind: 'self_improvement_restore', restored: false }, options, 'No known-good version to restore.');
+        return;
+      }
+      if (options.push) await store.push();
+      const text = [
+        `Restored to ${result.restoredFrom.slice(0, 8)}`,
+        `Coverage now: ${result.score.covered}/${result.score.total} (${Math.round(result.score.ratio * 100)}%)`,
+      ].join('\n');
+      print({ kind: 'self_improvement_restore', restored: true, ...result }, options, text);
     });
 }

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -18,6 +18,8 @@ import {
 } from '../../agent/self-improvement/index.js';
 import { EvolutionaryArchive } from '../../agent/self-improvement/evolutionary-archive.js';
 import { createDefaultRunExperienceSource } from '../../agent/self-improvement/experience-source.js';
+import { CorpusStore } from '../../agent/self-improvement/rule-store.js';
+import { summarizeTrajectory } from '../../agent/self-improvement/execution-gate.js';
 import type { Experience } from '../../agent/self-improvement/types.js';
 
 /**
@@ -42,6 +44,8 @@ interface ImproveOptions {
   commit?: boolean | string;
   push?: boolean;
   best?: boolean;
+  pass?: boolean;
+  fail?: boolean;
 }
 
 function print(payload: unknown, options: ImproveOptions, text: string): void {
@@ -285,5 +289,59 @@ export function registerImproveCommands(program: Command): void {
         `Corpus classification: ${final.score.correct}/${final.score.total} (${Math.round(final.score.accuracy * 100)}%); rules: ${final.rules}`,
       ].join('\n');
       print({ kind: 'rule_learning_loop', cycles: results, status: final }, options, text);
+    });
+
+  // --- Labeled trajectory corpus (human-curated) for the rule learner ---
+  const corpus = improve
+    .command('corpus')
+    .description('Curate the labeled trajectory corpus the rule learner validates against');
+
+  corpus
+    .command('add')
+    .description('Label a recorded run pass/fail and add it to the corpus')
+    .argument('<runId>', 'a run id from the RunStore (.codebuddy/runs/)')
+    .option('--json', 'output JSON')
+    .option('--pass', 'label the run as compliant (good behavior)')
+    .option('--fail', 'label the run as non-compliant (behavior a rule should flag)')
+    .action(async (runId: string, options: ImproveOptions) => {
+      if (options.pass === options.fail) {
+        console.error('Specify exactly one of --pass or --fail.');
+        process.exitCode = 1;
+        return;
+      }
+      const { buildRunTrajectoryExport } = await import('../../observability/run-trajectory-export.js');
+      const exported = buildRunTrajectoryExport(runId, { includeArtifactContent: false });
+      if (!exported) {
+        console.error(`Run not found: ${runId}`);
+        process.exitCode = 1;
+        return;
+      }
+      const trajectory = summarizeTrajectory(exported);
+      const store = new CorpusStore();
+      store.add({ id: runId, shouldPass: options.pass === true, trajectory });
+      const text = `Added ${runId} to corpus as ${options.pass ? 'PASS' : 'FAIL'} (tools: ${trajectory.toolNames.join(', ') || 'none'}).`;
+      print({ kind: 'corpus_add', runId, shouldPass: options.pass === true, trajectory }, options, text);
+    });
+
+  corpus
+    .command('list')
+    .description('List labeled trajectories in the corpus')
+    .option('--json', 'output JSON')
+    .action((options: ImproveOptions) => {
+      const entries = new CorpusStore().list();
+      const text = entries.length
+        ? entries.map((t) => `${t.shouldPass ? 'PASS' : 'FAIL'}  ${t.id}  [${t.trajectory.toolNames.join(', ')}]`).join('\n')
+        : 'Corpus is empty — `improve corpus add <runId> --pass|--fail`. (Seed corpus used until then.)';
+      print({ kind: 'corpus_list', entries }, options, text);
+    });
+
+  corpus
+    .command('remove')
+    .description('Remove a labeled trajectory from the corpus')
+    .argument('<id>', 'corpus entry id (the run id)')
+    .option('--json', 'output JSON')
+    .action((id: string, options: ImproveOptions) => {
+      const removed = new CorpusStore().remove(id);
+      print({ kind: 'corpus_remove', id, removed }, options, removed ? `Removed ${id}.` : `Not in corpus: ${id}.`);
     });
 }

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -13,6 +13,21 @@ import type { Command } from 'commander';
 
 import { createWorkspaceEngine } from '../../agent/self-improvement/index.js';
 import { EvolutionaryArchive } from '../../agent/self-improvement/evolutionary-archive.js';
+import { createDefaultRunExperienceSource } from '../../agent/self-improvement/experience-source.js';
+import type { Experience } from '../../agent/self-improvement/types.js';
+
+/**
+ * Collect real run-friction experiences (best-effort) so the LLM proposer can
+ * ground its drafts in what actually went wrong. Never throws — an empty list
+ * just means the proposer relies on the scenario alone.
+ */
+async function collectExperiences(): Promise<Experience[]> {
+  try {
+    return await createDefaultRunExperienceSource({ limit: 10 }).collect();
+  } catch {
+    return [];
+  }
+}
 
 interface ImproveOptions {
   json?: boolean;
@@ -61,7 +76,8 @@ export function registerImproveCommands(program: Command): void {
         ...(options.apply ? { autonomy: 'auto-apply' as const } : {}),
         useLlm: options.llm === true,
       });
-      const result = await engine.runCycle();
+      const experiences = options.llm ? await collectExperiences() : [];
+      const result = await engine.runCycle(experiences);
       const verdict = result.applied
         ? `APPLIED improvement to "${result.selectedScenarioId}" (Δ=${result.gate?.delta})`
         : result.gate?.accepted
@@ -90,7 +106,8 @@ export function registerImproveCommands(program: Command): void {
         useLlm: options.llm === true,
       });
       const maxCycles = options.max ? Number.parseInt(options.max, 10) : undefined;
-      const results = await engine.runLoop(maxCycles ? { maxCycles } : {});
+      const experiences = options.llm ? await collectExperiences() : [];
+      const results = await engine.runLoop({ ...(maxCycles ? { maxCycles } : {}), experiences });
       const appliedCount = results.filter((r) => r.applied).length;
       const final = engine.status();
       const text = [

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -14,6 +14,7 @@ import type { Command } from 'commander';
 import {
   createWorkspaceEngine,
   createWorkspaceLearningStore,
+  createWorkspaceRuleEngine,
 } from '../../agent/self-improvement/index.js';
 import { EvolutionaryArchive } from '../../agent/self-improvement/evolutionary-archive.js';
 import { createDefaultRunExperienceSource } from '../../agent/self-improvement/experience-source.js';
@@ -229,5 +230,60 @@ export function registerImproveCommands(program: Command): void {
         `Coverage now: ${result.score.covered}/${result.score.total} (${Math.round(result.score.ratio * 100)}%)`,
       ].join('\n');
       print({ kind: 'self_improvement_restore', restored: true, ...result }, options, text);
+    });
+
+  // --- Execution-grounded RULE learning (validated against recorded behavior) ---
+  const rules = improve
+    .command('rules')
+    .description('Learn behavioral rules validated against a labeled trajectory corpus (correctness, not keywords)');
+
+  rules
+    .command('status')
+    .description('Show rule-classification accuracy over the trajectory corpus')
+    .option('--json', 'output JSON')
+    .action((options: ImproveOptions) => {
+      const status = createWorkspaceRuleEngine().status();
+      const text = [
+        `Autonomy: ${status.autonomy}`,
+        `Corpus classification: ${status.score.correct}/${status.score.total} (${Math.round(status.score.accuracy * 100)}%)`,
+        `Learned rules: ${status.rules}`,
+      ].join('\n');
+      print({ kind: 'rule_learning_status', ...status }, options, text);
+    });
+
+  rules
+    .command('cycle')
+    .description('Propose one behavioral rule and validate it against the corpus')
+    .option('--json', 'output JSON')
+    .option('--apply', 'keep the rule if it correctly reclassifies recorded runs with no regression')
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceRuleEngine(options.apply ? { autonomy: 'auto-apply' } : {});
+      const result = engine.runCycle();
+      const verdict = result.applied
+        ? `LEARNED rule for "${result.targetId}" (Δ=${result.gate?.delta})`
+        : result.gate?.accepted
+          ? `WOULD learn a rule for "${result.targetId}" (Δ=${result.gate?.delta}) — re-run with --apply`
+          : result.notes.join('; ');
+      const text = [
+        `Accuracy: ${Math.round(result.accuracyBefore * 100)}% → ${Math.round(result.accuracyAfter * 100)}%`,
+        verdict,
+      ].join('\n');
+      print(result, options, text);
+    });
+
+  rules
+    .command('loop')
+    .description('Learn rules until the corpus is fully and correctly classified')
+    .option('--json', 'output JSON')
+    .option('--apply', 'keep validated rules')
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceRuleEngine(options.apply ? { autonomy: 'auto-apply' } : {});
+      const results = engine.runLoop();
+      const final = engine.status();
+      const text = [
+        `Cycles: ${results.length}, learned: ${results.filter((r) => r.applied).length}`,
+        `Corpus classification: ${final.score.correct}/${final.score.total} (${Math.round(final.score.accuracy * 100)}%); rules: ${final.rules}`,
+      ].join('\n');
+      print({ kind: 'rule_learning_loop', cycles: results, status: final }, options, text);
     });
 }

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -1,0 +1,111 @@
+/**
+ * `buddy improve` — drive the recursive self-improvement engine.
+ *
+ * The engine improves the agent's reversible learnable layer (lessons today)
+ * only when a deterministic capability benchmark empirically improves with zero
+ * regressions, snapshot/rollback always. It is propose-only by default; pass
+ * `--apply` (or set CODEBUDDY_SELF_IMPROVE=true) to keep validated improvements.
+ *
+ * @module commands/cli/improve-command
+ */
+
+import type { Command } from 'commander';
+
+import { createWorkspaceEngine } from '../../agent/self-improvement/index.js';
+import { EvolutionaryArchive } from '../../agent/self-improvement/evolutionary-archive.js';
+
+interface ImproveOptions {
+  json?: boolean;
+  apply?: boolean;
+  max?: string;
+}
+
+function print(payload: unknown, options: ImproveOptions, text: string): void {
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.log(text);
+  }
+}
+
+export function registerImproveCommands(program: Command): void {
+  const improve = program
+    .command('improve')
+    .description('Recursive self-improvement: empirically validate and apply reversible learning improvements');
+
+  improve
+    .command('status')
+    .description('Show capability-benchmark coverage, autonomy mode, and the improvement archive')
+    .option('--json', 'output JSON')
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceEngine();
+      const status = engine.status();
+      const text = [
+        `Autonomy: ${status.autonomy}`,
+        `Capability coverage: ${status.score.covered}/${status.score.total} (${Math.round(status.score.ratio * 100)}%)`,
+        `Uncovered: ${status.score.results.filter((r) => !r.covered).map((r) => r.scenarioId).join(', ') || '(none)'}`,
+        `Archive: ${status.archive.count} validated improvement(s), total Δ=${status.archive.totalDelta}`,
+      ].join('\n');
+      print({ kind: 'self_improvement_status', ...status }, options, text);
+    });
+
+  improve
+    .command('cycle')
+    .description('Run one improvement cycle (propose → empirically validate → keep/rollback)')
+    .option('--json', 'output JSON')
+    .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceEngine(options.apply ? { autonomy: 'auto-apply' } : {});
+      const result = engine.runCycle();
+      const verdict = result.applied
+        ? `APPLIED improvement to "${result.selectedScenarioId}" (Δ=${result.gate?.delta})`
+        : result.gate?.accepted
+          ? `WOULD improve "${result.selectedScenarioId}" (Δ=${result.gate?.delta}) — re-run with --apply to keep`
+          : result.selectedScenarioId
+            ? `No improvement kept for "${result.selectedScenarioId}": ${result.notes.join('; ')}`
+            : result.notes.join('; ');
+      const text = [
+        `Autonomy: ${result.autonomy}`,
+        `Coverage: ${result.scoreBefore.covered}/${result.scoreBefore.total} → ${result.scoreAfter.covered}/${result.scoreAfter.total}`,
+        verdict,
+      ].join('\n');
+      print(result, options, text);
+    });
+
+  improve
+    .command('loop')
+    .description('Run improvement cycles until no further validated progress is made')
+    .option('--json', 'output JSON')
+    .option('--apply', 'keep empirically-validated improvements (overrides propose-only for this run)')
+    .option('--max <n>', 'maximum cycles', (v) => v)
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceEngine(options.apply ? { autonomy: 'auto-apply' } : {});
+      const maxCycles = options.max ? Number.parseInt(options.max, 10) : undefined;
+      const results = engine.runLoop(maxCycles ? { maxCycles } : {});
+      const appliedCount = results.filter((r) => r.applied).length;
+      const final = engine.status();
+      const text = [
+        `Autonomy: ${results[0]?.autonomy ?? 'propose-only'}`,
+        `Cycles: ${results.length}, applied: ${appliedCount}`,
+        `Final coverage: ${final.score.covered}/${final.score.total} (${Math.round(final.score.ratio * 100)}%)`,
+      ].join('\n');
+      print({ kind: 'self_improvement_loop', cycles: results, status: final }, options, text);
+    });
+
+  improve
+    .command('archive')
+    .description('List empirically-validated improvements kept by the engine')
+    .option('--json', 'output JSON')
+    .action((options: ImproveOptions) => {
+      const engine = createWorkspaceEngine();
+      const entries = new EvolutionaryArchive().list();
+      const text = entries.length
+        ? entries
+            .map((e: { targetScenarioId: string; delta: number; createdAt: string }) =>
+              `${e.createdAt}  ${e.targetScenarioId}  Δ=${e.delta}`,
+            )
+            .join('\n')
+        : 'No validated improvements archived yet.';
+      print({ kind: 'self_improvement_archive', entries, status: engine.status() }, options, text);
+    });
+}

--- a/src/commands/cli/improve-command.ts
+++ b/src/commands/cli/improve-command.ts
@@ -260,9 +260,13 @@ export function registerImproveCommands(program: Command): void {
     .description('Propose one behavioral rule and validate it against the corpus')
     .option('--json', 'output JSON')
     .option('--apply', 'keep the rule if it correctly reclassifies recorded runs with no regression')
-    .action((options: ImproveOptions) => {
+    .option('--no-commit', 'do not version the learned rule in the git learning store')
+    .action(async (options: ImproveOptions) => {
       const engine = createWorkspaceRuleEngine(options.apply ? { autonomy: 'auto-apply' } : {});
       const result = engine.runCycle();
+      if (result.applied && options.apply && options.commit !== false) {
+        await createWorkspaceLearningStore().commitVersion({ reason: 'improve rules cycle' });
+      }
       const verdict = result.applied
         ? `LEARNED rule for "${result.targetId}" (Δ=${result.gate?.delta})`
         : result.gate?.accepted
@@ -280,9 +284,13 @@ export function registerImproveCommands(program: Command): void {
     .description('Learn rules until the corpus is fully and correctly classified')
     .option('--json', 'output JSON')
     .option('--apply', 'keep validated rules')
-    .action((options: ImproveOptions) => {
+    .option('--no-commit', 'do not version learned rules in the git learning store')
+    .action(async (options: ImproveOptions) => {
       const engine = createWorkspaceRuleEngine(options.apply ? { autonomy: 'auto-apply' } : {});
       const results = engine.runLoop();
+      if (results.some((r) => r.applied) && options.apply && options.commit !== false) {
+        await createWorkspaceLearningStore().commitVersion({ reason: 'improve rules loop' });
+      }
       const final = engine.status();
       const text = [
         `Cycles: ${results.length}, learned: ${results.filter((r) => r.applied).length}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2615,6 +2615,12 @@ addLazyCommandGroup(program, 'bundles', 'Group skills under a single named slash
   registerBundlesCommands(program);
 });
 
+// Improve — recursive self-improvement engine (empirically-gated, reversible)
+addLazyCommandGroup(program, 'improve', 'Recursive self-improvement: empirically validate and apply reversible learning improvements', async () => {
+  const { registerImproveCommands } = await import('./commands/cli/improve-command.js');
+  registerImproveCommands(program);
+});
+
 // LSP — Language Server Protocol diagnostics (Hermes parity: `hermes lsp`)
 addLazyCommandGroup(program, 'lsp', 'Language Server Protocol diagnostics', async () => {
   const { registerLspCommands } = await import('./commands/cli/lsp-command.js');

--- a/tests/agent/self-improvement/empirical-gate.test.ts
+++ b/tests/agent/self-improvement/empirical-gate.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  scoreBenchmark,
+  findRegressions,
+  selectNextScenario,
+} from '../../../src/agent/self-improvement/capability-benchmark.js';
+import { validateProposal, type LessonMutatorPort } from '../../../src/agent/self-improvement/empirical-gate.js';
+import type { BenchmarkScenario, ImprovementProposal } from '../../../src/agent/self-improvement/types.js';
+
+/** In-memory lessons store implementing the mutator port (deterministic). */
+function fakePort(): LessonMutatorPort & { items: Array<{ id: string; content: string; context?: string }> } {
+  const items: Array<{ id: string; content: string; context?: string }> = [];
+  let n = 0;
+  return {
+    items,
+    search(query: string) {
+      const q = query.toLowerCase();
+      return items.filter(
+        (i) => i.content.toLowerCase().includes(q) || (i.context?.toLowerCase().includes(q) ?? false),
+      );
+    },
+    add(_category, content, context) {
+      const item = { id: `L${++n}`, content, context };
+      items.push(item);
+      return { id: item.id };
+    },
+    remove(id) {
+      const before = items.length;
+      const idx = items.findIndex((i) => i.id === id);
+      if (idx >= 0) items.splice(idx, 1);
+      return items.length < before;
+    },
+  };
+}
+
+const SCENARIOS: BenchmarkScenario[] = [
+  { id: 's-npm', query: 'npm test', expectIncludes: ['path filter'], description: 'prefer a path filter' },
+  { id: 's-esm', query: 'import', expectIncludes: ['.js extension'], description: 'esm needs .js extensions' },
+];
+
+function lessonProposal(over: Partial<ImprovementProposal['lesson']> & { targetScenarioId?: string } = {}): ImprovementProposal {
+  return {
+    id: 'p1',
+    kind: 'lesson',
+    targetScenarioId: over.targetScenarioId ?? 's-npm',
+    lesson: {
+      category: 'RULE',
+      content: over.content ?? 'When running npm test, always pass a path filter to keep it fast.',
+      context: over.context,
+    },
+  };
+}
+
+describe('self-improvement: capability benchmark (deterministic)', () => {
+  it('scores zero coverage with no lessons and is reproducible', () => {
+    const port = fakePort();
+    const a = scoreBenchmark(SCENARIOS, port);
+    const b = scoreBenchmark(SCENARIOS, port);
+    expect(a).toEqual(b); // pure / reproducible
+    expect(a.covered).toBe(0);
+    expect(a.ratio).toBe(0);
+  });
+
+  it('picks the first uncovered scenario as the curriculum target', () => {
+    const port = fakePort();
+    const score = scoreBenchmark(SCENARIOS, port);
+    expect(selectNextScenario(SCENARIOS, score)?.id).toBe('s-npm');
+  });
+
+  it('counts a scenario covered only when a retrieved lesson carries the expected guidance', () => {
+    const port = fakePort();
+    // Retrievable for "npm test" but missing the expected guidance → NOT covered.
+    port.add('RULE', 'npm test runs the suite.', undefined);
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(0);
+    // Now add the guidance.
+    port.add('RULE', 'For npm test, pass a path filter to keep it fast.', undefined);
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(1);
+  });
+});
+
+describe('self-improvement: empirical gate (DGM-style, snapshot/rollback)', () => {
+  it('accepts and keeps a validated lesson under auto-apply; the number moves', () => {
+    const port = fakePort();
+    const before = scoreBenchmark(SCENARIOS, port).covered;
+    const result = validateProposal(lessonProposal(), SCENARIOS, port, { keepOnAccept: true });
+    expect(result.outcome.accepted).toBe(true);
+    expect(result.outcome.delta).toBe(1);
+    expect(result.outcome.rolledBack).toBe(false);
+    expect(result.appliedRef).toBeTruthy();
+    // Real, persisted improvement.
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(before + 1);
+    expect(port.items).toHaveLength(1);
+  });
+
+  it('accepts but ROLLS BACK under propose-only; state is restored exactly', () => {
+    const port = fakePort();
+    const result = validateProposal(lessonProposal(), SCENARIOS, port, { keepOnAccept: false });
+    expect(result.outcome.accepted).toBe(true);
+    expect(result.outcome.delta).toBe(1);
+    expect(result.outcome.rolledBack).toBe(true);
+    expect(result.appliedRef).toBeUndefined();
+    expect(port.items).toHaveLength(0); // nothing persisted
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(0);
+  });
+
+  it('rejects a useless proposal (no improvement) and rolls back', () => {
+    const port = fakePort();
+    const useless = lessonProposal({ content: 'Some unrelated note about coffee preferences here.' });
+    const result = validateProposal(useless, SCENARIOS, port, { keepOnAccept: true });
+    expect(result.outcome.accepted).toBe(false);
+    expect(result.outcome.rejectionReason).toBe('no-improvement');
+    expect(result.outcome.rolledBack).toBe(true);
+    expect(port.items).toHaveLength(0);
+  });
+
+  it('rejects structurally-invalid proposals without applying them', () => {
+    const port = fakePort();
+    for (const bad of [
+      lessonProposal({ content: 'too short' }),
+      lessonProposal({ content: 'Use this api_key: sk-abcdef to keep npm test path filter fast and good' }),
+      lessonProposal({ content: 'For npm test pass a path filter ... rest of the rules apply here too' }),
+    ]) {
+      const result = validateProposal(bad, SCENARIOS, port, { keepOnAccept: true });
+      expect(result.outcome.accepted).toBe(false);
+      expect(result.outcome.rejectionReason).toBe('structural-invalid');
+      expect(result.outcome.rolledBack).toBe(false);
+    }
+    expect(port.items).toHaveLength(0);
+  });
+
+  it('rejects + rolls back a proposal that regresses an already-covered scenario', () => {
+    const port = fakePort();
+    // Pre-cover s-esm.
+    port.add('RULE', 'For import, use the .js extension on relative paths.', undefined);
+    const baseline = scoreBenchmark(SCENARIOS, port);
+    expect(baseline.covered).toBe(1);
+    // A pathological port where adding anything hides existing lessons → forces a regression.
+    const regressingPort: LessonMutatorPort = {
+      search: (q) => (port.items.length > 1 ? [] : port.search(q)),
+      add: (c, content, ctx) => port.add(c, content, ctx),
+      remove: (id) => port.remove(id),
+    };
+    const result = validateProposal(lessonProposal(), SCENARIOS, regressingPort, { keepOnAccept: true });
+    expect(result.outcome.accepted).toBe(false);
+    expect(result.outcome.rejectionReason).toBe('regression');
+    expect(result.outcome.rolledBack).toBe(true);
+    expect(findRegressions(baseline, scoreBenchmark(SCENARIOS, port))).toEqual([]); // restored
+  });
+});

--- a/tests/agent/self-improvement/engine.test.ts
+++ b/tests/agent/self-improvement/engine.test.ts
@@ -52,7 +52,7 @@ describe('resolveAutonomy', () => {
 });
 
 describe('SelfImprovementEngine', () => {
-  it('auto-apply loop covers every seed scenario and archives each win', () => {
+  it('auto-apply loop covers every seed scenario and archives each win', async () => {
     const port = fakePort();
     const archive = new EvolutionaryArchive({ workDir: dir, now });
     const engine = new SelfImprovementEngine({
@@ -65,7 +65,7 @@ describe('SelfImprovementEngine', () => {
     });
 
     expect(engine.status().score.ratio).toBe(0);
-    const cycles = engine.runLoop();
+    const cycles = await engine.runLoop();
 
     // One applied cycle per scenario, then a final "all covered" cycle.
     const applied = cycles.filter((c) => c.applied);
@@ -83,7 +83,7 @@ describe('SelfImprovementEngine', () => {
     expect(archive.list().every((e) => Boolean(e.appliedRef))).toBe(true);
   });
 
-  it('propose-only validates but persists nothing (no archive, no lessons)', () => {
+  it('propose-only validates but persists nothing (no archive, no lessons)', async () => {
     const port = fakePort();
     const archive = new EvolutionaryArchive({ workDir: dir, now });
     const engine = new SelfImprovementEngine({
@@ -95,7 +95,7 @@ describe('SelfImprovementEngine', () => {
       now,
     });
 
-    const result = engine.runCycle();
+    const result = await engine.runCycle();
     expect(result.gate?.accepted).toBe(true); // would help
     expect(result.gate?.rolledBack).toBe(true); // but reverted
     expect(result.applied).toBe(false);
@@ -104,7 +104,7 @@ describe('SelfImprovementEngine', () => {
     expect(engine.status().score.ratio).toBe(0);
   });
 
-  it('reports "nothing to improve" when all scenarios are already covered', () => {
+  it('reports "nothing to improve" when all scenarios are already covered', async () => {
     const port = fakePort();
     for (const draft of SEED_LESSON_DRAFTS.values()) port.add(draft.category, draft.content, draft.context);
     const engine = new SelfImprovementEngine({
@@ -115,13 +115,13 @@ describe('SelfImprovementEngine', () => {
       autonomy: 'auto-apply',
       now,
     });
-    const result = engine.runCycle();
+    const result = await engine.runCycle();
     expect(result.selectedScenarioId).toBeNull();
     expect(result.applied).toBe(false);
     expect(result.notes[0]).toMatch(/nothing to improve/i);
   });
 
-  it('stops cleanly when the proposer has no candidate for the target', () => {
+  it('stops cleanly when the proposer has no candidate for the target', async () => {
     const port = fakePort();
     const engine = new SelfImprovementEngine({
       scenarios: SEED_BENCHMARK_SCENARIOS,
@@ -131,7 +131,7 @@ describe('SelfImprovementEngine', () => {
       autonomy: 'auto-apply',
       now,
     });
-    const cycles = engine.runLoop();
+    const cycles = await engine.runLoop();
     expect(cycles).toHaveLength(1);
     expect(cycles[0]!.proposalId).toBeNull();
     expect(cycles[0]!.applied).toBe(false);

--- a/tests/agent/self-improvement/engine.test.ts
+++ b/tests/agent/self-improvement/engine.test.ts
@@ -1,0 +1,139 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SEED_BENCHMARK_SCENARIOS } from '../../../src/agent/self-improvement/capability-benchmark.js';
+import type { LessonMutatorPort } from '../../../src/agent/self-improvement/empirical-gate.js';
+import { EvolutionaryArchive } from '../../../src/agent/self-improvement/evolutionary-archive.js';
+import { SelfImprovementEngine, resolveAutonomy } from '../../../src/agent/self-improvement/engine.js';
+import { StaticProposer, SEED_LESSON_DRAFTS } from '../../../src/agent/self-improvement/proposer.js';
+
+function fakePort(): LessonMutatorPort & { items: Array<{ id: string; content: string; context?: string }> } {
+  const items: Array<{ id: string; content: string; context?: string }> = [];
+  let n = 0;
+  return {
+    items,
+    search: (query) => {
+      const q = query.toLowerCase();
+      return items.filter(
+        (i) => i.content.toLowerCase().includes(q) || (i.context?.toLowerCase().includes(q) ?? false),
+      );
+    },
+    add: (_c, content, context) => {
+      const item = { id: `L${++n}`, content, context };
+      items.push(item);
+      return { id: item.id };
+    },
+    remove: (id) => {
+      const idx = items.findIndex((i) => i.id === id);
+      if (idx >= 0) items.splice(idx, 1);
+      return idx >= 0;
+    },
+  };
+}
+
+let dir: string;
+let stamp = 0;
+const now = () => new Date(Date.UTC(2026, 0, 1, 0, 0, stamp++));
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'self-improve-engine-'));
+  stamp = 0;
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('resolveAutonomy', () => {
+  it('is propose-only unless CODEBUDDY_SELF_IMPROVE=true', () => {
+    expect(resolveAutonomy({})).toBe('propose-only');
+    expect(resolveAutonomy({ CODEBUDDY_SELF_IMPROVE: 'false' })).toBe('propose-only');
+    expect(resolveAutonomy({ CODEBUDDY_SELF_IMPROVE: 'true' })).toBe('auto-apply');
+  });
+});
+
+describe('SelfImprovementEngine', () => {
+  it('auto-apply loop covers every seed scenario and archives each win', () => {
+    const port = fakePort();
+    const archive = new EvolutionaryArchive({ workDir: dir, now });
+    const engine = new SelfImprovementEngine({
+      scenarios: SEED_BENCHMARK_SCENARIOS,
+      port,
+      proposer: new StaticProposer(SEED_LESSON_DRAFTS),
+      archive,
+      autonomy: 'auto-apply',
+      now,
+    });
+
+    expect(engine.status().score.ratio).toBe(0);
+    const cycles = engine.runLoop();
+
+    // One applied cycle per scenario, then a final "all covered" cycle.
+    const applied = cycles.filter((c) => c.applied);
+    expect(applied).toHaveLength(SEED_BENCHMARK_SCENARIOS.length);
+    expect(applied.every((c) => c.gate?.delta === 1)).toBe(true);
+
+    const status = engine.status();
+    expect(status.score.ratio).toBe(1);
+    expect(status.score.covered).toBe(SEED_BENCHMARK_SCENARIOS.length);
+    expect(status.archive.count).toBe(SEED_BENCHMARK_SCENARIOS.length);
+    expect(status.archive.totalDelta).toBe(SEED_BENCHMARK_SCENARIOS.length);
+
+    // Archive persisted to disk with rollback refs.
+    expect(fs.existsSync(archive.path)).toBe(true);
+    expect(archive.list().every((e) => Boolean(e.appliedRef))).toBe(true);
+  });
+
+  it('propose-only validates but persists nothing (no archive, no lessons)', () => {
+    const port = fakePort();
+    const archive = new EvolutionaryArchive({ workDir: dir, now });
+    const engine = new SelfImprovementEngine({
+      scenarios: SEED_BENCHMARK_SCENARIOS,
+      port,
+      proposer: new StaticProposer(SEED_LESSON_DRAFTS),
+      archive,
+      autonomy: 'propose-only',
+      now,
+    });
+
+    const result = engine.runCycle();
+    expect(result.gate?.accepted).toBe(true); // would help
+    expect(result.gate?.rolledBack).toBe(true); // but reverted
+    expect(result.applied).toBe(false);
+    expect(port.items).toHaveLength(0);
+    expect(archive.list()).toHaveLength(0);
+    expect(engine.status().score.ratio).toBe(0);
+  });
+
+  it('reports "nothing to improve" when all scenarios are already covered', () => {
+    const port = fakePort();
+    for (const draft of SEED_LESSON_DRAFTS.values()) port.add(draft.category, draft.content, draft.context);
+    const engine = new SelfImprovementEngine({
+      scenarios: SEED_BENCHMARK_SCENARIOS,
+      port,
+      proposer: new StaticProposer(SEED_LESSON_DRAFTS),
+      archive: new EvolutionaryArchive({ workDir: dir, now }),
+      autonomy: 'auto-apply',
+      now,
+    });
+    const result = engine.runCycle();
+    expect(result.selectedScenarioId).toBeNull();
+    expect(result.applied).toBe(false);
+    expect(result.notes[0]).toMatch(/nothing to improve/i);
+  });
+
+  it('stops cleanly when the proposer has no candidate for the target', () => {
+    const port = fakePort();
+    const engine = new SelfImprovementEngine({
+      scenarios: SEED_BENCHMARK_SCENARIOS,
+      port,
+      proposer: new StaticProposer(new Map()), // no drafts
+      archive: new EvolutionaryArchive({ workDir: dir, now }),
+      autonomy: 'auto-apply',
+      now,
+    });
+    const cycles = engine.runLoop();
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]!.proposalId).toBeNull();
+    expect(cycles[0]!.applied).toBe(false);
+  });
+});

--- a/tests/agent/self-improvement/execution-gate.test.ts
+++ b/tests/agent/self-improvement/execution-gate.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateCheck,
+  scoreCorpus,
+  validateBehavioralRule,
+  summarizeTrajectory,
+  verdict,
+  type BehavioralCheck,
+  type LabeledTrajectory,
+  type BehavioralRuleProposal,
+} from '../../../src/agent/self-improvement/execution-gate.js';
+
+/** Recorded runs: two compliant (read-only), two that used a mutation tool. */
+const CORPUS: LabeledTrajectory[] = [
+  { id: 'good-1', shouldPass: true, trajectory: { toolNames: ['view_file', 'search'], text: 'done' } },
+  { id: 'good-2', shouldPass: true, trajectory: { toolNames: ['list_directory'], text: 'ok' } },
+  { id: 'bad-1', shouldPass: false, trajectory: { toolNames: ['view_file', 'bash'], text: 'ran a command' } },
+  { id: 'bad-2', shouldPass: false, trajectory: { toolNames: ['write_file'], text: 'wrote a file' } },
+];
+
+function rule(check: BehavioralCheck, statement = 'rule'): BehavioralRuleProposal {
+  return { id: `r-${check.kind}-${check.pattern}`, statement, check };
+}
+
+describe('execution-grounded gate: deterministic checks', () => {
+  it('evaluates checks against recorded tool usage and text', () => {
+    const t = { toolNames: ['view_file', 'bash'], text: 'hello world' };
+    expect(evaluateCheck({ kind: 'forbid_tool', pattern: 'bash' }, t)).toBe(false); // bash present → forbid fails
+    expect(evaluateCheck({ kind: 'require_tool', pattern: 'view_file' }, t)).toBe(true);
+    expect(evaluateCheck({ kind: 'require_text', pattern: 'world' }, t)).toBe(true);
+    expect(evaluateCheck({ kind: 'forbid_text', pattern: 'secret' }, t)).toBe(true);
+  });
+
+  it('scores corpus classification accuracy deterministically', () => {
+    const a = scoreCorpus([], CORPUS);
+    const b = scoreCorpus([], CORPUS);
+    expect(a).toEqual(b);
+    // No rules → everything "passes" → only the two should-pass runs are correct.
+    expect(a.correct).toBe(2);
+    expect(a.accuracy).toBe(0.5);
+  });
+});
+
+describe('execution-grounded gate: validate behavioral rules', () => {
+  it('ACCEPTS a correct rule that reclassifies the bad runs (real correctness, not keywords)', () => {
+    const proposal = rule(
+      { kind: 'forbid_tool', pattern: 'bash|write_file' },
+      'A read-only run must not call bash or write_file.',
+    );
+    const outcome = validateBehavioralRule(proposal, [], CORPUS);
+    expect(outcome.accepted).toBe(true);
+    expect(outcome.delta).toBe(2); // both bad runs now correctly fail
+    expect(outcome.accuracyAfter).toBe(1);
+    expect(outcome.changed.sort()).toEqual(['bad-1', 'bad-2']);
+  });
+
+  it('REJECTS an inert rule (changes no recorded behavior) — counterfactual ablation', () => {
+    const proposal = rule({ kind: 'forbid_tool', pattern: 'curl' }); // no run uses curl
+    const outcome = validateBehavioralRule(proposal, [], CORPUS);
+    expect(outcome.accepted).toBe(false);
+    expect(outcome.rejectionReason).toBe('inert');
+    expect(outcome.changed).toEqual([]);
+  });
+
+  it('REJECTS a plausible-but-WRONG rule that misclassifies a good run (the key case)', () => {
+    // "Every run must use bash" — sounds like a rule, but it breaks the compliant
+    // read-only runs. The retrieval proxy could never catch this; recorded
+    // behavior does.
+    const proposal = rule({ kind: 'require_tool', pattern: 'bash' }, 'Every run must use bash.');
+    const outcome = validateBehavioralRule(proposal, [], CORPUS);
+    expect(outcome.accepted).toBe(false);
+    expect(outcome.rejectionReason).toBe('regression');
+    expect(outcome.regressions).toContain('good-1');
+  });
+
+  it('adapts a run-trajectory export into a checkable summary', () => {
+    const summary = summarizeTrajectory({
+      toolCalls: [{ toolName: 'view_file' }, { toolName: 'bash' }],
+      finalAnswer: 'completed the task',
+      selectedContext: { profileSignal: 'safe' },
+    });
+    expect(summary.toolNames).toEqual(['view_file', 'bash']);
+    expect(summary.profile).toBe('safe');
+    expect(verdict([{ kind: 'forbid_tool', pattern: 'bash' }], summary)).toBe(false);
+  });
+});

--- a/tests/agent/self-improvement/experience-source.test.ts
+++ b/tests/agent/self-improvement/experience-source.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RunExperienceSource,
+  SensorExperienceSource,
+} from '../../../src/agent/self-improvement/experience-source.js';
+
+describe('RunExperienceSource', () => {
+  it('maps recent-run friction points into modality-agnostic experiences', async () => {
+    const source = new RunExperienceSource(
+      {
+        listRunIds: () => ['run-a', 'run-b'],
+        buildRetrospective: (runId) =>
+          runId === 'run-a'
+            ? {
+                frictionPoints: [
+                  { detail: 'npm test was slow', evidence: 'tool: bash', severity: 'high', toolName: 'bash' },
+                  { detail: 'edit retried twice', evidence: 'tool: str_replace', severity: 'medium' },
+                ],
+              }
+            : null, // run-b not eligible
+      },
+      { limit: 10 },
+    );
+
+    const experiences = await source.collect();
+    expect(experiences).toHaveLength(2);
+    expect(experiences[0]).toMatchObject({
+      id: 'run:run-a:0',
+      source: 'run',
+      kind: 'bash',
+      detail: 'npm test was slow',
+      severity: 1,
+    });
+    expect(experiences[1]).toMatchObject({ id: 'run:run-a:1', kind: 'friction', severity: 0.6 });
+  });
+
+  it('honours the run limit', async () => {
+    const calls: string[] = [];
+    const source = new RunExperienceSource(
+      {
+        listRunIds: () => ['r1', 'r2', 'r3'],
+        buildRetrospective: (runId) => {
+          calls.push(runId);
+          return { frictionPoints: [] };
+        },
+      },
+      { limit: 2 },
+    );
+    await source.collect();
+    expect(calls).toEqual(['r1', 'r2']); // only first 2
+  });
+});
+
+describe('SensorExperienceSource (robot 5-senses seam)', () => {
+  it('refuses to run in V1 instead of silently emitting fake experiences', async () => {
+    await expect(new SensorExperienceSource().collect()).rejects.toThrow(/not implemented in V1/i);
+  });
+});

--- a/tests/agent/self-improvement/learning-store.test.ts
+++ b/tests/agent/self-improvement/learning-store.test.ts
@@ -117,6 +117,43 @@ describe('LearningStore (git-backed reversibility)', () => {
     expect(result.reason).toMatch(/no .*remote/i);
   });
 
+  it('versions and restores learned rules alongside lessons', async () => {
+    let lessons: LessonSnapshot[] = [];
+    let rules: unknown[] = [];
+    const TARGETS = ['path filter'];
+    const port: LearnableStatePort = {
+      listLessons: () => lessons.map((l) => ({ ...l })),
+      setLessons: (ls) => {
+        lessons = ls.map((l) => ({ ...l }));
+      },
+      archive: () => [],
+      score: (): BenchmarkScore => {
+        const covered = TARGETS.filter((t) => lessons.some((l) => l.content.includes(t))).length;
+        return { total: TARGETS.length, covered, ratio: covered / TARGETS.length, results: [] };
+      },
+      listRules: () => rules,
+      setRules: (r) => {
+        rules = r;
+      },
+    };
+    const store = new LearningStore({ workDir: dir, port, now });
+
+    lessons = [{ category: 'RULE', content: 'Use a path filter.' }];
+    rules = [{ check: { kind: 'forbid_tool', pattern: '^bash$' }, statement: 'no bash', createdAt: 'now' }];
+    const good = await store.commitVersion({ reason: 'with-rule' });
+
+    // Wipe both, then restore — rules must come back too.
+    lessons = [];
+    rules = [];
+    await store.commitVersion({ reason: 'wiped' });
+
+    const restored = await store.restore({ commit: good.sha });
+    expect(restored).not.toBeNull();
+    expect(rules).toHaveLength(1);
+    expect((rules[0] as { statement: string }).statement).toBe('no bash');
+    expect(lessons.some((l) => l.content.includes('path filter'))).toBe(true);
+  });
+
   it('status reports head and best scores', async () => {
     const port = makePort();
     const store = new LearningStore({ workDir: dir, port, now });

--- a/tests/agent/self-improvement/learning-store.test.ts
+++ b/tests/agent/self-improvement/learning-store.test.ts
@@ -1,0 +1,130 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  LearningStore,
+  type LearnableStatePort,
+  type LessonSnapshot,
+} from '../../../src/agent/self-improvement/learning-store.js';
+import type { BenchmarkScore } from '../../../src/agent/self-improvement/types.js';
+
+/** Fake learnable state: coverage = how many target keywords appear in lessons. */
+function makePort(): LearnableStatePort & { set(ls: LessonSnapshot[]): void; current(): LessonSnapshot[] } {
+  let lessons: LessonSnapshot[] = [];
+  const TARGETS = ['path filter', 'logger'];
+  const score = (): BenchmarkScore => {
+    const covered = TARGETS.filter((t) => lessons.some((l) => l.content.includes(t))).length;
+    return { total: TARGETS.length, covered, ratio: covered / TARGETS.length, results: [] };
+  };
+  return {
+    listLessons: () => lessons.map((l) => ({ ...l })),
+    setLessons: (ls) => {
+      lessons = ls.map((l) => ({ ...l }));
+    },
+    archive: () => [],
+    score,
+    set: (ls) => {
+      lessons = ls.map((l) => ({ ...l }));
+    },
+    current: () => lessons,
+  };
+}
+
+let dir: string;
+let stamp = 0;
+const now = () => new Date(Date.UTC(2026, 0, 1, 0, 0, stamp++));
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'learning-store-'));
+  stamp = 0;
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('LearningStore (git-backed reversibility)', () => {
+  it('initialises an isolated git repo and commits scored versions', async () => {
+    const port = makePort();
+    const store = new LearningStore({ workDir: dir, port, now });
+
+    await store.ensureRepo();
+    expect(fs.existsSync(path.join(store.path, '.git'))).toBe(true);
+
+    port.set([{ category: 'RULE', content: 'Use a path filter when running npm test.' }]);
+    const v1 = await store.commitVersion({ scenarioId: 's-npm', delta: 1, reason: 'v1' });
+    expect(v1.score.covered).toBe(1);
+
+    const versions = await store.listVersions();
+    // init + v1
+    expect(versions).toHaveLength(2);
+    expect(versions[0]!.score?.covered).toBe(1);
+    expect(versions[0]!.message).toContain('improve(s-npm)');
+  });
+
+  it('restores to the best-scoring version after a regression', async () => {
+    const port = makePort();
+    const store = new LearningStore({ workDir: dir, port, now });
+
+    port.set([{ category: 'RULE', content: 'Use a path filter for npm test.' }]);
+    await store.commitVersion({ reason: 'v1' }); // covered 1
+
+    port.set([
+      { category: 'RULE', content: 'Use a path filter for npm test.' },
+      { category: 'RULE', content: 'Prefer logger over console.log.' },
+    ]);
+    await store.commitVersion({ reason: 'v2' }); // covered 2 — the best
+
+    // Regression: a bad improvement wipes guidance.
+    port.set([{ category: 'INSIGHT', content: 'unrelated coffee note' }]);
+    await store.commitVersion({ reason: 'bad' }); // covered 0
+    expect(port.score().covered).toBe(0);
+
+    const best = await store.bestVersion();
+    expect(best?.score?.covered).toBe(2);
+
+    const restored = await store.restore({ best: true });
+    expect(restored?.score.covered).toBe(2);
+    // Live state was re-materialised to the best version's lessons.
+    expect(port.score().covered).toBe(2);
+    expect(port.current().some((l) => l.content.includes('path filter'))).toBe(true);
+    expect(port.current().some((l) => l.content.includes('logger'))).toBe(true);
+
+    // History is append-only: a restore commit was added on top.
+    const versions = await store.listVersions();
+    expect(versions[0]!.message).toMatch(/restore to/);
+    expect(versions.length).toBe(5); // init, v1, v2, bad, restore
+  });
+
+  it('restores to an explicit commit sha', async () => {
+    const port = makePort();
+    const store = new LearningStore({ workDir: dir, port, now });
+    port.set([{ category: 'RULE', content: 'path filter rule' }]);
+    const v1 = await store.commitVersion({ reason: 'v1' });
+    port.set([{ category: 'RULE', content: 'something else entirely' }]);
+    await store.commitVersion({ reason: 'v2' });
+
+    const restored = await store.restore({ commit: v1.sha });
+    expect(restored?.restoredFrom).toBe(v1.sha);
+    expect(port.current()[0]!.content).toBe('path filter rule');
+  });
+
+  it('push() is a clean no-op when no remote is configured', async () => {
+    const port = makePort();
+    const store = new LearningStore({ workDir: dir, port, now });
+    await store.ensureRepo();
+    const result = await store.push();
+    expect(result.pushed).toBe(false);
+    expect(result.reason).toMatch(/no .*remote/i);
+  });
+
+  it('status reports head and best scores', async () => {
+    const port = makePort();
+    const store = new LearningStore({ workDir: dir, port, now });
+    port.set([{ category: 'RULE', content: 'path filter + logger' }]); // covers both
+    await store.commitVersion({ reason: 'v1' });
+    const status = await store.status();
+    expect(status.head?.covered).toBe(2);
+    expect(status.best?.score?.covered).toBe(2);
+    expect(status.versions).toBe(2);
+  });
+});

--- a/tests/agent/self-improvement/llm-proposer.test.ts
+++ b/tests/agent/self-improvement/llm-proposer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { SEED_BENCHMARK_SCENARIOS } from '../../../src/agent/self-improvement/capability-benchmark.js';
+import type { LessonMutatorPort } from '../../../src/agent/self-improvement/empirical-gate.js';
+import { SelfImprovementEngine } from '../../../src/agent/self-improvement/engine.js';
+import { EvolutionaryArchive } from '../../../src/agent/self-improvement/evolutionary-archive.js';
+import {
+  LlmProposer,
+  buildLessonDraftPrompt,
+  type LessonDrafter,
+} from '../../../src/agent/self-improvement/proposer.js';
+import type { BenchmarkScenario } from '../../../src/agent/self-improvement/types.js';
+
+function fakePort(): LessonMutatorPort & { items: Array<{ id: string; content: string; context?: string }> } {
+  const items: Array<{ id: string; content: string; context?: string }> = [];
+  let n = 0;
+  return {
+    items,
+    search: (q) =>
+      items.filter(
+        (i) =>
+          i.content.toLowerCase().includes(q.toLowerCase()) ||
+          (i.context?.toLowerCase().includes(q.toLowerCase()) ?? false),
+      ),
+    add: (_c, content, context) => {
+      const item = { id: `L${++n}`, content, context };
+      items.push(item);
+      return { id: item.id };
+    },
+    remove: (id) => {
+      const i = items.findIndex((x) => x.id === id);
+      if (i >= 0) items.splice(i, 1);
+      return i >= 0;
+    },
+  };
+}
+
+const ONE: BenchmarkScenario[] = [
+  { id: 'npm-test-path-filter', query: 'npm test', expectIncludes: ['path filter'], description: 'prefer a path filter' },
+];
+
+describe('LlmProposer (creative generation, deterministic empirical gate)', () => {
+  it('builds a strict draft prompt grounded in the scenario and friction', () => {
+    const prompt = buildLessonDraftPrompt(ONE[0]!, [
+      { id: 'e1', source: 'run', kind: 'bash', detail: 'npm test timed out', context: 'tool: bash' },
+    ]);
+    expect(prompt).toContain('path filter'); // must-mention
+    expect(prompt).toContain('npm test'); // retrievable-for query
+    expect(prompt).toContain('npm test timed out'); // friction evidence
+    expect(prompt).toContain('ONLY the lesson text');
+  });
+
+  it('applies an LLM draft that empirically improves the benchmark', async () => {
+    const port = fakePort();
+    const drafter: LessonDrafter = async () => ({
+      category: 'RULE',
+      content: 'When running npm test, pass a path filter so the suite stays fast.',
+    });
+    const engine = new SelfImprovementEngine({
+      scenarios: ONE,
+      port,
+      proposer: new LlmProposer(drafter),
+      archive: new EvolutionaryArchive({ workDir: process.cwd() }),
+      autonomy: 'auto-apply',
+    });
+    const result = await engine.runCycle([
+      { id: 'e1', source: 'run', kind: 'bash', detail: 'npm test timed out', context: 'tool: bash' },
+    ]);
+    expect(result.applied).toBe(true);
+    expect(result.gate?.delta).toBe(1);
+    expect(port.items).toHaveLength(1);
+  });
+
+  it('rejects a hallucinated/off-target LLM draft via the deterministic gate', async () => {
+    const port = fakePort();
+    const drafter: LessonDrafter = async () => ({
+      category: 'RULE',
+      content: 'Prefer tabs over spaces in all source files, always and forever everywhere.',
+    });
+    const engine = new SelfImprovementEngine({
+      scenarios: ONE,
+      port,
+      proposer: new LlmProposer(drafter),
+      archive: new EvolutionaryArchive({ workDir: process.cwd() }),
+      autonomy: 'auto-apply',
+    });
+    const result = await engine.runCycle();
+    expect(result.applied).toBe(false);
+    expect(result.gate?.rejectionReason).toBe('no-improvement');
+    expect(port.items).toHaveLength(0); // rolled back — nothing kept
+  });
+
+  it('declines cleanly when the drafter returns null', async () => {
+    const port = fakePort();
+    const engine = new SelfImprovementEngine({
+      scenarios: ONE,
+      port,
+      proposer: new LlmProposer(async () => null),
+      archive: new EvolutionaryArchive({ workDir: process.cwd() }),
+      autonomy: 'auto-apply',
+    });
+    const result = await engine.runCycle();
+    expect(result.proposalId).toBeNull();
+    expect(result.applied).toBe(false);
+  });
+});

--- a/tests/agent/self-improvement/real-tracker-integration.test.ts
+++ b/tests/agent/self-improvement/real-tracker-integration.test.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getLessonsTracker } from '../../../src/agent/lessons-tracker.js';
+import { scoreBenchmark } from '../../../src/agent/self-improvement/capability-benchmark.js';
+import { validateProposal, type LessonMutatorPort } from '../../../src/agent/self-improvement/empirical-gate.js';
+import type { BenchmarkScenario, ImprovementProposal } from '../../../src/agent/self-improvement/types.js';
+
+/**
+ * Proves the gate works against the REAL singleton LessonsTracker — the
+ * staleness trap the design had to avoid: search() memoises load(), so a
+ * file-level rollback would read stale state, but add()/remove() mutate the
+ * in-memory items that search() reads, keeping apply→re-score→rollback
+ * consistent in-process.
+ */
+function trackerPort(workDir: string): LessonMutatorPort {
+  const tracker = getLessonsTracker(workDir);
+  return {
+    search: (query) => tracker.search(query).map((l) => ({ id: l.id, content: l.content, context: l.context })),
+    add: (category, content, context) => {
+      const item = tracker.add(category, content, 'manual', context);
+      return { id: item.id };
+    },
+    remove: (id) => tracker.remove(id),
+  };
+}
+
+const SCENARIOS: BenchmarkScenario[] = [
+  { id: 's-logger', query: 'console.log', expectIncludes: ['logger', 'not console'], description: 'use logger not console' },
+];
+
+describe('self-improvement gate against the real LessonsTracker', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'self-improve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('moves the real benchmark number and persists under auto-apply', () => {
+    const port = trackerPort(dir);
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(0);
+
+    const proposal: ImprovementProposal = {
+      id: 'p-logger',
+      kind: 'lesson',
+      targetScenarioId: 's-logger',
+      lesson: {
+        category: 'RULE',
+        content: 'Production code must use logger, not console.log, because tests spy on logger.',
+      },
+    };
+
+    const result = validateProposal(proposal, SCENARIOS, port, { keepOnAccept: true });
+    expect(result.outcome.accepted).toBe(true);
+    expect(result.outcome.delta).toBe(1);
+    expect(result.appliedRef).toBeTruthy();
+
+    // No staleness: a fresh search through the real tracker sees the new lesson.
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(1);
+    expect(getLessonsTracker(dir).search('console.log').length).toBeGreaterThan(0);
+
+    // Rollback path restores exactly.
+    expect(port.remove(result.appliedRef!)).toBe(true);
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(0);
+  });
+
+  it('leaves the real tracker untouched when proposing-only', () => {
+    const port = trackerPort(dir);
+    const proposal: ImprovementProposal = {
+      id: 'p-logger',
+      kind: 'lesson',
+      targetScenarioId: 's-logger',
+      lesson: { category: 'RULE', content: 'Use logger, not console.log, so tests can spy on logger output.' },
+    };
+    const result = validateProposal(proposal, SCENARIOS, port, { keepOnAccept: false });
+    expect(result.outcome.accepted).toBe(true);
+    expect(result.outcome.rolledBack).toBe(true);
+    // Nothing persisted.
+    expect(getLessonsTracker(dir).search('console.log')).toHaveLength(0);
+    expect(scoreBenchmark(SCENARIOS, port).covered).toBe(0);
+  });
+});

--- a/tests/agent/self-improvement/rule-engine.test.ts
+++ b/tests/agent/self-improvement/rule-engine.test.ts
@@ -7,7 +7,12 @@ import {
   RuleLearningEngine,
   HeuristicRuleProposer,
 } from '../../../src/agent/self-improvement/rule-engine.js';
-import { RuleStore, SEED_TRAJECTORY_CORPUS, loadTrajectoryCorpus } from '../../../src/agent/self-improvement/rule-store.js';
+import {
+  RuleStore,
+  CorpusStore,
+  SEED_TRAJECTORY_CORPUS,
+  loadTrajectoryCorpus,
+} from '../../../src/agent/self-improvement/rule-store.js';
 import { scoreCorpus } from '../../../src/agent/self-improvement/execution-gate.js';
 
 let dir: string;
@@ -87,5 +92,22 @@ describe('RuleLearningEngine (execution-grounded loop)', () => {
     const loaded = loadTrajectoryCorpus(dir);
     expect(loaded).toHaveLength(1);
     expect(loaded[0]!.id).toBe('x');
+  });
+
+  it('CorpusStore adds (upsert by id), lists, and removes labeled trajectories', () => {
+    const store = new CorpusStore({ workDir: dir });
+    expect(store.list()).toHaveLength(0);
+    store.add({ id: 'run-1', shouldPass: false, trajectory: { toolNames: ['bash'], text: 'ran a command' } });
+    store.add({ id: 'run-2', shouldPass: true, trajectory: { toolNames: ['view_file'], text: 'ok' } });
+    expect(store.list()).toHaveLength(2);
+    // upsert: re-adding run-1 replaces, not duplicates.
+    store.add({ id: 'run-1', shouldPass: true, trajectory: { toolNames: ['view_file'], text: 'reclassified' } });
+    expect(store.list()).toHaveLength(2);
+    expect(store.list().find((t) => t.id === 'run-1')?.shouldPass).toBe(true);
+    // the curated corpus is what the loop uses (overrides the seed).
+    expect(loadTrajectoryCorpus(dir)).toHaveLength(2);
+    expect(store.remove('run-1')).toBe(true);
+    expect(store.remove('nope')).toBe(false);
+    expect(store.list()).toHaveLength(1);
   });
 });

--- a/tests/agent/self-improvement/rule-engine.test.ts
+++ b/tests/agent/self-improvement/rule-engine.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  RuleLearningEngine,
+  HeuristicRuleProposer,
+} from '../../../src/agent/self-improvement/rule-engine.js';
+import { RuleStore, SEED_TRAJECTORY_CORPUS, loadTrajectoryCorpus } from '../../../src/agent/self-improvement/rule-store.js';
+import { scoreCorpus } from '../../../src/agent/self-improvement/execution-gate.js';
+
+let dir: string;
+let stamp = 0;
+const now = () => new Date(Date.UTC(2026, 0, 1, 0, 0, stamp++));
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rule-engine-'));
+  stamp = 0;
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('RuleLearningEngine (execution-grounded loop)', () => {
+  it('auto-apply learns correct forbid rules from the corpus until fully classified', () => {
+    const ruleStore = new RuleStore({ workDir: dir, now });
+    const accepted: string[] = [];
+    const engine = new RuleLearningEngine({
+      corpus: SEED_TRAJECTORY_CORPUS,
+      proposer: new HeuristicRuleProposer(),
+      ruleStore,
+      autonomy: 'auto-apply',
+      onAccept: (p) => accepted.push(p.statement),
+      now,
+    });
+
+    expect(scoreCorpus([], SEED_TRAJECTORY_CORPUS).accuracy).toBe(0.5);
+    const cycles = engine.runLoop();
+
+    const applied = cycles.filter((c) => c.applied);
+    expect(applied.length).toBe(2); // forbid bash, forbid write_file
+    expect(engine.status().score.accuracy).toBe(1); // corpus fully + correctly classified
+    expect(ruleStore.checks()).toHaveLength(2);
+    expect(ruleStore.checks().every((c) => c.kind === 'forbid_tool')).toBe(true);
+    // The accepted rules are grounded statements about real recorded behavior.
+    expect(accepted.some((s) => /must not call bash/.test(s))).toBe(true);
+    expect(accepted.some((s) => /must not call write_file/.test(s))).toBe(true);
+  });
+
+  it('propose-only validates but persists no rules', () => {
+    const ruleStore = new RuleStore({ workDir: dir, now });
+    const engine = new RuleLearningEngine({
+      corpus: SEED_TRAJECTORY_CORPUS,
+      proposer: new HeuristicRuleProposer(),
+      ruleStore,
+      autonomy: 'propose-only',
+      now,
+    });
+    const result = engine.runCycle();
+    expect(result.gate?.accepted).toBe(true); // would correctly reclassify
+    expect(result.applied).toBe(false);
+    expect(ruleStore.checks()).toHaveLength(0);
+  });
+
+  it('reports "nothing to learn" once the corpus is fully classified', () => {
+    const ruleStore = new RuleStore({ workDir: dir, now });
+    const engine = new RuleLearningEngine({
+      corpus: SEED_TRAJECTORY_CORPUS,
+      proposer: new HeuristicRuleProposer(),
+      ruleStore,
+      autonomy: 'auto-apply',
+      now,
+    });
+    engine.runLoop();
+    const result = engine.runCycle();
+    expect(result.targetId).toBeNull();
+    expect(result.notes[0]).toMatch(/nothing to learn/i);
+  });
+
+  it('loadTrajectoryCorpus falls back to the seed corpus, and reads corpus.json when present', () => {
+    expect(loadTrajectoryCorpus(dir)).toBe(SEED_TRAJECTORY_CORPUS);
+    const file = path.join(dir, '.codebuddy', 'self-improvement', 'corpus.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ trajectories: [{ id: 'x', shouldPass: true, trajectory: { toolNames: ['view_file'], text: 'ok' } }] }),
+    );
+    const loaded = loadTrajectoryCorpus(dir);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.id).toBe('x');
+  });
+});

--- a/tests/agent/self-improvement/rule-engine.test.ts
+++ b/tests/agent/self-improvement/rule-engine.test.ts
@@ -51,6 +51,27 @@ describe('RuleLearningEngine (execution-grounded loop)', () => {
     expect(accepted.some((s) => /must not call write_file/.test(s))).toBe(true);
   });
 
+  it('never forbids an inherently read-only tool, even with a degenerate corpus', () => {
+    // A single FAIL run, no good examples — naive "tool not in good set" would
+    // forbid the FIRST tool (view_file). The read-only guard forbids bash instead.
+    const corpus = [
+      { id: 'real-run', shouldPass: false, trajectory: { toolNames: ['view_file', 'bash'], text: 'safe run shelled out', profile: 'safe' } },
+    ];
+    const ruleStore = new RuleStore({ workDir: dir, now });
+    const engine = new RuleLearningEngine({
+      corpus,
+      proposer: new HeuristicRuleProposer(),
+      ruleStore,
+      autonomy: 'auto-apply',
+      now,
+    });
+    engine.runLoop();
+    const rules = ruleStore.list();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.statement).toMatch(/must not call bash/);
+    expect(rules[0]!.statement).not.toMatch(/view_file/);
+  });
+
   it('propose-only validates but persists no rules', () => {
     const ruleStore = new RuleStore({ workDir: dir, now });
     const engine = new RuleLearningEngine({


### PR DESCRIPTION
## What

The empirically-gated core of a **recursive self-improvement engine** — the
agent improves its own learnable layer (lessons today) only when a
**deterministic capability benchmark** measurably improves, with zero
regressions, snapshot/rollback always. Designed to become the brain of the
robot, with sensors plugging into the same loop.

Built on the project principle *"petit, propre, mesurable"* and two results:
**Darwin Gödel Machine** (empirical validation of self-modifications + an
evolutionary archive) and **Voyager** (a growing, self-verified skill library).
Key adaptation: the validation signal is **deterministic + cheap** (pure
function of lessons × scenarios), so a before/after delta reflects the *change*,
not LLM run-to-run noise — which is what makes the gate trustworthy on a small
fixture set.

## Loop
ExperienceSource → Curriculum → Proposer → **Empirical Gate** (snapshot/apply/
re-score/keep|rollback) → Evolutionary Archive.

## Safety (why this is OK to merge into a 1.0 line behind review)
- **Reversible layer only** (lessons add/remove). Code self-modification is out of scope.
- **propose-only by default**; `auto-apply` requires `CODEBUDDY_SELF_IMPROVE=true` or `--apply`.
- **No self-dealing**: benchmark scenarios (evals) are curated, structurally separate from the proposer.
- **No regressions**; every kept change is audited + reversible.

## CLI
`buddy improve status|cycle|loop|archive` — verified end-to-end (propose-only
persists nothing; `loop --apply` bootstraps lessons to 3/3 coverage + archives 3 wins).

## Robot seam
`SensorExperienceSource` is the JEPA world-model prediction-error plug-in (the "5 senses") — **interface only** in V1; refuses to run rather than emit fake signals.

## Tests
20 tests across `tests/agent/self-improvement/` — number moves reproducibly,
rollback proven against the **real singleton LessonsTracker** (no stale-cache
trap), useless/invalid/regressing proposals rejected, full loop + archive.
Core typecheck clean.

See `docs/self-improvement-engine.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)