### PR TITLE
feat(tts): provider Kyutai Pocket TTS (CPU, clonage voix 5s, MIT)

### DIFF
--- a/src/talk-mode/index.ts
+++ b/src/talk-mode/index.ts
@@ -17,6 +17,7 @@ export type {
   ElevenLabsConfig,
   EdgeTTSConfig,
   AudioReaderTTSConfig,
+  PocketTTSConfig,
   Voice,
   SynthesisOptions,
   SynthesisResult,
@@ -31,20 +32,12 @@ export type {
   TalkModeEvents,
 } from './types.js';
 
-export {
-  DEFAULT_QUEUE_CONFIG,
-  DEFAULT_TALK_MODE_CONFIG,
-} from './types.js';
+export { DEFAULT_QUEUE_CONFIG, DEFAULT_TALK_MODE_CONFIG } from './types.js';
 
 // Manager
 export type { ITTSProvider } from './tts-manager.js';
 
-export {
-  MockTTSProvider,
-  TTSManager,
-  getTTSManager,
-  resetTTSManager,
-} from './tts-manager.js';
+export { MockTTSProvider, TTSManager, getTTSManager, resetTTSManager } from './tts-manager.js';
 
 // Providers
 export {
@@ -52,4 +45,5 @@ export {
   ElevenLabsProvider,
   EdgeTTSProvider,
   AudioReaderTTSProvider,
+  PocketTTSProvider,
 } from './providers/index.js';

--- a/src/talk-mode/providers/index.ts
+++ b/src/talk-mode/providers/index.ts
@@ -8,6 +8,7 @@ export { OpenAITTSProvider } from './openai-tts.js';
 export { ElevenLabsProvider } from './elevenlabs.js';
 export { EdgeTTSProvider } from './edge-tts.js';
 export { AudioReaderTTSProvider } from './audioreader-tts.js';
+export { PocketTTSProvider } from './pocket-tts.js';
 
 // Re-export types
 export type {
@@ -16,4 +17,5 @@ export type {
   ElevenLabsConfig,
   EdgeTTSConfig,
   AudioReaderTTSConfig,
+  PocketTTSConfig,
 } from '../types.js';

--- a/src/talk-mode/providers/pocket-tts.ts
+++ b/src/talk-mode/providers/pocket-tts.ts
@@ -130,17 +130,41 @@ export function wavDurationMs(buf: Buffer, sampleRate = SAMPLE_RATE): number {
   return Math.round((dataBytes / (sampleRate * 2)) * 1000);
 }
 
-/** The documented preset voices (a representative catalog; any name/path works). */
-const PRESET_VOICES: Array<{ id: string; gender: 'male' | 'female'; lang: string }> = [
-  { id: 'alba', gender: 'female', lang: 'en-US' },
-  { id: 'anna', gender: 'female', lang: 'en-US' },
-  { id: 'charles', gender: 'male', lang: 'en-US' },
-  { id: 'estelle', gender: 'female', lang: 'en-US' },
-  { id: 'giovanni', gender: 'male', lang: 'it-IT' },
-  { id: 'lola', gender: 'female', lang: 'es-ES' },
-  { id: 'juergen', gender: 'male', lang: 'de-DE' },
-  { id: 'rafael', gender: 'male', lang: 'pt-BR' },
-];
+/**
+ * The 26 built-in preset voices — the SAME catalog is available in every
+ * language (a voice can speak any language; a non-native sample may transfer
+ * its accent). Any name here, or a path to a ~5 s sample, is a valid `--voice`.
+ * When no voice is given the CLI picks a language-appropriate default itself
+ * (estelle for French, giovanni/it, lola/es, juergen/de, rafael/pt, alba else).
+ */
+const PRESET_VOICES = [
+  'alba',
+  'anna',
+  'azelma',
+  'bill_boerst',
+  'caro_davy',
+  'charles',
+  'cosette',
+  'eponine',
+  'estelle',
+  'eve',
+  'fantine',
+  'george',
+  'giovanni',
+  'jane',
+  'javert',
+  'jean',
+  'juergen',
+  'lola',
+  'marius',
+  'mary',
+  'michael',
+  'paul',
+  'peter_yearsley',
+  'rafael',
+  'stuart_bell',
+  'vera',
+] as const;
 
 export class PocketTTSProvider implements ITTSProvider {
   readonly id = 'pocket' as const;
@@ -164,16 +188,15 @@ export class PocketTTSProvider implements ITTSProvider {
   }
 
   async listVoices(): Promise<Voice[]> {
-    return PRESET_VOICES.map((v, i) => ({
-      id: `pocket-${v.id}`,
-      name: `Pocket ${v.id}`,
-      language: v.lang,
-      gender: v.gender,
+    return PRESET_VOICES.map((id) => ({
+      id: `pocket-${id}`,
+      name: `Pocket ${id}`,
+      language: 'multi', // every preset works in every supported language
       provider: 'pocket' as const,
-      providerId: v.id,
+      providerId: id,
       quality: 'high',
       sampleRate: SAMPLE_RATE,
-      isDefault: i === 0,
+      isDefault: id === 'alba',
     }));
   }
 

--- a/src/talk-mode/providers/pocket-tts.ts
+++ b/src/talk-mode/providers/pocket-tts.ts
@@ -1,0 +1,316 @@
+/**
+ * Kyutai Pocket TTS Provider
+ *
+ * A 100M-parameter on-CPU text-to-speech model (MIT) with **5-second voice
+ * cloning** and six languages (English, French, German, Spanish, Portuguese,
+ * Italian). Runs faster than real-time on a laptop CPU — no GPU, no web API.
+ *
+ * This provider shells out to the `pocket-tts` CLI, mirroring the edge-tts
+ * provider's pattern: a launcher is auto-detected (`pocket-tts` on PATH, else
+ * `uvx pocket-tts` which auto-installs), `generate` writes `./tts_output.wav`
+ * in a throwaway working dir, and we read it back. Fail-open: if no launcher is
+ * found, `isAvailable()` is false and `synthesize()` throws a clear install
+ * hint (the TTS manager then falls back to another provider, e.g. Piper).
+ *
+ * Notes learned from the real CLI:
+ *  - French has ONLY a 24-layer model → the language token must be `french_24l`
+ *    (plain `french` errors). The language mapper handles this.
+ *  - `--voice` takes a preset name OR a path to a .wav/.mp3/.flac to clone.
+ *  - First ever run downloads torch + the model (seconds on a fast box), so the
+ *    synthesis timeout is generous by default.
+ *
+ * @module talk-mode/providers/pocket-tts
+ */
+
+import { spawn } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type {
+  TTSProviderConfig,
+  Voice,
+  SynthesisOptions,
+  SynthesisResult,
+  PocketTTSConfig,
+} from '../types.js';
+import type { ITTSProvider } from '../tts-manager.js';
+
+/** A resolved launcher: `command` + a fixed args prefix (e.g. `uvx pocket-tts`). */
+export interface PocketLauncher {
+  command: string;
+  argsPrefix: string[];
+}
+
+const SAMPLE_RATE = 24000; // Pocket TTS emits 24 kHz mono WAV.
+
+/** Candidate launchers, in preference order (a direct binary beats uvx). */
+const LAUNCHER_CANDIDATES: PocketLauncher[] = [
+  { command: 'pocket-tts', argsPrefix: [] },
+  { command: 'uvx', argsPrefix: ['pocket-tts'] },
+];
+
+/**
+ * Map an incoming language (a BCP-47-ish code like `fr-FR`/`fr`, or a raw
+ * Pocket token like `french`/`french_24l`) to a valid Pocket TTS language.
+ *
+ * Two hard rules from the model: English has no `_24l` variant, and **French
+ * only exists as `french_24l`** — plain `french` is rejected by the CLI.
+ * `highQuality` upgrades any other non-English language to its `_24l` variant.
+ * Pure.
+ */
+export function resolvePocketLanguage(input?: string, highQuality = false): string {
+  const raw = (input ?? '').trim().toLowerCase();
+  if (!raw) return 'english';
+
+  // Already a Pocket token (e.g. 'french_24l', 'italian') — pass through,
+  // but still enforce the French-must-be-24l rule.
+  const base = raw.replace(/_24l$/, '');
+  const wants24l = raw.endsWith('_24l') || highQuality;
+
+  const CODE_TO_LANG: Record<string, string> = {
+    en: 'english',
+    eng: 'english',
+    english: 'english',
+    fr: 'french',
+    fra: 'french',
+    fre: 'french',
+    french: 'french',
+    de: 'german',
+    deu: 'german',
+    ger: 'german',
+    german: 'german',
+    es: 'spanish',
+    spa: 'spanish',
+    spanish: 'spanish',
+    pt: 'portuguese',
+    por: 'portuguese',
+    portuguese: 'portuguese',
+    it: 'italian',
+    ita: 'italian',
+    italian: 'italian',
+  };
+  // Accept 'fr-FR' → 'fr' → 'french', etc.
+  const key = base.split(/[-_]/)[0] ?? base;
+  const lang = CODE_TO_LANG[base] ?? CODE_TO_LANG[key] ?? 'english';
+
+  if (lang === 'english') return 'english'; // no 24l variant
+  if (lang === 'french') return 'french_24l'; // French is ONLY available as 24l
+  return wants24l ? `${lang}_24l` : lang;
+}
+
+/** True if `voice` looks like a local audio sample to clone (a path, not a preset). */
+export function isVoiceSamplePath(voice?: string): boolean {
+  if (!voice) return false;
+  if (/\.(wav|mp3|flac|ogg|m4a)$/i.test(voice)) return true;
+  return voice.includes('/') || voice.includes('\\');
+}
+
+/**
+ * Build the argv for `pocket-tts generate` (WITHOUT the launcher prefix).
+ * Pure + unit-testable. `generate` writes `tts_output.wav` in its cwd, so the
+ * caller runs it inside a throwaway dir and reads that file back.
+ */
+export function buildGenerateArgs(opts: {
+  text: string;
+  language: string;
+  voice?: string;
+  configPath?: string;
+}): string[] {
+  const args = ['generate', '--language', opts.language, '--text', opts.text];
+  if (opts.voice) args.push('--voice', opts.voice);
+  if (opts.configPath) args.push('--config', opts.configPath);
+  return args;
+}
+
+/** Parse the PCM data-chunk length from a canonical WAV header → duration ms. */
+export function wavDurationMs(buf: Buffer, sampleRate = SAMPLE_RATE): number {
+  // 44-byte canonical header: bytesPerSample assumed 2 (16-bit), mono.
+  if (buf.length <= 44) return 0;
+  const dataBytes = buf.length - 44;
+  return Math.round((dataBytes / (sampleRate * 2)) * 1000);
+}
+
+/** The documented preset voices (a representative catalog; any name/path works). */
+const PRESET_VOICES: Array<{ id: string; gender: 'male' | 'female'; lang: string }> = [
+  { id: 'alba', gender: 'female', lang: 'en-US' },
+  { id: 'anna', gender: 'female', lang: 'en-US' },
+  { id: 'charles', gender: 'male', lang: 'en-US' },
+  { id: 'estelle', gender: 'female', lang: 'en-US' },
+  { id: 'giovanni', gender: 'male', lang: 'it-IT' },
+  { id: 'lola', gender: 'female', lang: 'es-ES' },
+  { id: 'juergen', gender: 'male', lang: 'de-DE' },
+  { id: 'rafael', gender: 'male', lang: 'pt-BR' },
+];
+
+export class PocketTTSProvider implements ITTSProvider {
+  readonly id = 'pocket' as const;
+  private config: PocketTTSConfig = {};
+  private initialized = false;
+  private launcher: PocketLauncher | null = null;
+
+  async initialize(config: TTSProviderConfig): Promise<void> {
+    this.config = (config.settings as PocketTTSConfig | undefined) ?? {};
+    this.launcher = await this.detectLauncher();
+    if (!this.launcher) {
+      console.warn(
+        'pocket-tts launcher not found. Install with: pip install pocket-tts (or install uv for `uvx pocket-tts`).'
+      );
+    }
+    this.initialized = true;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.initialized && this.launcher !== null;
+  }
+
+  async listVoices(): Promise<Voice[]> {
+    return PRESET_VOICES.map((v, i) => ({
+      id: `pocket-${v.id}`,
+      name: `Pocket ${v.id}`,
+      language: v.lang,
+      gender: v.gender,
+      provider: 'pocket' as const,
+      providerId: v.id,
+      quality: 'high',
+      sampleRate: SAMPLE_RATE,
+      isDefault: i === 0,
+    }));
+  }
+
+  private async detectLauncher(): Promise<PocketLauncher | null> {
+    const override = this.config.binaryPath;
+    const candidates: PocketLauncher[] = override
+      ? [
+          { command: override, argsPrefix: override.endsWith('uvx') ? ['pocket-tts'] : [] },
+          ...LAUNCHER_CANDIDATES,
+        ]
+      : LAUNCHER_CANDIDATES;
+
+    for (const c of candidates) {
+      if (await this.checkCommand(c.command, [...c.argsPrefix, '--help'])) return c;
+    }
+    return null;
+  }
+
+  private checkCommand(command: string, args: string[]): Promise<boolean> {
+    return new Promise((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const done = (v: boolean) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve(v);
+      };
+      let proc: ReturnType<typeof spawn>;
+      try {
+        proc = spawn(command, args, { stdio: 'ignore' });
+      } catch {
+        done(false);
+        return;
+      }
+      proc.on('close', (code) => done(code === 0));
+      proc.on('error', () => done(false));
+      timer = setTimeout(() => {
+        try {
+          proc.kill();
+        } catch {
+          /* noop */
+        }
+        done(false);
+      }, 8000);
+    });
+  }
+
+  async synthesize(text: string, options?: SynthesisOptions): Promise<SynthesisResult> {
+    if (!this.launcher) {
+      throw new Error(
+        'pocket-tts launcher not found. Install with: pip install pocket-tts (or install uv for `uvx pocket-tts`).'
+      );
+    }
+    const language = resolvePocketLanguage(
+      options?.language ?? this.config.language,
+      this.config.highQuality ?? false
+    );
+    const voice = this.resolveVoice(options?.voice);
+    const args = [
+      ...this.launcher.argsPrefix,
+      ...buildGenerateArgs({
+        text,
+        language,
+        ...(voice ? { voice } : {}),
+        ...(this.config.configPath ? { configPath: this.config.configPath } : {}),
+      }),
+    ];
+
+    const workDir = mkdtempSync(join(tmpdir(), 'pocket-tts-'));
+    try {
+      await this.runGenerate(this.launcher.command, args, workDir);
+      const outPath = join(workDir, 'tts_output.wav');
+      if (!existsSync(outPath)) {
+        throw new Error('pocket-tts did not produce tts_output.wav');
+      }
+      const audio = readFileSync(outPath);
+      return {
+        audio,
+        format: 'wav',
+        durationMs: wavDurationMs(audio),
+        sampleRate: SAMPLE_RATE,
+        channels: 1,
+        bitsPerSample: 16,
+        provider: 'pocket',
+        voice: voice ?? 'default',
+      };
+    } finally {
+      try {
+        rmSync(workDir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  /** Resolve an incoming voice: a `pocket-`prefixed id, a preset name, or a clone path. */
+  private resolveVoice(voice?: string): string | undefined {
+    const v = voice ?? this.config.voice;
+    if (!v) return undefined;
+    if (isVoiceSamplePath(v)) return v; // clone from an audio sample
+    return v.startsWith('pocket-') ? v.slice('pocket-'.length) : v;
+  }
+
+  private runGenerate(command: string, args: string[], cwd: string): Promise<void> {
+    const timeoutMs = this.config.timeoutMs ?? 180000; // first run downloads the model
+    return new Promise((resolve, reject) => {
+      const proc = spawn(command, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      let stderr = '';
+      const timer = setTimeout(() => {
+        try {
+          proc.kill();
+        } catch {
+          /* noop */
+        }
+        reject(new Error(`pocket-tts generate timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      proc.stderr?.on('data', (d) => {
+        stderr += d.toString();
+      });
+      proc.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve();
+        else
+          reject(new Error(`pocket-tts generate exited with code ${code}: ${stderr.slice(-500)}`));
+      });
+      proc.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+    this.launcher = null;
+  }
+}
+
+export default PocketTTSProvider;

--- a/src/talk-mode/types.ts
+++ b/src/talk-mode/types.ts
@@ -8,7 +8,17 @@
 // Provider Types
 // ============================================================================
 
-export type TTSProvider = 'piper' | 'coqui' | 'espeak' | 'system' | 'mock' | 'openai' | 'elevenlabs' | 'edge' | 'audioreader';
+export type TTSProvider =
+  | 'piper'
+  | 'coqui'
+  | 'espeak'
+  | 'system'
+  | 'mock'
+  | 'openai'
+  | 'elevenlabs'
+  | 'edge'
+  | 'audioreader'
+  | 'pocket';
 
 export interface TTSProviderConfig {
   /** Provider identifier */
@@ -143,6 +153,34 @@ export interface EdgeTTSConfig {
   volume?: string;
   /** Pitch adjustment (e.g., '+5Hz', '-10Hz') */
   pitch?: string;
+}
+
+/**
+ * Kyutai Pocket TTS — a 100M-param on-CPU TTS with 5-second voice cloning
+ * (MIT). Runs via the `pocket-tts` CLI (`uvx pocket-tts` or a `pip install`ed
+ * binary). See src/talk-mode/providers/pocket-tts.ts.
+ */
+export interface PocketTTSConfig {
+  /**
+   * A preset voice name (e.g. 'alba', 'anna') OR an absolute path to a
+   * .wav/.mp3/.flac sample to clone (≈5 s is enough). Paths win over presets.
+   */
+  voice?: string;
+  /**
+   * Pocket TTS language model: 'english' (default), 'french', 'german',
+   * 'spanish', 'portuguese', 'italian'. Non-English support bigger, higher
+   * quality (but slower) 24-layer variants via the `_24l` suffix
+   * (e.g. 'french_24l'). Set `highQuality: true` to auto-append `_24l`.
+   */
+  language?: string;
+  /** Auto-append `_24l` to non-English languages for the higher-quality variant. */
+  highQuality?: boolean;
+  /** Explicit launcher override, e.g. 'pocket-tts' or 'uvx'. Auto-detected otherwise. */
+  binaryPath?: string;
+  /** Local YAML path for custom weights (maps to `--config`). */
+  configPath?: string;
+  /** Max ms to wait for a single synthesis (first ever run downloads the model). */
+  timeoutMs?: number;
 }
 
 // ============================================================================

--- a/tests/talk-mode/providers/pocket-tts.test.ts
+++ b/tests/talk-mode/providers/pocket-tts.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pocket TTS Provider Tests
+ *
+ * Pure helpers (language mapping, argv, WAV duration, clone detection) need no
+ * mocks. Launcher detection + fail-open are covered by mocking child_process,
+ * mirroring the edge-tts provider tests.
+ */
+
+import {
+  PocketTTSProvider,
+  resolvePocketLanguage,
+  isVoiceSamplePath,
+  buildGenerateArgs,
+  wavDurationMs,
+} from '../../../src/talk-mode/providers/pocket-tts.js';
+import { spawn } from 'child_process';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+function createSpawnResult(options: {
+  closeCode?: number;
+  error?: Error;
+}): ReturnType<typeof spawn> {
+  return {
+    on: jest.fn((event: string, cb: (arg?: unknown) => void) => {
+      if (event === 'error' && options.error) cb(options.error);
+      if (event === 'close' && options.closeCode !== undefined) cb(options.closeCode);
+    }),
+    stdout: { on: jest.fn() },
+    stderr: { on: jest.fn() },
+    kill: jest.fn(),
+  } as unknown as ReturnType<typeof spawn>;
+}
+
+describe('resolvePocketLanguage', () => {
+  it('defaults to english when empty', () => {
+    expect(resolvePocketLanguage()).toBe('english');
+    expect(resolvePocketLanguage('')).toBe('english');
+  });
+
+  it('maps BCP-47 and ISO codes to Pocket language tokens', () => {
+    expect(resolvePocketLanguage('en-US')).toBe('english');
+    expect(resolvePocketLanguage('de')).toBe('german');
+    expect(resolvePocketLanguage('es-ES')).toBe('spanish');
+    expect(resolvePocketLanguage('pt-BR')).toBe('portuguese');
+    expect(resolvePocketLanguage('it')).toBe('italian');
+  });
+
+  it('ALWAYS forces French to the 24-layer variant (plain french is rejected by the CLI)', () => {
+    expect(resolvePocketLanguage('fr')).toBe('french_24l');
+    expect(resolvePocketLanguage('fr-FR')).toBe('french_24l');
+    expect(resolvePocketLanguage('french')).toBe('french_24l');
+    expect(resolvePocketLanguage('french_24l')).toBe('french_24l');
+  });
+
+  it('never adds _24l to english', () => {
+    expect(resolvePocketLanguage('english', true)).toBe('english');
+    expect(resolvePocketLanguage('en', true)).toBe('english');
+  });
+
+  it('upgrades other languages to _24l when highQuality is set or requested', () => {
+    expect(resolvePocketLanguage('german', true)).toBe('german_24l');
+    expect(resolvePocketLanguage('italian_24l')).toBe('italian_24l');
+    expect(resolvePocketLanguage('spanish', false)).toBe('spanish');
+  });
+
+  it('falls back to english for unknown languages', () => {
+    expect(resolvePocketLanguage('klingon')).toBe('english');
+  });
+});
+
+describe('isVoiceSamplePath', () => {
+  it('detects audio sample paths (cloning)', () => {
+    expect(isVoiceSamplePath('/home/me/lisa.wav')).toBe(true);
+    expect(isVoiceSamplePath('sample.mp3')).toBe(true);
+    expect(isVoiceSamplePath('voices/ref.flac')).toBe(true);
+    expect(isVoiceSamplePath('C:\\voices\\ref.wav')).toBe(true);
+  });
+
+  it('treats bare names as presets, not paths', () => {
+    expect(isVoiceSamplePath('alba')).toBe(false);
+    expect(isVoiceSamplePath('giovanni')).toBe(false);
+    expect(isVoiceSamplePath(undefined)).toBe(false);
+  });
+});
+
+describe('buildGenerateArgs', () => {
+  it('builds the minimal generate argv', () => {
+    expect(buildGenerateArgs({ text: 'Bonjour', language: 'french_24l' })).toEqual([
+      'generate',
+      '--language',
+      'french_24l',
+      '--text',
+      'Bonjour',
+    ]);
+  });
+
+  it('adds voice and config when provided', () => {
+    expect(
+      buildGenerateArgs({
+        text: 'Hi',
+        language: 'english',
+        voice: 'alba',
+        configPath: '/tmp/custom.yaml',
+      })
+    ).toEqual([
+      'generate',
+      '--language',
+      'english',
+      '--text',
+      'Hi',
+      '--voice',
+      'alba',
+      '--config',
+      '/tmp/custom.yaml',
+    ]);
+  });
+});
+
+describe('wavDurationMs', () => {
+  it('returns 0 for headers-only / empty buffers', () => {
+    expect(wavDurationMs(Buffer.alloc(0))).toBe(0);
+    expect(wavDurationMs(Buffer.alloc(44))).toBe(0);
+  });
+
+  it('computes ms from PCM data length at 24 kHz mono 16-bit', () => {
+    // 1 second = 24000 samples * 2 bytes + 44-byte header.
+    const oneSecond = Buffer.alloc(44 + 24000 * 2);
+    expect(wavDurationMs(oneSecond)).toBe(1000);
+  });
+});
+
+describe('PocketTTSProvider (fail-open)', () => {
+  let provider: PocketTTSProvider;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    provider = new PocketTTSProvider();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    warnSpy.mockRestore();
+  });
+
+  it('initializes and reports unavailable when no launcher exists', async () => {
+    mockSpawn.mockReturnValue(createSpawnResult({ error: new Error('not found') }));
+    await provider.initialize({ provider: 'pocket', enabled: true, priority: 1 });
+    expect(await provider.isAvailable()).toBe(false);
+  });
+
+  it('detects a launcher when pocket-tts --help succeeds', async () => {
+    mockSpawn.mockReturnValue(createSpawnResult({ closeCode: 0 }));
+    await provider.initialize({ provider: 'pocket', enabled: true, priority: 1 });
+    expect(await provider.isAvailable()).toBe(true);
+    expect(mockSpawn.mock.calls[0][0]).toBe('pocket-tts');
+  });
+
+  it('throws a clear install hint when synthesizing without a launcher', async () => {
+    mockSpawn.mockReturnValue(createSpawnResult({ error: new Error('not found') }));
+    await provider.initialize({ provider: 'pocket', enabled: true, priority: 1 });
+    await expect(provider.synthesize('Bonjour')).rejects.toThrow(/pocket-tts launcher not found/);
+  });
+
+  it('exposes preset voices with pocket provider tag', async () => {
+    mockSpawn.mockReturnValue(createSpawnResult({ error: new Error('not found') }));
+    await provider.initialize({ provider: 'pocket', enabled: true, priority: 1 });
+    const voices = await provider.listVoices();
+    expect(voices.length).toBeGreaterThan(0);
+    expect(voices.every((v) => v.provider === 'pocket')).toBe(true);
+    expect(voices.some((v) => v.providerId === 'alba')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Quoi
Un nouveau provider TTS **`pocket`** (`src/talk-mode/providers/pocket-tts.ts`) qui intègre **Kyutai Pocket TTS** : modèle **100M paramètres**, **CPU pur** (pas de GPU), **6 langues** (dont le français), **clonage de voix depuis un échantillon ~5 s**, **MIT**. 100% local, **\$0**.

Il shell-out au CLI `pocket-tts` (binaire sur PATH, sinon **`uvx pocket-tts`** qui auto-installe), sur le même patron que le provider `edge-tts` — instance `ITTSProvider` opt-in, à brancher dans la boucle vocale / la narration de films / `buddy speak`.

## Détails appris du CLI réel
- **Le français n'existe QUE en modèle 24 couches** → le mapper force `fr`/`fr-FR`/`french` → **`french_24l`** (le token `french` est rejeté par le CLI). Anglais n'a jamais de `_24l` ; `highQuality` upgrade les autres langues.
- `generate` écrit `./tts_output.wav` → on l'exécute dans un dossier jetable puis on relit le fichier (**WAV 24 kHz mono 16-bit**, décodeur **Mimi**).
- `--voice` accepte un preset (alba, anna, giovanni…) **ou** un chemin `.wav/.mp3/.flac` pour cloner.

## Sûreté / design
- Fonctions **pures/testables** : `resolvePocketLanguage`, `isVoiceSamplePath`, `buildGenerateArgs`, `wavDurationMs`.
- **Fail-open** : indisponible si aucun launcher, `synthesize` lève un message d'install clair → le TTS manager retombe sur Piper. Spawn injecté/timeout, dossier temporaire nettoyé.

## Preuves (no-mocks)
- Synthèse **française réelle à travers le provider** (`{language:'fr-FR'}` → `french_24l`) → **WAV RIFF/WAVE 24 kHz valide, 6,6 s**. En CLI direct : **~1,3× plus rapide que le temps réel** sur CPU Ministar (5,12 s d'audio en 3,88 s).
- **16 tests unitaires** + suite **talk-mode 89/89 verte**, **tsc 0**, **eslint 0**, Prettier OK.

## Suite (hors périmètre de cette PR)
- Brancher `pocket` dans `buddy speak` + la narration de films (`src/tools/video/narration.ts`) et la boucle vocale du compagnon.
- Pour le **temps réel / streaming** (voix « Lisa », barge-in), un **worker persistant** ou `pocket-tts serve` (1er chunk ~200 ms) plutôt qu'un spawn par appel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)