### PR TITLE
feat(cowork): sélecteur de format Paysage/Short 9:16 dans le Video Studio

### DIFF
--- a/cowork/src/main/film/film-service.ts
+++ b/cowork/src/main/film/film-service.ts
@@ -16,6 +16,8 @@ export interface FilmProduceRequest {
   subtitles?: boolean;
   lang?: string;
   model?: string;
+  /** 'short' = punchy vertical/social format (drives the planner's tone). */
+  style?: 'short' | 'standard';
 }
 
 export interface FilmProgress {
@@ -86,6 +88,7 @@ export class FilmService {
           subtitles: req.subtitles !== false,
           ...(req.lang ? { lang: req.lang } : {}),
           ...(req.model ? { model: req.model } : {}),
+          ...(req.style ? { style: req.style } : {}),
           rootDir: this.rootDir,
         },
         { ...(onProgress ? { onProgress } : {}) }

--- a/cowork/src/preload/index.ts
+++ b/cowork/src/preload/index.ts
@@ -727,6 +727,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       noMusic?: boolean;
       subtitles?: boolean;
       lang?: string;
+      style?: 'short' | 'standard';
     }): Promise<{
       ok: boolean;
       filmPath?: string;
@@ -4640,7 +4641,7 @@ declare global {
         copyToClipboard: (sourcePath: string) => Promise<{ ok: boolean; mode?: 'image' | 'path'; error?: string }>;
       };
       film: {
-        produce: (request: { pitch: string; scenes?: number; resolution?: string; noMusic?: boolean; subtitles?: boolean; lang?: string }) => Promise<{ ok: boolean; filmPath?: string; url?: string; sceneCount?: number; duration?: number; qualityPass?: boolean; warnings?: string[]; error?: string }>;
+        produce: (request: { pitch: string; scenes?: number; resolution?: string; noMusic?: boolean; subtitles?: boolean; lang?: string; style?: 'short' | 'standard' }) => Promise<{ ok: boolean; filmPath?: string; url?: string; sceneCount?: number; duration?: number; qualityPass?: boolean; warnings?: string[]; error?: string }>;
         onProgress: (cb: (p: { phase: string; scene?: number; total?: number; message?: string }) => void) => () => void;
       };
       selectFiles: () => Promise<string[]>;

--- a/cowork/src/renderer/components/videostudio/VideoStudioView.tsx
+++ b/cowork/src/renderer/components/videostudio/VideoStudioView.tsx
@@ -45,13 +45,23 @@ function phasePercent(p: Progress | null): number {
   return 10;
 }
 
+type Format = 'landscape' | 'short';
+
 export function VideoStudioView() {
   const [pitch, setPitch] = useState('');
   const [scenes, setScenes] = useState(6);
+  const [format, setFormat] = useState<Format>('landscape');
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState<Progress | null>(null);
   const [result, setResult] = useState<ProduceResult | null>(null);
+  const [resultFormat, setResultFormat] = useState<Format>('landscape');
   const offRef = useRef<(() => void) | null>(null);
+
+  // Switching to Short defaults to a tighter, punchier scene count (and back).
+  const pickFormat = (f: Format): void => {
+    setFormat(f);
+    setScenes(f === 'short' ? 3 : 6);
+  };
 
   useEffect(() => {
     const film = window.electronAPI?.film;
@@ -68,9 +78,16 @@ export function VideoStudioView() {
     if (!film?.produce || !topic || busy) return;
     setBusy(true);
     setResult(null);
+    setResultFormat(format);
     setProgress({ phase: 'planning' });
     try {
-      const res = await film.produce({ pitch: topic, scenes });
+      const res = await film.produce({
+        pitch: topic,
+        scenes,
+        ...(format === 'short'
+          ? { resolution: '1080x1920', style: 'short' as const }
+          : {}),
+      });
       setResult(res);
     } catch (err) {
       setResult({ ok: false, error: err instanceof Error ? err.message : String(err) });
@@ -115,6 +132,34 @@ export function VideoStudioView() {
         />
 
         <div className="flex flex-wrap items-center gap-4">
+          <div
+            className="inline-flex rounded-full border border-border bg-surface p-0.5 text-sm"
+            role="group"
+            aria-label="Format vidéo"
+          >
+            {(
+              [
+                ['landscape', '🖥 Paysage 16:9'],
+                ['short', '📱 Short 9:16'],
+              ] as const
+            ).map(([f, label]) => (
+              <button
+                key={f}
+                type="button"
+                data-testid={`video-studio-format-${f}`}
+                onClick={() => pickFormat(f)}
+                disabled={busy}
+                aria-pressed={format === f}
+                className={`rounded-full px-3 py-1 transition ${
+                  format === f
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
           <label className="flex items-center gap-2 text-sm">
             <span className="text-muted-foreground">Scènes</span>
             <input
@@ -170,7 +215,11 @@ export function VideoStudioView() {
                 <video
                   controls
                   src={result.url}
-                  className="w-full rounded-lg bg-black"
+                  className={
+                    resultFormat === 'short'
+                      ? 'mx-auto max-h-[70vh] w-auto rounded-lg bg-black'
+                      : 'w-full rounded-lg bg-black'
+                  }
                   data-testid="video-studio-player"
                 />
                 <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">


### PR DESCRIPTION
## Quoi

Un **toggle de format** dans le panneau **Video Studio** de Cowork : `🖥 Paysage 16:9` / `📱 Short 9:16`.

En mode **Short**, le panneau envoie `resolution=1080x1920` + `style=short` au moteur `produceVideoFromPrompt` :
- planner LLM **percutant** (narration d'UNE phrase par scène, titres ultra-courts) ;
- sous-titres karaoké **agrandis** + cadrage recalculés pour le vertical (déjà livré en PR #45, rendu aspect-aware) ;
- bascule automatique sur **3 scènes** ;
- lecteur d'aperçu adapté au vertical (hauteur bornée, centré) pour ne pas déborder.

## Câblage
- `FilmProduceRequest.style` + relais dans `produceFromPrompt` (`film-service.ts`).
- Type de `film.produce` dans le preload (runtime + type `electronAPI`).
- `VideoStudioView` : état `format` + `pickFormat` (défaut scènes 3/6) + contrôle segmenté + player conditionnel.

## Preuves
- `tsc` Cowork : **0 erreur**.
- **Validé live via CDP** sur le build : ouverture du rail Video Studio, clic sur `Short 9:16` → `aria-pressed=true` (Paysage relâché), **Scènes → 3**, prompt rempli, capture d'écran conforme.
- Le rendu vertical end-to-end est déjà prouvé par la CLI `buddy film from-prompt … --short` (PR #45, short 1080×1920 qualité PASS).

100% local / \$0 (LLM via l'abonnement ChatGPT, Piper, ffmpeg, Mermaid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)