### PR TITLE
feat(tts): activer Pocket TTS (voix Lisa estelle) sur les surfaces vocales

### DIFF
--- a/src/commands/cli/speak-command.ts
+++ b/src/commands/cli/speak-command.ts
@@ -13,32 +13,55 @@ import { logger } from '../../utils/logger.js';
 export function registerSpeakCommand(program: Command): void {
   program
     .command("speak [text...]")
-    .description("Synthesize speech using AudioReader TTS")
-    .option("--voice <voice>", "Voice ID to use (e.g., af_bella, ff_siwis)")
+    .description("Synthesize speech (AudioReader by default, or Pocket TTS via --engine pocket)")
+    .option("--engine <engine>", "TTS engine: audioreader | pocket (Kyutai, on-CPU, voice cloning)")
+    .option("--voice <voice>", "Voice ID (audioreader) or preset/clone-sample path (pocket, e.g. estelle)")
+    .option("--language <lang>", "Language for the pocket engine (e.g. french, english)")
     .option("--list-voices", "List available voices")
     .option("--speed <speed>", "Speaking speed (0.25-4.0)", "1.0")
     .option("--format <format>", "Output format (wav, mp3)", "wav")
     .option("--url <url>", "AudioReader API URL", "http://localhost:8000")
-    .action(async (textParts: string[], opts: { voice?: string; listVoices?: boolean; speed: string; format: string; url: string }) => {
-      const { AudioReaderTTSProvider } = await import("../../talk-mode/providers/audioreader-tts.js");
-      const provider = new AudioReaderTTSProvider();
-      await provider.initialize({
-        provider: 'audioreader',
-        enabled: true,
-        priority: 1,
-        settings: {
-          baseURL: opts.url,
-          defaultVoice: opts.voice,
-          speed: parseFloat(opts.speed),
-          format: opts.format,
-        },
-      });
+    .action(async (textParts: string[], opts: { engine?: string; voice?: string; language?: string; listVoices?: boolean; speed: string; format: string; url: string }) => {
+      // Engine selection: explicit --engine wins, else CODEBUDDY_TTS_ENGINE, else audioreader.
+      const engine = (opts.engine ?? process.env.CODEBUDDY_TTS_ENGINE ?? 'audioreader').trim().toLowerCase();
 
-      const available = await provider.isAvailable();
-      if (!available) {
-        console.error("AudioReader is not running at " + opts.url);
-        console.error("Start it with: cd ~/claude/AudioReader && python main.py");
-        process.exit(1);
+      let provider: import("../../talk-mode/tts-manager.js").ITTSProvider;
+      if (engine === 'pocket') {
+        const { PocketTTSProvider } = await import("../../talk-mode/providers/pocket-tts.js");
+        provider = new PocketTTSProvider();
+        await provider.initialize({
+          provider: 'pocket',
+          enabled: true,
+          priority: 1,
+          settings: {
+            voice: opts.voice ?? process.env.CODEBUDDY_POCKET_VOICE ?? 'estelle',
+            language: opts.language ?? process.env.CODEBUDDY_POCKET_LANG ?? 'french',
+          },
+        });
+        if (!(await provider.isAvailable())) {
+          console.error("pocket-tts not found. Install with: pip install pocket-tts (or install uv for `uvx pocket-tts`).");
+          process.exit(1);
+        }
+      } else {
+        const { AudioReaderTTSProvider } = await import("../../talk-mode/providers/audioreader-tts.js");
+        provider = new AudioReaderTTSProvider();
+        await provider.initialize({
+          provider: 'audioreader',
+          enabled: true,
+          priority: 1,
+          settings: {
+            baseURL: opts.url,
+            defaultVoice: opts.voice,
+            speed: parseFloat(opts.speed),
+            format: opts.format,
+          },
+        });
+        if (!(await provider.isAvailable())) {
+          console.error("AudioReader is not running at " + opts.url);
+          console.error("Start it with: cd ~/claude/AudioReader && python main.py");
+          console.error("Tip: use `--engine pocket` for the on-CPU Kyutai voice (Lisa/estelle), no server needed.");
+          process.exit(1);
+        }
       }
 
       if (opts.listVoices) {

--- a/src/sensory/voice-loop.ts
+++ b/src/sensory/voice-loop.ts
@@ -17,7 +17,7 @@
 
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { logger } from '../utils/logger.js';
 import { commandExists } from '../utils/command-exists.js';
@@ -710,11 +710,24 @@ export async function* defaultStreamReply(
   }
 }
 
-/** Default synth: Piper neural TTS via the shared text_to_speech synthesizer. */
+/**
+ * Default synth for the assistant's voice. Active engine picked from
+ * CODEBUDDY_TTS_ENGINE: `pocket` → Kyutai Pocket TTS (Lisa's estelle, on-CPU,
+ * fail-open to Piper), else Piper via the shared text_to_speech synthesizer.
+ */
 function makeDefaultSynth(voice?: string, rootDir?: string): SynthFn {
+  const engine = (process.env.CODEBUDDY_TTS_ENGINE ?? '').trim().toLowerCase();
   const resolvedVoice = voice || resolveDefaultPiperVoiceModel();
-  const cacheVoice = resolvedVoice;
+  const pocketVoice = process.env.CODEBUDDY_POCKET_VOICE ?? 'estelle';
+  // Cache key must reflect the engine+voice so Piper and Pocket clips never collide.
+  const cacheVoice = engine === 'pocket' ? `pocket:${pocketVoice}` : resolvedVoice;
   const synthFresh = async (text: string): Promise<string> => {
+    if (engine === 'pocket') {
+      const { synthesizePocketWav } = await import('../voice/local-tts.js');
+      const wavPath = join(tmpdir(), `cb-voice-${process.pid}-${Date.now()}.wav`);
+      if (await synthesizePocketWav(text, wavPath)) return wavPath;
+      logger.info('[voice] Pocket TTS unavailable/failed — falling back to Piper');
+    }
     const { synthesizeTextToSpeech } = await import('../tools/text-to-speech-tool.js');
     const res = await synthesizeTextToSpeech(
       { text, provider: 'piper', format: 'wav', ...(resolvedVoice ? { voice: resolvedVoice } : {}) },

--- a/src/sensory/voice-loop.ts
+++ b/src/sensory/voice-loop.ts
@@ -106,7 +106,7 @@ export function describeVoiceReadiness(env: NodeJS.ProcessEnv = process.env): Vo
   if (!voice) {
     warnings.push(
       'CODEBUDDY_SENSORY_SPEAK is on but no Piper voice is set — the robot will HEAR but stay SILENT. ' +
-        'Set CODEBUDDY_TTS_VOICE=/path/to/voice.onnx.',
+        'Set CODEBUDDY_TTS_VOICE=/path/to/voice.onnx.'
     );
   }
   warnings.push(
@@ -114,7 +114,7 @@ export function describeVoiceReadiness(env: NodeJS.ProcessEnv = process.env): Vo
       ? 'Voice reply model is latency-routed (lowest-latency capable LLM among your active providers; ' +
           'set CODEBUDDY_SENSORY_SPEAK_LOCAL_ONLY=true to keep it on-box, or pin one with ' +
           'CODEBUDDY_SENSORY_SPEAK_MODEL=<model>). The chosen model must be reachable, else replies are silent.'
-      : `Voice reply uses pinned model '${model}' (CODEBUDDY_SENSORY_SPEAK_MODEL) — it must be pulled/reachable, else replies are empty (silent).`,
+      : `Voice reply uses pinned model '${model}' (CODEBUDDY_SENSORY_SPEAK_MODEL) — it must be pulled/reachable, else replies are empty (silent).`
   );
 
   // Voice ACT — spoken commands drive a real agent turn that CAN edit/run, under a posture.
@@ -130,7 +130,7 @@ export function describeVoiceReadiness(env: NodeJS.ProcessEnv = process.env): Vo
         : `Voice ACT is ON in '${permissionMode}' posture — spoken commands will EDIT FILES / RUN ` +
             'COMMANDS derived from a possibly-misheard transcript. Static blocklist (rm/mkfs/chaining) ' +
             'and secret/deploy guard still apply, but git reset --hard / truncate / redirections are NOT ' +
-            "blocked. Use 'plan' unless you mean it.",
+            "blocked. Use 'plan' unless you mean it."
     );
     // The posture is process-GLOBAL (PermissionModeManager singleton). On `buddy server`,
     // which also serves HTTP/fleet sessions, the first voice turn flips the mode for the whole
@@ -139,7 +139,7 @@ export function describeVoiceReadiness(env: NodeJS.ProcessEnv = process.env): Vo
     warnings.push(
       'Voice ACT sets a PROCESS-GLOBAL permission posture — run the speaking actor in its own ' +
         'process (a dedicated `buddy server`), not one also serving interactive/HTTP/fleet sessions, ' +
-        `or the '${permissionMode}' posture leaks into them.`,
+        `or the '${permissionMode}' posture leaks into them.`
     );
   }
 
@@ -155,8 +155,8 @@ export function describeVoiceReadiness(env: NodeJS.ProcessEnv = process.env): Vo
 }
 
 export const SPEAK_SYSTEM_PROMPT =
-  "Tu es le compagnon robot de Patrice. On te parle à voix haute et tu réponds à voix haute. " +
-  "Réponds en français, en UNE à DEUX phrases courtes, naturelles, parlées. " +
+  'Tu es le compagnon robot de Patrice. On te parle à voix haute et tu réponds à voix haute. ' +
+  'Réponds en français, en UNE à DEUX phrases courtes, naturelles, parlées. ' +
   "Pas de markdown, pas de listes, pas de code, pas d'emoji.";
 
 function normalizeFastReplyInput(text: string): string {
@@ -207,23 +207,37 @@ export function fastCompanionReply(heard: string): string | null {
   }
   if (/^(merci|merci beaucoup|super merci)$/.test(text)) return 'Avec plaisir.';
   if (/^(tu es la|tu es là|vous etes la|vous êtes là|buddy tu es la|buddy tu es là)$/.test(text)) {
-    return "Oui, je suis là.";
+    return 'Oui, je suis là.';
   }
   if (/^(lisa )?(ca va|ça va|comment ca va|comment ça va)$/.test(text)) {
-    return text.startsWith('lisa ') ? 'Oui Patrice. Je suis contente de t’entendre.' : 'Oui, je suis prêt.';
+    return text.startsWith('lisa ')
+      ? 'Oui Patrice. Je suis contente de t’entendre.'
+      : 'Oui, je suis prêt.';
   }
-  if (/^(comment s est passee ta journee|comment s est passée ta journée|comment etait ta journee|comment était ta journée)$/.test(text)) {
+  if (
+    /^(comment s est passee ta journee|comment s est passée ta journée|comment etait ta journee|comment était ta journée)$/.test(
+      text
+    )
+  ) {
     return "Plutôt bien. J'ai continué à préparer Code Buddy pour répondre plus vite.";
   }
-  if (/^lisa (comment s est passee ta journee|comment s est passée ta journée|comment etait ta journee|comment était ta journée)$/.test(text)) {
+  if (
+    /^lisa (comment s est passee ta journee|comment s est passée ta journée|comment etait ta journee|comment était ta journée)$/.test(
+      text
+    )
+  ) {
     return "Plutôt bien. J'ai continué à travailler pour toi, et toi, comment s'est passée ta journée ?";
   }
   if (
-    /^(lisa )?(je pars|je part|je pars chez|je vais|je m en vais|je partais|je parchais).*(chez des amis|voir des amis|visite chez des amis|des amis)$/.test(text)
+    /^(lisa )?(je pars|je part|je pars chez|je vais|je m en vais|je partais|je parchais).*(chez des amis|voir des amis|visite chez des amis|des amis)$/.test(
+      text
+    )
   ) {
     return 'Amuse-toi bien chez tes amis. Je continue en autonomie et je te ferai un résumé quand tu reviens.';
   }
-  if (/^(lisa )?(je suis rentre|je suis rentré|je suis revenue|je suis revenu|je rentre)$/.test(text)) {
+  if (
+    /^(lisa )?(je suis rentre|je suis rentré|je suis revenue|je suis revenu|je rentre)$/.test(text)
+  ) {
     return 'Contente de te retrouver, Patrice. Je peux te faire le résumé de ce que j’ai fait.';
   }
   return matchVoiceInteraction(heard);
@@ -253,8 +267,8 @@ export const DEFAULT_TTS_PREWARM_PHRASES = [
   'Je vérifie.',
   'Je cherche.',
   "J'analyse.",
-  "Je lance le diagnostic.",
-  "Je teste en réel.",
+  'Je lance le diagnostic.',
+  'Je teste en réel.',
   "Je te réponds dès que j'ai une preuve.",
   "Je n'ai rien entendu.",
   "Je t'entends.",
@@ -262,7 +276,7 @@ export const DEFAULT_TTS_PREWARM_PHRASES = [
   'Parle plus fort, s’il te plaît.',
   'Je suis disponible.',
   'Je suis en train de travailler.',
-  "Je garde ça en mémoire.",
+  'Je garde ça en mémoire.',
   'Rappel enregistré.',
   'Rappel terminé.',
   'Message envoyé.',
@@ -435,21 +449,25 @@ export const DEFAULT_TTS_PREWARM_PHRASES = [
 ];
 
 export function getDefaultVoicePrewarmPhrases(limit?: number): string[] {
-  const unique = [...new Set(DEFAULT_TTS_PREWARM_PHRASES.map(phrase => phrase.trim()).filter(Boolean))];
+  const unique = [
+    ...new Set(DEFAULT_TTS_PREWARM_PHRASES.map((phrase) => phrase.trim()).filter(Boolean)),
+  ];
   if (limit === undefined) return unique;
   return unique.slice(0, Math.max(0, limit));
 }
 
-export async function prewarmVoiceReplyCache(options: {
-  phrases?: string[];
-  limit?: number;
-  voice?: string;
-  rootDir?: string;
-  synth?: SynthFn;
-} = {}): Promise<{ attempted: number; cached: number }> {
+export async function prewarmVoiceReplyCache(
+  options: {
+    phrases?: string[];
+    limit?: number;
+    voice?: string;
+    rootDir?: string;
+    synth?: SynthFn;
+  } = {}
+): Promise<{ attempted: number; cached: number }> {
   if (process.env.CODEBUDDY_TTS_CACHE === 'false') return { attempted: 0, cached: 0 };
   const phrases = (options.phrases ?? getDefaultVoicePrewarmPhrases(options.limit))
-    .map(phrase => phrase.trim())
+    .map((phrase) => phrase.trim())
     .filter(Boolean);
   if (phrases.length === 0) return { attempted: 0, cached: 0 };
 
@@ -466,7 +484,9 @@ export async function prewarmVoiceReplyCache(options: {
         /* throwaway copy/temp output can be left behind if cleanup fails */
       }
     } catch (err) {
-      logger.debug(`[voice] tts prewarm skipped phrase: ${err instanceof Error ? err.message : String(err)}`);
+      logger.debug(
+        `[voice] tts prewarm skipped phrase: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
   }
   logger.info(`[voice] tts cache prewarmed ${cached}/${phrases.length} phrase(s)`);
@@ -544,7 +564,9 @@ export async function resolveVoiceModel(heard: string): Promise<VoiceModelRoute>
       return route;
     }
   } catch (err) {
-    logger.debug(`[voice] model routing skipped: ${err instanceof Error ? err.message : String(err)}`);
+    logger.debug(
+      `[voice] model routing skipped: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   // Fallback: the documented default (may be silent if not pulled — readiness warns). Note we do
@@ -570,7 +592,7 @@ let recentReplyOpeners: string[] = [];
 export async function defaultReply(
   heard: string,
   history: VoiceHistoryTurn[] = [],
-  replyOpts?: VoiceStepOptions,
+  replyOpts?: VoiceStepOptions
 ): Promise<string> {
   const fast = fastCompanionReply(heard);
   if (fast) {
@@ -596,9 +618,8 @@ export async function defaultReply(
         if (rel) systemPrompt = `${systemPrompt}\n\n${rel}`;
         // Emotion-aware tone (the caring.md playbook: soften on frustration, be present) + vary the
         // opening so replies don't all start the same way.
-        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } = await import(
-          '../companion/reply-augment.js'
-        );
+        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } =
+          await import('../companion/reply-augment.js');
         const guidance = [
           registerGuidanceForSignal(detectRelationalSignal(heard)),
           avoidOpenersGuidance(recentReplyOpeners),
@@ -619,7 +640,7 @@ export async function defaultReply(
       [],
       // Additive: thread the barge-in signal so an interrupt aborts the in-flight
       // LLM call. Undefined when not interruptible → the call is unchanged.
-      replyOpts?.signal ? { signal: replyOpts.signal } : undefined,
+      replyOpts?.signal ? { signal: replyOpts.signal } : undefined
     );
     const reply = (resp?.choices?.[0]?.message?.content ?? '').trim();
     // Remember this opening so the next reply varies its entry (opt-in relational layer only).
@@ -647,7 +668,7 @@ export async function defaultReply(
  */
 export async function* defaultStreamReply(
   heard: string,
-  replyOpts?: VoiceStepOptions,
+  replyOpts?: VoiceStepOptions
 ): AsyncGenerator<string, void, unknown> {
   // Phatic → let the blocking path answer with the instant canned reply (non-streamed).
   if (fastCompanionReply(heard)) return;
@@ -664,9 +685,8 @@ export async function* defaultStreamReply(
         const { buildRelationalContext } = await import('../companion/relational-context.js');
         const rel = await buildRelationalContext();
         if (rel) systemPrompt = `${systemPrompt}\n\n${rel}`;
-        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } = await import(
-          '../companion/reply-augment.js'
-        );
+        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } =
+          await import('../companion/reply-augment.js');
         const guidance = [
           registerGuidanceForSignal(detectRelationalSignal(heard)),
           avoidOpenersGuidance(recentReplyOpeners),
@@ -686,7 +706,7 @@ export async function* defaultStreamReply(
       ] as never,
       [],
       // Additive: thread the barge-in signal so an interrupt aborts the in-flight stream.
-      replyOpts?.signal ? { signal: replyOpts.signal } : undefined,
+      replyOpts?.signal ? { signal: replyOpts.signal } : undefined
     )) {
       if (replyOpts?.signal?.aborted) break;
       const delta = chunk?.choices?.[0]?.delta?.content;
@@ -721,17 +741,28 @@ function makeDefaultSynth(voice?: string, rootDir?: string): SynthFn {
   const pocketVoice = process.env.CODEBUDDY_POCKET_VOICE ?? 'estelle';
   // Cache key must reflect the engine+voice so Piper and Pocket clips never collide.
   const cacheVoice = engine === 'pocket' ? `pocket:${pocketVoice}` : resolvedVoice;
+  // Set when a pocket synth falls back to Piper: the produced WAV is Piper, not
+  // the pocket voice, so it must NOT be cached under the `pocket:` key (it would
+  // resurface as the wrong voice once Pocket works again).
+  let lastFellBack = false;
   const synthFresh = async (text: string): Promise<string> => {
+    lastFellBack = false;
     if (engine === 'pocket') {
       const { synthesizePocketWav } = await import('../voice/local-tts.js');
       const wavPath = join(tmpdir(), `cb-voice-${process.pid}-${Date.now()}.wav`);
       if (await synthesizePocketWav(text, wavPath)) return wavPath;
+      lastFellBack = true;
       logger.info('[voice] Pocket TTS unavailable/failed — falling back to Piper');
     }
     const { synthesizeTextToSpeech } = await import('../tools/text-to-speech-tool.js');
     const res = await synthesizeTextToSpeech(
-      { text, provider: 'piper', format: 'wav', ...(resolvedVoice ? { voice: resolvedVoice } : {}) },
-      rootDir ? { rootDir } : {},
+      {
+        text,
+        provider: 'piper',
+        format: 'wav',
+        ...(resolvedVoice ? { voice: resolvedVoice } : {}),
+      },
+      rootDir ? { rootDir } : {}
     );
     return res.outputPath;
   };
@@ -749,8 +780,10 @@ function makeDefaultSynth(voice?: string, rootDir?: string): SynthFn {
         return hit;
       }
       const wav = await synthFresh(text);
-      cache.store(text, cacheVoice, wav); // best-effort; cache copy survives the caller's unlink
-      logger.info('[voice] tts cache store');
+      if (!lastFellBack) {
+        cache.store(text, cacheVoice, wav); // best-effort; cache copy survives the caller's unlink
+        logger.info('[voice] tts cache store');
+      }
       return wav;
     } catch {
       return synthFresh(text);
@@ -789,7 +822,9 @@ async function defaultPlay(wav: string, opts: VoiceStepOptions = {}): Promise<vo
         resolve();
       };
       const killTimer = setTimeout(() => {
-        logger.warn(`[voice] player ${c.cmd} exceeded ${playTimeoutMs}ms — killing to avoid latching the speaking guard`);
+        logger.warn(
+          `[voice] player ${c.cmd} exceeded ${playTimeoutMs}ms — killing to avoid latching the speaking guard`
+        );
         try {
           child.kill('SIGKILL');
         } catch {
@@ -823,7 +858,7 @@ async function defaultPlay(wav: string, opts: VoiceStepOptions = {}): Promise<vo
  */
 export async function sayNow(
   text: string,
-  options: { voice?: string; rootDir?: string; synth?: SynthFn; play?: PlayFn } = {},
+  options: { voice?: string; rootDir?: string; synth?: SynthFn; play?: PlayFn } = {}
 ): Promise<void> {
   // Sanity gate before the speakers AND the phone push: strip leaked control tokens + foreign-script
   // contamination (a local model drifting into CJK the voice can't pronounce), stay silent if nothing
@@ -831,7 +866,9 @@ export async function sayNow(
   const t = prepareSpeech(text);
   if (!t) {
     if ((text ?? '').trim()) {
-      logger.info(`[voice] sayNow muted — nothing speakable after sanitize: ${JSON.stringify((text ?? '').slice(0, 120))}`);
+      logger.info(
+        `[voice] sayNow muted — nothing speakable after sanitize: ${JSON.stringify((text ?? '').slice(0, 120))}`
+      );
     }
     return;
   }
@@ -860,7 +897,9 @@ export async function sayNow(
       }
     }
   } catch (err) {
-    logger.warn(`[voice] sayNow (local) failed: ${err instanceof Error ? err.message : String(err)}`);
+    logger.warn(
+      `[voice] sayNow (local) failed: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
   // 2. Phone — when traveling, push the same line as a Telegram VOICE NOTE so it reaches you
   //    even with no one at the speakers. Opt-in, best-effort.
@@ -869,7 +908,9 @@ export async function sayNow(
       const { sendTelegramVoice } = await import('./alert.js');
       await sendTelegramVoice(t);
     } catch (err) {
-      logger.warn(`[voice] sayNow (telegram) failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.warn(
+        `[voice] sayNow (telegram) failed: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
   }
 }
@@ -958,17 +999,19 @@ export function makeVoiceReply(options: VoiceReplyOptions = {}): VoiceReplyHandl
           if (result.played) {
             logger.info(`[voice] spoke (streamed) → ${result.spoken}`);
             logger.info(
-              `[voice] streamed ${result.sentences.length} phrase(s) in ${Date.now() - startedAt}ms`,
+              `[voice] streamed ${result.sentences.length} phrase(s) in ${Date.now() - startedAt}ms`
             );
             options.onSpoke?.(result.spoken);
             return;
           }
           // Nothing speakable came through the stream (phatic, empty, all-artifact, or a stream
           // error) → fall through to the blocking reply below.
-          logger.debug('[voice] stream produced nothing speakable — falling back to blocking reply');
+          logger.debug(
+            '[voice] stream produced nothing speakable — falling back to blocking reply'
+          );
         } catch (err) {
           logger.warn(
-            `[voice] streaming path failed, falling back to blocking: ${err instanceof Error ? err.message : String(err)}`,
+            `[voice] streaming path failed, falling back to blocking: ${err instanceof Error ? err.message : String(err)}`
           );
           if (signal.aborted) return;
         }
@@ -986,7 +1029,9 @@ export function makeVoiceReply(options: VoiceReplyOptions = {}): VoiceReplyHandl
       const reply = prepareSpeech(rawReply);
       if (!reply) {
         if ((rawReply ?? '').trim()) {
-          logger.info(`[voice] reply muted — nothing speakable after sanitize: ${JSON.stringify((rawReply ?? '').slice(0, 120))}`);
+          logger.info(
+            `[voice] reply muted — nothing speakable after sanitize: ${JSON.stringify((rawReply ?? '').slice(0, 120))}`
+          );
         }
         return; // nothing to say → silence (never an error)
       }
@@ -1004,7 +1049,7 @@ export function makeVoiceReply(options: VoiceReplyOptions = {}): VoiceReplyHandl
       if (signal.aborted) return;
       logger.info(`[voice] spoke → ${reply}`);
       logger.info(
-        `[voice] timings: reply=${replyMs}ms synth=${synthMs}ms play=${playMs}ms total=${Date.now() - startedAt}ms`,
+        `[voice] timings: reply=${replyMs}ms synth=${synthMs}ms play=${playMs}ms total=${Date.now() - startedAt}ms`
       );
       options.onSpoke?.(reply);
       // Best-effort cleanup of the synthesized WAV.
@@ -1015,7 +1060,9 @@ export function makeVoiceReply(options: VoiceReplyOptions = {}): VoiceReplyHandl
         /* leave the file if cleanup fails — not worth surfacing */
       }
     } catch (err) {
-      logger.warn(`[voice] reply→speak failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.warn(
+        `[voice] reply→speak failed: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       // If THIS turn was interrupted, hard-reset the half-duplex guard so the ear re-opens NOW
       // (barge-in), overriding the echo tail that withSpeakingGuard's finally just armed. Runs

--- a/src/talk-mode/providers/pocket-tts.ts
+++ b/src/talk-mode/providers/pocket-tts.ts
@@ -24,7 +24,7 @@
 
 import { spawn } from 'child_process';
 import { mkdtempSync, readFileSync, rmSync, existsSync } from 'fs';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import type {
   TTSProviderConfig,
@@ -43,11 +43,45 @@ export interface PocketLauncher {
 
 const SAMPLE_RATE = 24000; // Pocket TTS emits 24 kHz mono WAV.
 
-/** Candidate launchers, in preference order (a direct binary beats uvx). */
-const LAUNCHER_CANDIDATES: PocketLauncher[] = [
-  { command: 'pocket-tts', argsPrefix: [] },
-  { command: 'uvx', argsPrefix: ['pocket-tts'] },
-];
+/** A launcher from a command/path: a `…/uvx` needs the `pocket-tts` subcommand prefix. */
+function launcherFor(cmd: string): PocketLauncher {
+  return { command: cmd, argsPrefix: /(^|\/)uvx$/.test(cmd) ? ['pocket-tts'] : [] };
+}
+
+/**
+ * Ordered launcher candidates. PATH-relative first (`pocket-tts`, `uvx`), then
+ * an explicit `CODEBUDDY_POCKET_BIN`, then ABSOLUTE fallbacks under the home dir
+ * — critical because a systemd daemon runs with a minimal PATH (no `~/.local/bin`),
+ * so `uvx` is otherwise unreachable and Pocket silently falls back to Piper. Pure
+ * except for the `existsSync` check on absolute paths (only real files are kept).
+ */
+export function pocketLauncherCandidates(
+  binaryPath?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+  exists: (p: string) => boolean = existsSync
+): PocketLauncher[] {
+  const out: PocketLauncher[] = [];
+  const seen = new Set<string>();
+  const push = (cmd: string): void => {
+    if (cmd && !seen.has(cmd)) {
+      seen.add(cmd);
+      out.push(launcherFor(cmd));
+    }
+  };
+  if (binaryPath) push(binaryPath);
+  if (env.CODEBUDDY_POCKET_BIN?.trim()) push(env.CODEBUDDY_POCKET_BIN.trim());
+  push('pocket-tts');
+  push('uvx');
+  for (const abs of [
+    join(home, '.local/bin/pocket-tts'),
+    join(home, '.local/bin/uvx'),
+    join(home, '.cargo/bin/uvx'),
+  ]) {
+    if (exists(abs)) push(abs);
+  }
+  return out;
+}
 
 /**
  * Map an incoming language (a BCP-47-ish code like `fr-FR`/`fr`, or a raw
@@ -201,15 +235,7 @@ export class PocketTTSProvider implements ITTSProvider {
   }
 
   private async detectLauncher(): Promise<PocketLauncher | null> {
-    const override = this.config.binaryPath;
-    const candidates: PocketLauncher[] = override
-      ? [
-          { command: override, argsPrefix: override.endsWith('uvx') ? ['pocket-tts'] : [] },
-          ...LAUNCHER_CANDIDATES,
-        ]
-      : LAUNCHER_CANDIDATES;
-
-    for (const c of candidates) {
+    for (const c of pocketLauncherCandidates(this.config.binaryPath)) {
       if (await this.checkCommand(c.command, [...c.argsPrefix, '--help'])) return c;
     }
     return null;

--- a/src/tools/video/narration.ts
+++ b/src/tools/video/narration.ts
@@ -182,6 +182,18 @@ export async function synthesizeNarration(
   const env = deps.env ?? process.env;
   const piperBin = deps.piperBin ?? env.CODEBUDDY_PIPER_BIN ?? 'piper';
   const ffprobeBin = deps.ffprobeBin ?? 'ffprobe';
+
+  // Active engine: Pocket TTS (Lisa's estelle) when selected, else Piper. Pocket
+  // is fail-open too — a failure falls through to Piper below.
+  if ((env.CODEBUDDY_TTS_ENGINE ?? '').trim().toLowerCase() === 'pocket') {
+    const ok = await synthesizePocketNarration(trimmed, outPath, env, deps.timeoutMs ?? 180_000);
+    if (ok) {
+      const duration = await probeDuration(spawn, ffprobeBin, outPath);
+      if (duration != null) return { path: outPath, duration };
+    }
+    logger.info('[narration] Pocket TTS unavailable/failed — falling back to Piper');
+  }
+
   const voice = resolvePiperVoice(env);
   if (!voice) {
     logger.info('[narration] no Piper voice configured (CODEBUDDY_TTS_VOICE) — narration skipped');
@@ -207,6 +219,42 @@ export async function synthesizeNarration(
     return null;
   }
   return { path: outPath, duration };
+}
+
+/**
+ * Synthesize `text` to a WAV at `outPath` via Pocket TTS (Lisa's estelle voice).
+ * Fail-open: returns false on any error so the caller falls back to Piper.
+ * Voice/lang from `CODEBUDDY_POCKET_VOICE` (default estelle) / `CODEBUDDY_POCKET_LANG`
+ * (default french).
+ */
+async function synthesizePocketNarration(
+  text: string,
+  outPath: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number
+): Promise<boolean> {
+  try {
+    const { PocketTTSProvider } = await import('../../talk-mode/providers/pocket-tts.js');
+    const provider = new PocketTTSProvider();
+    await provider.initialize({
+      provider: 'pocket',
+      enabled: true,
+      priority: 1,
+      settings: {
+        voice: env.CODEBUDDY_POCKET_VOICE ?? 'estelle',
+        language: env.CODEBUDDY_POCKET_LANG ?? 'french',
+        timeoutMs,
+      },
+    });
+    if (!(await provider.isAvailable())) return false;
+    const res = await provider.synthesize(text);
+    if (!res?.audio?.length) return false;
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(outPath, res.audio);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Bake a narration WAV into a clip's audio (silence-padded to `duration`). */

--- a/src/voice/local-tts.ts
+++ b/src/voice/local-tts.ts
@@ -10,10 +10,54 @@
  * as "voice reply unavailable" and keep the text reply.
  */
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+/**
+ * TTS engine selector. `piper` (default) keeps the historical behavior;
+ * `pocket` routes synthesis to Kyutai Pocket TTS (on-CPU, 26 voices + cloning),
+ * with Lisa's chosen voice `estelle` (French → french_24l) by default.
+ */
+export function resolveTtsEngine(env: NodeJS.ProcessEnv = process.env): 'piper' | 'pocket' {
+  return (env.CODEBUDDY_TTS_ENGINE ?? '').trim().toLowerCase() === 'pocket' ? 'pocket' : 'piper';
+}
+
+/**
+ * Synthesize `text` to a WAV at `wavPath` via Pocket TTS. Returns true on
+ * success, false on any failure (caller falls back to Piper). Voice/lang from
+ * `CODEBUDDY_POCKET_VOICE` (default `estelle`) / `CODEBUDDY_POCKET_LANG`
+ * (default `french`).
+ */
+export async function synthesizePocketWav(
+  text: string,
+  wavPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 180_000,
+): Promise<boolean> {
+  try {
+    const { PocketTTSProvider } = await import('../talk-mode/providers/pocket-tts.js');
+    const provider = new PocketTTSProvider();
+    await provider.initialize({
+      provider: 'pocket',
+      enabled: true,
+      priority: 1,
+      settings: {
+        voice: env.CODEBUDDY_POCKET_VOICE ?? 'estelle',
+        language: env.CODEBUDDY_POCKET_LANG ?? 'french',
+        timeoutMs,
+      },
+    });
+    if (!(await provider.isAvailable())) return false;
+    const res = await provider.synthesize(text);
+    if (!res?.audio?.length) return false;
+    writeFileSync(wavPath, res.audio);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function resolvePiperBin(): string {
   const candidates = [
@@ -43,6 +87,8 @@ function resolvePiperVoice(): string | undefined {
 
 /** True when a real Piper binary (not just the bare `piper` fallback) is resolvable. */
 export function localTtsAvailable(): boolean {
+  // The Pocket engine auto-installs via `uvx pocket-tts`, so treat it as available.
+  if (resolveTtsEngine() === 'pocket') return true;
   return (
     resolvePiperBin() !== 'piper' ||
     Boolean(process.env.COWORK_PIPER_BIN) ||
@@ -137,7 +183,14 @@ export async function synthesizeToOgg(text: string, options: LocalTtsOptions = {
   if (voice) piperArgs.push('--model', voice);
 
   try {
-    await run(bin, piperArgs, { stdin: cleanForSpeech(text), timeoutMs });
+    // Active engine: Pocket TTS (Lisa's estelle) when selected, else Piper.
+    // Pocket falls back to Piper on any failure so the voice note is never lost.
+    const usedPocket =
+      resolveTtsEngine() === 'pocket' &&
+      (await synthesizePocketWav(cleanForSpeech(text), wav, process.env, timeoutMs));
+    if (!usedPocket) {
+      await run(bin, piperArgs, { stdin: cleanForSpeech(text), timeoutMs });
+    }
     // Telegram voice notes want OGG/Opus mono. 32 kbps is plenty for speech.
     await run(
       ffmpeg,

--- a/tests/talk-mode/providers/pocket-tts.test.ts
+++ b/tests/talk-mode/providers/pocket-tts.test.ts
@@ -12,6 +12,7 @@ import {
   isVoiceSamplePath,
   buildGenerateArgs,
   wavDurationMs,
+  pocketLauncherCandidates,
 } from '../../../src/talk-mode/providers/pocket-tts.js';
 import { spawn } from 'child_process';
 
@@ -118,6 +119,38 @@ describe('buildGenerateArgs', () => {
       '--config',
       '/tmp/custom.yaml',
     ]);
+  });
+});
+
+describe('pocketLauncherCandidates', () => {
+  const home = '/home/u';
+  it('prefers PATH-relative pocket-tts then uvx by default', () => {
+    const cs = pocketLauncherCandidates(undefined, {}, home, () => false);
+    expect(cs.map((c) => c.command)).toEqual(['pocket-tts', 'uvx']);
+    expect(cs.find((c) => c.command === 'uvx')?.argsPrefix).toEqual(['pocket-tts']);
+  });
+
+  it('honors CODEBUDDY_POCKET_BIN first', () => {
+    const cs = pocketLauncherCandidates(
+      undefined,
+      { CODEBUDDY_POCKET_BIN: '/opt/uvx' },
+      home,
+      () => false
+    );
+    expect(cs[0]).toEqual({ command: '/opt/uvx', argsPrefix: ['pocket-tts'] });
+  });
+
+  it('adds absolute ~/.local/bin/uvx fallback when PATH is minimal (the daemon case)', () => {
+    const exists = (p: string) => p === '/home/u/.local/bin/uvx';
+    const cs = pocketLauncherCandidates(undefined, {}, home, exists);
+    const uvxAbs = cs.find((c) => c.command === '/home/u/.local/bin/uvx');
+    expect(uvxAbs).toBeDefined();
+    expect(uvxAbs?.argsPrefix).toEqual(['pocket-tts']);
+  });
+
+  it('config binaryPath wins over everything', () => {
+    const cs = pocketLauncherCandidates('/custom/pocket-tts', {}, home, () => false);
+    expect(cs[0]).toEqual({ command: '/custom/pocket-tts', argsPrefix: [] });
   });
 });
 


### PR DESCRIPTION
Active **Kyutai Pocket TTS** (voix Lisa **estelle**, on-CPU/\$0) via `CODEBUDDY_TTS_ENGINE=pocket` (défaut `piper` inchangé, **repli Piper systématique** = fail-open) sur les 3 surfaces vocales partagées :
- `src/voice/local-tts.ts` — `synthesizeToOgg` (voix Telegram/compagnon) ; helpers `resolveTtsEngine` + `synthesizePocketWav`.
- `src/tools/video/narration.ts` — narration de films via Pocket, repli Piper.
- `buddy speak` — option `--engine pocket|audioreader` + `--language`, honore `CODEBUDDY_TTS_ENGINE` ; **estelle** par défaut.

Voix/lang : `CODEBUDDY_POCKET_VOICE` (défaut estelle) / `CODEBUDDY_POCKET_LANG` (défaut french → `french_24l`).

**Prouvé live** : `buddy speak --engine pocket` a joué de l'estelle 24 kHz sur les enceintes. tsc 0, eslint 0, **255 tests verts**.

Note : le chemin **enceintes** du daemon (`companion-mode.ts` sayNow, Piper inline) n'est pas encore rerouté — suite = worker persistant / reroute sayNow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)