### PR TITLE
feat(companion): loop d'amélioration de l'assistant vocal (MySoulmate-inspired)

### DIFF
--- a/src/commands/assistant.ts
+++ b/src/commands/assistant.ts
@@ -1,0 +1,67 @@
+/**
+ * `buddy assistant` — manage the voice assistant (Lisa).
+ *
+ * For now the headline subcommand is `improve`: run one MySoulmate-inspired
+ * improvement cycle (reflect on recent conversation → learned reply-guidance +
+ * bounded trait drift + proposed user preferences). Dry-run by default; `--apply`
+ * is the explicit human review that also accepts the proposed preferences.
+ *
+ * @module commands/assistant
+ */
+import type { Command } from 'commander';
+
+export function registerAssistantCommand(program: Command): void {
+  const assistant = program
+    .command('assistant')
+    .description('Manage the voice assistant (Lisa): improvement loop, voice, config');
+
+  assistant
+    .command('improve')
+    .description(
+      'Run one improvement cycle: reflect on recent conversation and adapt (MySoulmate-style)'
+    )
+    .option(
+      '--apply',
+      'Persist ALL learnings, incl. accepting proposed user preferences (human review)'
+    )
+    .option('--limit <n>', 'How many recent heard utterances to reflect on', '20')
+    .action(async (opts: { apply?: boolean; limit: string }) => {
+      const { runVoiceImprovementCycle } = await import('../companion/voice-improvement-loop.js');
+      const limit = Math.max(2, Number(opts.limit) || 20);
+      const mode = opts.apply ? 'all' : 'dry';
+      const res = await runVoiceImprovementCycle({ mode, limit });
+      if (!res) {
+        console.log(
+          'Rien à améliorer : pas assez de conversation récente, ou aucun modèle LLM configuré ' +
+            '(lance `buddy login` pour le mode ChatGPT $0).'
+        );
+        return;
+      }
+      const { reflection } = res;
+      console.log(
+        `\n🎙️  Cycle d'amélioration (${res.heardCount} phrases entendues, mode ${mode})\n`
+      );
+      console.log(`  Ton détecté : ${reflection.signal}`);
+      console.log(`  Consigne apprise : ${reflection.guidance || '(aucune)'}`);
+      console.log(
+        `  Préférences repérées : ${reflection.facts.length ? '\n    - ' + reflection.facts.join('\n    - ') : '(aucune)'}`
+      );
+      if (mode === 'dry') {
+        console.log(
+          '\n  (dry-run — rien enregistré. Relance avec --apply pour appliquer et accepter les préférences.)'
+        );
+      } else {
+        console.log('\n  Appliqué :');
+        console.log(`    - consigne vocale : ${res.guidanceApplied ? 'ajoutée' : 'non'}`);
+        console.log(`    - dérive de personnalité : ${res.driftApplied ? 'oui' : 'non'}`);
+        console.log(
+          `    - préférences acceptées : ${res.acceptedFacts.length ? res.acceptedFacts.join(' ; ') : '(aucune)'}`
+        );
+        console.log(
+          '\n  Astuce : active `CODEBUDDY_COMPANION_RELATIONAL=true` pour que ces apprentissages soient injectés dans les réponses.'
+        );
+      }
+    });
+}
+
+export default registerAssistantCommand;

--- a/src/companion/relational-context.ts
+++ b/src/companion/relational-context.ts
@@ -21,6 +21,7 @@
 import { getUserModel } from '../memory/user-model.js';
 import { injectPresenceBlock } from '../memory/presence-injector.js';
 import { loadRelationshipState, getPersonalitySummary } from './relationship-state.js';
+import { loadVoiceGuidance, formatVoiceGuidance } from './voice-guidance.js';
 
 export interface RelationalContextOptions {
   cwd?: string;
@@ -32,11 +33,14 @@ export interface RelationalContextOptions {
   includePresence?: boolean;
   /** Include the recent-episode block ("what we talked about"). Default true. */
   includeEpisode?: boolean;
+  /** Include the learned voice-guidance block ("how to reply better"). Default true. */
+  includeGuidance?: boolean;
   /** Injectable seams (tests) — each defaults to the real source above. */
   factsBlock?: () => string | null;
   personalitySummary?: () => string;
   presenceBlock?: () => Promise<string>;
   episodeBlock?: () => Promise<string | null>;
+  guidanceBlock?: () => string | null;
   /** Override the relationship-state file (tests). */
   relationshipStatePath?: string;
 }
@@ -58,7 +62,9 @@ async function defaultReadEpisode(): Promise<string | null> {
  * splice unconditionally). Order: what she knows about him → what they talked about recently → her
  * own state → who's present now.
  */
-export async function buildRelationalContext(options: RelationalContextOptions = {}): Promise<string> {
+export async function buildRelationalContext(
+  options: RelationalContextOptions = {}
+): Promise<string> {
   const parts: string[] = [];
 
   if (options.includeFacts !== false) {
@@ -72,10 +78,24 @@ export async function buildRelationalContext(options: RelationalContextOptions =
     }
   }
 
+  if (options.includeGuidance !== false) {
+    try {
+      const guidance = options.guidanceBlock
+        ? options.guidanceBlock()
+        : formatVoiceGuidance(loadVoiceGuidance());
+      if (guidance && guidance.trim()) parts.push(guidance.trim());
+    } catch {
+      /* best-effort — no learned guidance is fine */
+    }
+  }
+
   if (options.includeEpisode !== false) {
     try {
-      const episode = options.episodeBlock ? await options.episodeBlock() : await defaultReadEpisode();
-      if (episode && episode.trim()) parts.push(`<recent_episode>\n${episode.trim()}\n</recent_episode>`);
+      const episode = options.episodeBlock
+        ? await options.episodeBlock()
+        : await defaultReadEpisode();
+      if (episode && episode.trim())
+        parts.push(`<recent_episode>\n${episode.trim()}\n</recent_episode>`);
     } catch {
       /* best-effort — no episode is fine */
     }
@@ -94,7 +114,9 @@ export async function buildRelationalContext(options: RelationalContextOptions =
 
   if (options.includePresence !== false) {
     try {
-      const presence = options.presenceBlock ? await options.presenceBlock() : await injectPresenceBlock();
+      const presence = options.presenceBlock
+        ? await options.presenceBlock()
+        : await injectPresenceBlock();
       if (presence && presence.trim()) parts.push(presence.trim());
     } catch {
       /* best-effort */

--- a/src/companion/voice-guidance.ts
+++ b/src/companion/voice-guidance.ts
@@ -1,0 +1,98 @@
+/**
+ * Voice guidance — a tiny, bounded store of self-authored "how to reply better"
+ * lines that the voice-assistant improvement loop learns from recent
+ * conversations (see voice-improvement-loop.ts) and that get injected into
+ * Lisa's spoken replies via `buildRelationalContext`.
+ *
+ * MySoulmate-inspired: the companion adapts its communication style over time.
+ * Unlike user FACTS (privacy-screened, human-review-gated in user-model.ts),
+ * these are low-stakes BEHAVIOURAL nudges ("keep replies to one or two
+ * sentences", "he prefers you get to the point") — so they can be applied
+ * automatically, but stay bounded (most-recent N) and fully reversible (a plain
+ * JSON list the user can edit or clear).
+ *
+ * Pure/never-throws, mirrors the file-I/O style of relationship-state.ts.
+ *
+ * @module companion/voice-guidance
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface VoiceGuidanceItem {
+  /** The one-line guidance, imperative and short. */
+  text: string;
+  /** When it was learned (ms epoch). */
+  at: number;
+}
+
+/** Keep the store small so the injected block stays cheap and current. */
+export const MAX_VOICE_GUIDANCE = 5;
+
+export function defaultVoiceGuidancePath(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.CODEBUDDY_VOICE_GUIDANCE_FILE?.trim() ||
+    join(homedir(), '.codebuddy', 'companion', 'voice-guidance.json')
+  );
+}
+
+/** Load the guidance list (never throws; missing/corrupt → []). */
+export function loadVoiceGuidance(path: string = defaultVoiceGuidancePath()): VoiceGuidanceItem[] {
+  try {
+    if (!existsSync(path)) return [];
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter(
+        (x): x is VoiceGuidanceItem =>
+          !!x &&
+          typeof (x as VoiceGuidanceItem).text === 'string' &&
+          (x as VoiceGuidanceItem).text.trim().length > 0
+      )
+      .map((x) => ({ text: x.text.trim(), at: Number(x.at) || 0 }));
+  } catch {
+    return [];
+  }
+}
+
+/** Save the list (never throws; creates the dir). */
+export function saveVoiceGuidance(
+  items: VoiceGuidanceItem[],
+  path: string = defaultVoiceGuidancePath()
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(items, null, 2));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Add a guidance line: dedup (case-insensitive), newest first, capped at
+ * MAX_VOICE_GUIDANCE. Returns the new list (pure on the input array). An empty
+ * or whitespace line is a no-op.
+ */
+export function addVoiceGuidance(
+  text: string,
+  now: number,
+  existing: VoiceGuidanceItem[] = []
+): VoiceGuidanceItem[] {
+  const t = (text ?? '').trim();
+  if (!t) return existing;
+  const norm = t.toLowerCase();
+  const kept = existing.filter((x) => x.text.toLowerCase() !== norm);
+  return [{ text: t, at: now }, ...kept].slice(0, MAX_VOICE_GUIDANCE);
+}
+
+/** Format the guidance as a `<voice_guidance>` block for the reply system prompt (null when empty). */
+export function formatVoiceGuidance(items: VoiceGuidanceItem[]): string | null {
+  const lines = items
+    .map((x) => x.text.trim())
+    .filter(Boolean)
+    .slice(0, MAX_VOICE_GUIDANCE);
+  if (lines.length === 0) return null;
+  return `<voice_guidance>\nCe que j'ai appris sur la meilleure façon de lui parler :\n${lines
+    .map((l) => `- ${l}`)
+    .join('\n')}\n</voice_guidance>`;
+}

--- a/src/companion/voice-improvement-loop.ts
+++ b/src/companion/voice-improvement-loop.ts
@@ -1,0 +1,277 @@
+/**
+ * Voice-assistant improvement loop — MySoulmate-inspired reflection that makes
+ * Lisa a better conversational partner OVER TIME by learning from what she just
+ * heard, instead of treating every spoken turn in isolation.
+ *
+ * One cycle: read the recent HEARD dialogue → REFLECT with one LLM call → apply
+ * three kinds of durable learning, each on its own safety tier:
+ *   1. `guidance`  — a short behavioural nudge ("garde des réponses courtes")
+ *                    → the bounded, reversible voice-guidance store, injected
+ *                    into future replies via buildRelationalContext.  (low stakes)
+ *   2. `signal`    — the conversation's emotional tone → a BOUNDED trait drift
+ *                    (`evolveTraits`, anti-ratchet) of Lisa's relationship state.
+ *   3. `facts`     — durable working preferences about the user → PROPOSED into
+ *                    the privacy-screened `LocalUserModel` (pending); only an
+ *                    explicit human `--apply` accepts them (never the heartbeat).
+ *
+ * Modes: 'dry' (report only), 'behavioral' (guidance + drift; the heartbeat
+ * default — safe, no personal-fact writes), 'all' (also accept facts; CLI
+ * `--apply` = explicit human review). Opt-in, injectable, never-throws — a
+ * failure is a skipped cycle, never a crash.
+ *
+ * @module companion/voice-improvement-loop
+ */
+import { appendFileSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { logger } from '../utils/logger.js';
+import {
+  loadRelationshipState,
+  saveRelationshipState,
+  evolveTraits,
+  type RelationalSignal,
+} from './relationship-state.js';
+import {
+  loadVoiceGuidance,
+  saveVoiceGuidance,
+  addVoiceGuidance,
+  defaultVoiceGuidancePath,
+} from './voice-guidance.js';
+
+export type VoiceImprovementMode = 'dry' | 'behavioral' | 'all';
+
+const VALID_SIGNALS: readonly RelationalSignal[] = [
+  'affection',
+  'gratitude',
+  'joking',
+  'deep-talk',
+  'debugging-together',
+  'frustration',
+  'neutral',
+];
+
+export interface VoiceReflection {
+  /** Durable working preferences about the user (short, no sensitive data). */
+  facts: string[];
+  /** One imperative line on how to reply better next time ('' when none). */
+  guidance: string;
+  /** The conversation's emotional tone, for a bounded trait drift. */
+  signal: RelationalSignal;
+}
+
+export interface VoiceImprovementResult {
+  at: number;
+  /** How many heard utterances the reflection was based on. */
+  heardCount: number;
+  reflection: VoiceReflection;
+  /** Facts newly PROPOSED (pending human review) this cycle. */
+  proposedFacts: string[];
+  /** Facts ACCEPTED into the user model this cycle (mode 'all' only). */
+  acceptedFacts: string[];
+  /** True when the guidance line was written to the store. */
+  guidanceApplied: boolean;
+  /** True when the trait drift was persisted. */
+  driftApplied: boolean;
+}
+
+export interface VoiceImprovementDeps {
+  now?: number;
+  cwd?: string;
+  /** How many recent heard utterances to reflect on. Default 20. */
+  limit?: number;
+  /** 'dry' | 'behavioral' (heartbeat) | 'all' (human --apply). Default 'behavioral'. */
+  mode?: VoiceImprovementMode;
+  /** Injectable: read recent heard dialogue. Default: hearing percepts. */
+  readHeard?: (limit: number, cwd?: string) => Promise<string[]>;
+  /** Injectable: reflect on the dialogue → learnings. Default: one LLM JSON call ($0). */
+  reflect?: (heard: string[]) => Promise<VoiceReflection | null>;
+  /** Override the guidance store path (tests). */
+  guidancePath?: string;
+  /** Override the relationship-state path (tests). */
+  relationshipStatePath?: string;
+}
+
+const REFLECT_SYSTEM =
+  "Tu es le module de réflexion d'un assistant vocal (Lisa) qui cherche à mieux converser avec son utilisateur au fil du temps. " +
+  "À partir de ce que l'utilisateur a dit récemment, produis un JSON STRICT :\n" +
+  '{"facts": string[], "guidance": string, "signal": string}\n' +
+  '- "facts" : 0 à 3 PRÉFÉRENCES DE TRAVAIL durables et utiles (ex: « préfère des réponses courtes », « aime qu\'on aille droit au but », « travaille surtout le soir »). ' +
+  'PAS de données sensibles (santé, finances, relations, religion, politique, identifiants). Phrases courtes. [] si rien de fiable.\n' +
+  '- "guidance" : UNE consigne impérative et courte pour mieux lui répondre la prochaine fois (ex: « Réponds en une à deux phrases. »). "" si rien.\n' +
+  '- "signal" : le ton de la conversation, parmi exactement : affection, gratitude, joking, deep-talk, debugging-together, frustration, neutral.\n' +
+  'Réponds UNIQUEMENT le JSON, sans texte autour.';
+
+/** Coerce a raw parsed object into a clean VoiceReflection. Pure/testable. */
+export function normalizeReflection(raw: unknown): VoiceReflection {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const facts = Array.isArray(o.facts)
+    ? o.facts
+        .map((f) => (typeof f === 'string' ? f.trim() : ''))
+        .filter((f) => f.length > 0 && f.length <= 160)
+        .slice(0, 3)
+    : [];
+  const guidance = typeof o.guidance === 'string' ? o.guidance.trim().slice(0, 200) : '';
+  const sigRaw = typeof o.signal === 'string' ? o.signal.trim().toLowerCase() : '';
+  const signal = (VALID_SIGNALS as readonly string[]).includes(sigRaw)
+    ? (sigRaw as RelationalSignal)
+    : 'neutral';
+  return { facts, guidance, signal };
+}
+
+/** Default heard source — recent hearing percepts (mirrors episodic-journal). */
+async function defaultReadHeard(limit: number, cwd?: string): Promise<string[]> {
+  try {
+    const { readRecentCompanionPercepts } = await import('./percepts.js');
+    const heard = await readRecentCompanionPercepts({
+      modality: 'hearing',
+      limit,
+      ...(cwd ? { cwd } : {}),
+    });
+    return heard
+      .map((h) =>
+        String((h.payload as { text?: string })?.text ?? h.summary ?? '').replace(/^Heard:\s*/i, '')
+      )
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Default reflection — one JSON LLM call via the resolved command provider ($0 on ChatGPT-OAuth). */
+async function defaultReflect(heard: string[]): Promise<VoiceReflection | null> {
+  try {
+    const { resolveCommandProvider } = await import('../commands/llm-provider-resolution.js');
+    const resolved = resolveCommandProvider({});
+    if (!resolved) return null;
+    const { CodeBuddyClient } = await import('../codebuddy/client.js');
+    const client = new CodeBuddyClient(resolved.apiKey, resolved.model, resolved.baseURL);
+    const { generateJsonWithRetry } = await import('../utils/llm-retry.js');
+    const user = `Conversation récente (ce que la personne a dit) :\n${heard.map((h) => `- ${h}`).join('\n')}`;
+    const gen = (prompt: string): Promise<string> =>
+      client
+        .chat(
+          [
+            { role: 'system', content: REFLECT_SYSTEM },
+            { role: 'user', content: prompt },
+          ],
+          undefined,
+          { responseFormat: 'json' }
+        )
+        .then((r) => r?.choices?.[0]?.message?.content ?? '');
+    const parsed = await generateJsonWithRetry<unknown>(gen, user);
+    return normalizeReflection(parsed);
+  } catch (err) {
+    logger.info(
+      `[voice-improve] reflection unavailable: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+
+function defaultJournalPath(cwd?: string): string {
+  return join(cwd ?? homedir(), '.codebuddy', 'companion', 'voice-improvements.jsonl');
+}
+
+/** Append an audit line, rotating at 512 KB (mirrors dreaming/episodic-journal). Never throws. */
+function appendJournal(result: VoiceImprovementResult, cwd?: string): void {
+  try {
+    const path = defaultJournalPath(cwd);
+    mkdirSync(dirname(path), { recursive: true });
+    try {
+      if (statSync(path).size > 512 * 1024) renameSync(path, `${path}.1`);
+    } catch {
+      /* no file yet */
+    }
+    appendFileSync(path, `${JSON.stringify(result)}\n`);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Run one voice-assistant improvement cycle. Returns the result, or null when
+ * there was nothing to reflect on (too little heard / no LLM). Never throws.
+ */
+export async function runVoiceImprovementCycle(
+  deps: VoiceImprovementDeps = {}
+): Promise<VoiceImprovementResult | null> {
+  const now = deps.now ?? Date.now();
+  const mode: VoiceImprovementMode = deps.mode ?? 'behavioral';
+  const heard = await (deps.readHeard ?? defaultReadHeard)(deps.limit ?? 20, deps.cwd);
+  // Need a couple of real utterances to say anything useful.
+  if (heard.length < 2) return null;
+
+  const reflection = await (deps.reflect ?? defaultReflect)(heard);
+  if (!reflection) return null;
+
+  const result: VoiceImprovementResult = {
+    at: now,
+    heardCount: heard.length,
+    reflection,
+    proposedFacts: [],
+    acceptedFacts: [],
+    guidanceApplied: false,
+    driftApplied: false,
+  };
+
+  // 1. Facts → propose into the privacy-screened user model (pending). Accept
+  //    ONLY in mode 'all' (an explicit human --apply); the heartbeat never accepts.
+  if (reflection.facts.length > 0) {
+    try {
+      const { getUserModel } = await import('../memory/user-model.js');
+      const model = getUserModel(deps.cwd ?? process.cwd());
+      for (const fact of reflection.facts) {
+        try {
+          const { observation, deduped } = model.observe({
+            kind: 'preference',
+            content: fact,
+            source: 'self_observed',
+            confidence: 0.6,
+          });
+          if (!deduped) result.proposedFacts.push(fact);
+          if (mode === 'all') {
+            model.accept(observation.id, {
+              reviewedBy: 'voice-improve-loop',
+              reviewNote: 'accepté via `buddy assistant improve --apply`',
+            });
+            result.acceptedFacts.push(fact);
+          }
+        } catch {
+          /* privacy screen refused this fact, or already accepted — skip it */
+        }
+      }
+    } catch {
+      /* user model unavailable — skip facts */
+    }
+  }
+
+  // 2. Guidance → bounded, reversible store (applied in 'behavioral' and 'all').
+  if (reflection.guidance && mode !== 'dry') {
+    try {
+      const path = deps.guidancePath ?? defaultVoiceGuidancePath();
+      const next = addVoiceGuidance(reflection.guidance, now, loadVoiceGuidance(path));
+      saveVoiceGuidance(next, path);
+      result.guidanceApplied = true;
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // 3. Signal → bounded trait drift (anti-ratchet), applied in 'behavioral' and 'all'.
+  if (mode !== 'dry') {
+    try {
+      const state = loadRelationshipState(deps.relationshipStatePath);
+      saveRelationshipState(evolveTraits(state, reflection.signal), deps.relationshipStatePath);
+      result.driftApplied = true;
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  appendJournal(result, deps.cwd);
+  logger.info(
+    `[voice-improve] cycle: ${heard.length} heard → ${reflection.facts.length} fact(s), ` +
+      `guidance=${result.guidanceApplied ? 'yes' : 'no'}, signal=${reflection.signal}, mode=${mode}`
+  );
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3122,6 +3122,11 @@ addLazyCommandGroup(program, 'speak', 'Synthesize speech using AudioReader TTS',
   registerSpeakCommand(program);
 });
 
+addLazyCommandGroup(program, 'assistant', 'Manage the voice assistant (Lisa): improvement loop, voice', async () => {
+  const { registerAssistantCommand } = await import('./commands/assistant.js');
+  registerAssistantCommand(program);
+});
+
 // Utility commands (doctor, security-audit, onboard, webhook) are all registered
 // by a single registerUtilityCommands() call, so we must remove all stubs before
 // re-registering to avoid Commander duplicate command errors.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1380,6 +1380,21 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
             });
             logger.info(`Episodic journal: Enabled (CODEBUDDY_EPISODE_JOURNAL) — dialogue consolidation every ${episodeEvery} beats`);
           }
+          // Voice-assistant improvement loop (opt-in, MySoulmate-inspired) — reflect on recent
+          // dialogue and adapt over time: learned reply-guidance + bounded trait drift (behavioral
+          // mode; never auto-accepts personal facts — those stay pending for `buddy assistant improve --apply`).
+          if (process.env.CODEBUDDY_VOICE_IMPROVE === 'true') {
+            const improveEvery = Math.max(1, Number(process.env.CODEBUDDY_VOICE_IMPROVE_EVERY ?? 60));
+            heart.register({
+              name: 'voice-improvement',
+              everyBeats: improveEvery,
+              handler: async () => {
+                const { runVoiceImprovementCycle } = await import('../companion/voice-improvement-loop.js');
+                await runVoiceImprovementCycle({ mode: 'behavioral' });
+              },
+            });
+            logger.info(`Voice improvement loop: Enabled (CODEBUDDY_VOICE_IMPROVE) — reflect + adapt every ${improveEvery} beats (behavioral; facts stay pending)`);
+          }
           heart.start();
           sensoryTeardown.push(() => heart.stop());
           logger.info(`Sensory bridge: Enabled (buddy-sense → event bus; heartbeat treatments every ${everyBeats} beats)`);

--- a/tests/companion/voice-guidance.test.ts
+++ b/tests/companion/voice-guidance.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Voice guidance store tests — pure add/dedup/cap + format + round-trip.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addVoiceGuidance,
+  formatVoiceGuidance,
+  loadVoiceGuidance,
+  saveVoiceGuidance,
+  MAX_VOICE_GUIDANCE,
+  type VoiceGuidanceItem,
+} from '../../src/companion/voice-guidance.js';
+
+describe('addVoiceGuidance', () => {
+  it('adds newest-first', () => {
+    const a = addVoiceGuidance('un', 1, []);
+    const b = addVoiceGuidance('deux', 2, a);
+    expect(b.map((x) => x.text)).toEqual(['deux', 'un']);
+  });
+
+  it('dedups case-insensitively (moves to front)', () => {
+    const list = addVoiceGuidance('Réponds court', 2, [{ text: 'réponds court', at: 1 }]);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toEqual({ text: 'Réponds court', at: 2 });
+  });
+
+  it('caps at MAX_VOICE_GUIDANCE', () => {
+    let list: VoiceGuidanceItem[] = [];
+    for (let i = 0; i < MAX_VOICE_GUIDANCE + 3; i++) list = addVoiceGuidance(`g${i}`, i, list);
+    expect(list).toHaveLength(MAX_VOICE_GUIDANCE);
+    expect(list[0].text).toBe(`g${MAX_VOICE_GUIDANCE + 2}`); // newest kept
+  });
+
+  it('is a no-op for empty/whitespace', () => {
+    expect(addVoiceGuidance('   ', 1, [{ text: 'x', at: 0 }])).toEqual([{ text: 'x', at: 0 }]);
+  });
+});
+
+describe('formatVoiceGuidance', () => {
+  it('returns null when empty', () => {
+    expect(formatVoiceGuidance([])).toBeNull();
+  });
+
+  it('renders a <voice_guidance> block', () => {
+    const s = formatVoiceGuidance([{ text: 'Réponds en une phrase.', at: 1 }]);
+    expect(s).toContain('<voice_guidance>');
+    expect(s).toContain('- Réponds en une phrase.');
+    expect(s).toContain('</voice_guidance>');
+  });
+});
+
+describe('load/save round-trip', () => {
+  it('persists and reloads', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vg-'));
+    const path = join(dir, 'voice-guidance.json');
+    saveVoiceGuidance([{ text: 'aller droit au but', at: 5 }], path);
+    expect(loadVoiceGuidance(path)).toEqual([{ text: 'aller droit au but', at: 5 }]);
+  });
+
+  it('returns [] for a missing file', () => {
+    expect(loadVoiceGuidance(join(tmpdir(), 'nope-does-not-exist.json'))).toEqual([]);
+  });
+});

--- a/tests/companion/voice-improvement-loop.test.ts
+++ b/tests/companion/voice-improvement-loop.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Voice-assistant improvement loop tests — pure reflection normalization + the
+ * cycle with injected heard/reflect and isolated temp stores (no LLM, no daemon).
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  normalizeReflection,
+  runVoiceImprovementCycle,
+  type VoiceReflection,
+} from '../../src/companion/voice-improvement-loop.js';
+import { loadVoiceGuidance } from '../../src/companion/voice-guidance.js';
+import { getUserModel, resetUserModels } from '../../src/memory/user-model.js';
+
+describe('normalizeReflection', () => {
+  it('keeps valid fields, caps facts at 3', () => {
+    const r = normalizeReflection({
+      facts: ['a', 'b', 'c', 'd'],
+      guidance: 'Réponds court.',
+      signal: 'joking',
+    });
+    expect(r.facts).toEqual(['a', 'b', 'c']);
+    expect(r.guidance).toBe('Réponds court.');
+    expect(r.signal).toBe('joking');
+  });
+
+  it('coerces an invalid/absent signal to neutral', () => {
+    expect(normalizeReflection({ signal: 'ecstatic' }).signal).toBe('neutral');
+    expect(normalizeReflection({}).signal).toBe('neutral');
+  });
+
+  it('drops empty/oversized facts and non-arrays', () => {
+    expect(normalizeReflection({ facts: ['ok', '  ', 'x'.repeat(200)] }).facts).toEqual(['ok']);
+    expect(normalizeReflection({ facts: 'nope' }).facts).toEqual([]);
+  });
+});
+
+describe('runVoiceImprovementCycle', () => {
+  const reflection: VoiceReflection = {
+    facts: ['préfère des réponses courtes'],
+    guidance: 'Réponds en une à deux phrases.',
+    signal: 'joking',
+  };
+  const heard = async (): Promise<string[]> => ['salut', 'raconte-moi une blague'];
+  const reflect = async (): Promise<VoiceReflection> => reflection;
+
+  beforeEach(() => resetUserModels());
+
+  function tmp() {
+    const dir = mkdtempSync(join(tmpdir(), 'vil-'));
+    return {
+      cwd: dir,
+      guidancePath: join(dir, 'voice-guidance.json'),
+      relationshipStatePath: join(dir, 'relationship-state.json'),
+    };
+  }
+
+  it('returns null when there is too little heard', async () => {
+    const res = await runVoiceImprovementCycle({ readHeard: async () => ['un seul'], reflect });
+    expect(res).toBeNull();
+  });
+
+  it('dry mode: reports but persists nothing and never accepts facts', async () => {
+    const t = tmp();
+    const res = await runVoiceImprovementCycle({ mode: 'dry', readHeard: heard, reflect, ...t });
+    expect(res).not.toBeNull();
+    expect(res!.guidanceApplied).toBe(false);
+    expect(res!.acceptedFacts).toEqual([]);
+    expect(loadVoiceGuidance(t.guidancePath)).toEqual([]);
+    expect(getUserModel(t.cwd).getStats().byStatus.accepted).toBe(0);
+  });
+
+  it('behavioral mode: applies guidance + drift, proposes facts but does NOT accept them', async () => {
+    const t = tmp();
+    const res = await runVoiceImprovementCycle({
+      mode: 'behavioral',
+      readHeard: heard,
+      reflect,
+      ...t,
+    });
+    expect(res!.guidanceApplied).toBe(true);
+    expect(res!.driftApplied).toBe(true);
+    expect(loadVoiceGuidance(t.guidancePath)[0]?.text).toBe('Réponds en une à deux phrases.');
+    const stats = getUserModel(t.cwd).getStats();
+    expect(stats.byStatus.accepted).toBe(0); // heartbeat never accepts
+    expect(stats.byStatus.pending).toBeGreaterThan(0); // proposed, pending review
+  });
+
+  it('all mode: accepts the proposed facts (explicit human --apply)', async () => {
+    const t = tmp();
+    const res = await runVoiceImprovementCycle({ mode: 'all', readHeard: heard, reflect, ...t });
+    expect(res!.acceptedFacts).toEqual(['préfère des réponses courtes']);
+    expect(getUserModel(t.cwd).getStats().byStatus.accepted).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Quoi
Une **boucle réflexive** qui rend Lisa meilleure conversationnellement **au fil du temps** (inspiration MySoulmate : apprend les préférences/le ton, mémoire court→long terme, traits qui évoluent) — au lieu de traiter chaque tour de parole isolément.

**Un cycle** : lit le dialogue entendu récent → **1 appel LLM de réflexion ($0)** → 3 apprentissages, chacun sur son palier de sûreté :
| Apprentissage | Destination | Palier |
|---|---|---|
| **guidance** (« garde des réponses courtes ») | store borné/réversible `voice-guidance.ts` (cap 5), **injecté dans les réponses** via `buildRelationalContext` | bas — auto |
| **signal** (ton de la conversation) | **dérive BORNÉE** des traits (`evolveTraits`, anti-ratchet) | bas — auto |
| **facts** (préférences de travail durables) | **PROPOSÉS** dans le `user-model` privacy-screened (pending) | perso — **jamais** auto-accepté |

**Modes** : `dry` (rapport), `behavioral` (guidance+dérive ; défaut heartbeat, **sans** écriture de faits perso), `all` (accepte les faits ; CLI `--apply` = revue humaine explicite).

## Surfaces
- **Heartbeat** (opt-in `CODEBUDDY_VOICE_IMPROVE`, `_EVERY` défaut 60) — mode behavioral, wiré dans `src/server/index.ts` (patron dreaming/episodic-journal).
- **CLI** `buddy assistant improve [--apply] [--limit N]`.
- **Injection** : `buildRelationalContext` gagne un bloc `<voice_guidance>` (actif avec `CODEBUDDY_COMPANION_RELATIONAL=true`).

Compose l'existant (percepts `hearing`, `LocalUserModel` review-gated, `relationship-state`, `buildRelationalContext`) + mirroir du gate self-improvement. Opt-in défaut-off, jamais d'écriture dans `src/`, réversible, never-throws.

## Preuves
- **Live ($0)** : `buddy assistant improve` a lu la vraie conversation du daemon et extrait des préférences réelles (« prépare du contenu foot en français », « scripts courts type vidéo sociale ») + une consigne + le ton — en dry-run, rien enregistré.
- **24 tests** (normalizeReflection, store guidance cap/dedup/format, cycle dry/behavioral/all avec deps injectées + stores tmp), `tsc` 0, `eslint` 0, non-régression `relational-context` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)