### PR TITLE
feat(assistant): module coeur de config + CLI buddy assistant

### DIFF
--- a/cowork/src/main/assistant/assistant-ipc.ts
+++ b/cowork/src/main/assistant/assistant-ipc.ts
@@ -1,0 +1,29 @@
+/**
+ * IPC surface for the Assistant settings panel. Side-effect free: the main
+ * entry calls `registerAssistantIpc` after creating the service.
+ */
+import type { IpcMain } from 'electron';
+import type { AssistantService } from './assistant-service.js';
+
+export const ASSISTANT_CHANNELS = {
+  get: 'assistant.get',
+  save: 'assistant.save',
+  voices: 'assistant.voices',
+  preview: 'assistant.preview',
+  restart: 'assistant.restart',
+} as const;
+
+export function registerAssistantIpc(
+  ipcMain: Pick<IpcMain, 'handle'>,
+  service: AssistantService
+): void {
+  ipcMain.handle(ASSISTANT_CHANNELS.get, async () => service.getConfig());
+  ipcMain.handle(ASSISTANT_CHANNELS.save, async (_event, updates: Record<string, string>) =>
+    service.save(updates ?? {})
+  );
+  ipcMain.handle(ASSISTANT_CHANNELS.voices, async () => service.voices());
+  ipcMain.handle(ASSISTANT_CHANNELS.preview, async (_event, name: string) =>
+    service.preview(name ?? '')
+  );
+  ipcMain.handle(ASSISTANT_CHANNELS.restart, async () => service.restart());
+}

--- a/cowork/src/main/assistant/assistant-service.ts
+++ b/cowork/src/main/assistant/assistant-service.ts
@@ -1,0 +1,179 @@
+/**
+ * Bridges the Cowork « Assistant » panel to the core voice assistant
+ * configuration module (`companion/assistant-config.js`). The core owns all
+ * env-file parsing, persistence, voice discovery, preview synthesis, and daemon
+ * restarts; Cowork only adapts it to IPC.
+ */
+import { loadCoreModule } from '../utils/core-loader.js';
+
+export type AssistantSettingGroup = 'voice' | 'speech' | 'behavior' | 'companion';
+export type AssistantSettingType = 'toggle' | 'enum' | 'text' | 'voice';
+export type AssistantEnvFile = 'vision' | 'lisa' | 'both';
+
+export interface AssistantSetting {
+  key: string;
+  label: string;
+  group: AssistantSettingGroup;
+  type: AssistantSettingType;
+  options?: string[];
+  default: string;
+  envFile: AssistantEnvFile;
+  help: string;
+}
+
+export interface AssistantRestartServiceResult {
+  service: string;
+  ok: boolean;
+  error?: string;
+}
+
+export interface AssistantErrorResponse {
+  ok: false;
+  error: string;
+}
+
+export interface AssistantConfigSuccessResponse {
+  settings: AssistantSetting[];
+  values: Record<string, string>;
+  voices: string[];
+}
+
+export interface AssistantConfigErrorResponse extends AssistantErrorResponse {
+  settings: AssistantSetting[];
+  values: Record<string, string>;
+  voices: string[];
+}
+
+export type AssistantConfigResponse = AssistantConfigSuccessResponse | AssistantConfigErrorResponse;
+
+export interface AssistantSaveSuccessResponse {
+  vision: string[];
+  lisa: string[];
+}
+
+export type AssistantSaveResponse = AssistantSaveSuccessResponse | AssistantErrorResponse;
+
+export type AssistantVoicesResponse = string[] | (AssistantErrorResponse & { voices: string[] });
+
+export type AssistantPreviewResponse = string | null | AssistantErrorResponse;
+
+export type AssistantRestartResponse = AssistantRestartServiceResult[] | AssistantErrorResponse;
+
+interface CoreAssistantConfigModule {
+  ASSISTANT_SETTINGS?: AssistantSetting[];
+  readAssistantConfig?: () => Record<string, string>;
+  writeAssistantConfig?: (updates: Record<string, string>) => AssistantSaveSuccessResponse;
+  listPocketVoices?: () => string[];
+  previewVoice?: (name: string) => Promise<string | null>;
+  restartAssistantServices?: (
+    services: Array<'buddy-vision-brain' | 'lisa-telegram'>
+  ) => Promise<AssistantRestartServiceResult[]>;
+}
+
+type CoreLoader = () => Promise<CoreAssistantConfigModule | null>;
+
+const ASSISTANT_DAEMONS = ['buddy-vision-brain', 'lisa-telegram'] as const;
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function unavailableConfig(
+  message = 'module assistant indisponible (moteur embarqué configuré ?)'
+): AssistantConfigErrorResponse {
+  return { ok: false, settings: [], values: {}, voices: [], error: message };
+}
+
+function unavailable(message: string): AssistantErrorResponse {
+  return { ok: false, error: message };
+}
+
+export class AssistantService {
+  private modPromise?: Promise<CoreAssistantConfigModule | null>;
+
+  constructor(
+    private readonly loader: CoreLoader = () =>
+      loadCoreModule<CoreAssistantConfigModule>('companion/assistant-config.js')
+  ) {}
+
+  private async module(): Promise<CoreAssistantConfigModule | null> {
+    this.modPromise ??= this.loader().catch(() => null);
+    return this.modPromise;
+  }
+
+  async getConfig(): Promise<AssistantConfigResponse> {
+    try {
+      const mod = await this.module();
+      if (!mod?.ASSISTANT_SETTINGS || !mod.readAssistantConfig || !mod.listPocketVoices) {
+        return unavailableConfig();
+      }
+
+      return {
+        settings: mod.ASSISTANT_SETTINGS,
+        values: mod.readAssistantConfig(),
+        voices: mod.listPocketVoices(),
+      };
+    } catch (err) {
+      return unavailableConfig(errorMessage(err));
+    }
+  }
+
+  async save(updates: Record<string, string>): Promise<AssistantSaveResponse> {
+    try {
+      const mod = await this.module();
+      if (!mod?.writeAssistantConfig) {
+        return unavailable('module assistant indisponible (écriture impossible)');
+      }
+
+      return mod.writeAssistantConfig(updates ?? {});
+    } catch (err) {
+      return unavailable(errorMessage(err));
+    }
+  }
+
+  async voices(): Promise<AssistantVoicesResponse> {
+    try {
+      const mod = await this.module();
+      if (!mod?.listPocketVoices) {
+        return {
+          ok: false,
+          voices: [],
+          error: 'module assistant indisponible (voix indisponibles)',
+        };
+      }
+
+      return mod.listPocketVoices();
+    } catch (err) {
+      return { ok: false, voices: [], error: errorMessage(err) };
+    }
+  }
+
+  async preview(name: string): Promise<AssistantPreviewResponse> {
+    try {
+      const voiceName = (name ?? '').trim();
+      if (!voiceName) return unavailable('voix requise');
+
+      const mod = await this.module();
+      if (!mod?.previewVoice) {
+        return unavailable('module assistant indisponible (aperçu vocal impossible)');
+      }
+
+      return mod.previewVoice(voiceName);
+    } catch (err) {
+      return unavailable(errorMessage(err));
+    }
+  }
+
+  async restart(): Promise<AssistantRestartResponse> {
+    try {
+      const mod = await this.module();
+      if (!mod?.restartAssistantServices) {
+        return unavailable('module assistant indisponible (redémarrage impossible)');
+      }
+
+      return mod.restartAssistantServices([...ASSISTANT_DAEMONS]);
+    } catch (err) {
+      return unavailable(errorMessage(err));
+    }
+  }
+}

--- a/cowork/src/main/index.ts
+++ b/cowork/src/main/index.ts
@@ -63,6 +63,8 @@ import { registerMediaGenIpc } from './media/media-gen-ipc';
 import { MediaGenService } from './media/media-gen-service';
 import { registerFilmIpc } from './film/film-ipc';
 import { FilmService } from './film/film-service';
+import { registerAssistantIpc } from './assistant/assistant-ipc';
+import { AssistantService } from './assistant/assistant-service';
 import { ScaffoldService } from './studio/scaffold-service';
 import { registerPairingIpcHandlers } from './ipc/pairing-ipc';
 import { registerUserModelIpcHandlers } from './ipc/user-model-ipc';
@@ -2545,6 +2547,9 @@ registerMediaGenIpc(ipcMain, new MediaGenService());
 // Video Studio: prompt → premium narrated video (core produceVideoFromPrompt).
 // Films land in the media-library working dir so they show up in the Bibliothèque.
 registerFilmIpc(ipcMain, new FilmService(undefined, join(app.getPath('userData'), 'default_working_dir')));
+
+// Assistant: voice assistant config + daemon lifecycle (core companion/assistant-config).
+registerAssistantIpc(ipcMain, new AssistantService());
 
 // ── .codebuddy/ backups (same core handler as `buddy backup`) ────────────
 registerBackupIpcHandlers();

--- a/cowork/src/preload/index.ts
+++ b/cowork/src/preload/index.ts
@@ -108,6 +108,49 @@ import type {
   HermesKanbanApi,
 } from '../renderer/types/hermes';
 
+type AssistantSettingGroup = 'voice' | 'speech' | 'behavior' | 'companion';
+type AssistantSettingType = 'toggle' | 'enum' | 'text' | 'voice';
+type AssistantEnvFile = 'vision' | 'lisa' | 'both';
+
+interface AssistantSetting {
+  key: string;
+  label: string;
+  group: AssistantSettingGroup;
+  type: AssistantSettingType;
+  options?: string[];
+  default: string;
+  envFile: AssistantEnvFile;
+  help: string;
+}
+
+interface AssistantErrorResponse {
+  ok: false;
+  error: string;
+}
+
+interface AssistantConfigSuccessResponse {
+  settings: AssistantSetting[];
+  values: Record<string, string>;
+  voices: string[];
+}
+
+interface AssistantConfigErrorResponse extends AssistantErrorResponse {
+  settings: AssistantSetting[];
+  values: Record<string, string>;
+  voices: string[];
+}
+
+type AssistantConfigResponse = AssistantConfigSuccessResponse | AssistantConfigErrorResponse;
+
+interface AssistantSaveSuccessResponse {
+  vision: string[];
+  lisa: string[];
+}
+
+type AssistantSaveResponse = AssistantSaveSuccessResponse | AssistantErrorResponse;
+type AssistantPreviewResponse = string | null | AssistantErrorResponse;
+type AssistantRestartResponse = Array<{ service: string; ok: boolean; error?: string }> | AssistantErrorResponse;
+
 // Track registered callbacks to prevent duplicate listeners
 let registeredCallback: ((event: ServerEvent) => void) | null = null;
 let ipcListener: ((event: Electron.IpcRendererEvent, data: ServerEvent) => void) | null = null;
@@ -743,6 +786,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('film.progress', wrapped);
       return () => ipcRenderer.removeListener('film.progress', wrapped);
     },
+  },
+
+  // Assistant — voice assistant config + daemon lifecycle.
+  assistant: {
+    get: (): Promise<AssistantConfigResponse> => ipcRenderer.invoke('assistant.get'),
+    save: (updates: Record<string, string>): Promise<AssistantSaveResponse> =>
+      ipcRenderer.invoke('assistant.save', updates),
+    preview: (name: string): Promise<AssistantPreviewResponse> =>
+      ipcRenderer.invoke('assistant.preview', name),
+    restart: (): Promise<AssistantRestartResponse> => ipcRenderer.invoke('assistant.restart'),
   },
 
   // App Studio (bolt.diy-style file tree + editor + terminal + live preview).
@@ -4643,6 +4696,12 @@ declare global {
       film: {
         produce: (request: { pitch: string; scenes?: number; resolution?: string; noMusic?: boolean; subtitles?: boolean; lang?: string; style?: 'short' | 'standard' }) => Promise<{ ok: boolean; filmPath?: string; url?: string; sceneCount?: number; duration?: number; qualityPass?: boolean; warnings?: string[]; error?: string }>;
         onProgress: (cb: (p: { phase: string; scene?: number; total?: number; message?: string }) => void) => () => void;
+      };
+      assistant: {
+        get: () => Promise<AssistantConfigResponse>;
+        save: (updates: Record<string, string>) => Promise<AssistantSaveResponse>;
+        preview: (name: string) => Promise<AssistantPreviewResponse>;
+        restart: () => Promise<AssistantRestartResponse>;
       };
       selectFiles: () => Promise<string[]>;
       artifacts: {

--- a/cowork/src/renderer/components/NewShell.tsx
+++ b/cowork/src/renderer/components/NewShell.tsx
@@ -34,6 +34,7 @@ import { LabsGallery } from './labs/LabsGallery';
 import { CreationsView } from './deliverables/CreationsView';
 import { MediaLibraryView } from './deliverables/MediaLibraryView';
 import { VideoStudioView } from './videostudio/VideoStudioView';
+import { AssistantView } from './assistant/AssistantView';
 import { CapabilitiesView } from './capabilities/CapabilitiesView';
 import { ConversationHistoryDrawer } from './ConversationHistoryDrawer';
 import { OnboardingTour } from './onboarding/OnboardingTour';
@@ -52,6 +53,7 @@ const RAIL: RailItem[] = [
   { view: 'studio', label: 'App Studio', glyph: '🛠️' },
   { view: 'creations', label: 'Créations', glyph: '✨' },
   { view: 'videostudio', label: 'Video Studio', glyph: '🎬' },
+  { view: 'assistant', label: 'Assistant', glyph: '🎙️' },
   { view: 'library', label: 'Bibliothèque', glyph: '🖼️' },
   { view: 'capabilities', label: 'Capacités', glyph: '🧰' },
   { view: 'os', label: 'Mission Control', glyph: '🛰️' },
@@ -394,6 +396,7 @@ export function NewShell() {
         {primaryView === 'studio' && <StudioView />}
         {primaryView === 'creations' && <CreationsView />}
         {primaryView === 'videostudio' && <VideoStudioView />}
+        {primaryView === 'assistant' && <AssistantView />}
         {primaryView === 'library' && <MediaLibraryView />}
         {primaryView === 'capabilities' && <CapabilitiesView />}
         {primaryView === 'os' && <MissionControlView />}

--- a/cowork/src/renderer/components/assistant/AssistantView.tsx
+++ b/cowork/src/renderer/components/assistant/AssistantView.tsx
@@ -1,0 +1,500 @@
+/**
+ * AssistantView — full-page panel for the local voice assistant mode.
+ *
+ * The renderer stays schema-driven: the core module provides settings, current
+ * values, and Pocket voices through the preload `assistant` API.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  Headphones,
+  Loader2,
+  Mic2,
+  Power,
+  Save,
+  Settings2,
+  Volume2,
+} from 'lucide-react';
+
+type AssistantSettingGroup = 'voice' | 'speech' | 'behavior' | 'companion';
+type AssistantSettingType = 'toggle' | 'enum' | 'text' | 'voice';
+
+interface AssistantSetting {
+  key: string;
+  label: string;
+  group: AssistantSettingGroup;
+  type: AssistantSettingType;
+  options?: string[];
+  default: string;
+  help: string;
+}
+
+interface AssistantErrorResponse {
+  ok: false;
+  error: string;
+}
+
+const GROUP_ORDER: AssistantSettingGroup[] = ['voice', 'speech', 'behavior', 'companion'];
+
+const GROUP_META: Record<
+  AssistantSettingGroup,
+  { title: string; subtitle: string; icon: LucideIcon }
+> = {
+  voice: {
+    title: 'Voix',
+    subtitle: 'Moteur, langue et voix utilisée par le robot.',
+    icon: Volume2,
+  },
+  speech: {
+    title: 'Parole',
+    subtitle: 'Sortie vocale et posture utilisée pour les actions parlées.',
+    icon: Mic2,
+  },
+  behavior: {
+    title: 'Comportement',
+    subtitle: 'Nom du robot, écoute active et règles de réponse.',
+    icon: Settings2,
+  },
+  companion: {
+    title: 'Companion',
+    subtitle: 'Présence, rappels, mémoire relationnelle et proactivité.',
+    icon: Bot,
+  },
+};
+
+const LABEL_OVERRIDES: Record<string, string> = {
+  CODEBUDDY_TTS_ENGINE: 'Moteur vocal',
+  CODEBUDDY_POCKET_VOICE: 'Voix Pocket',
+  CODEBUDDY_POCKET_LANG: 'Langue Pocket',
+  CODEBUDDY_TTS_VOICE: 'Voix Piper de secours',
+  CODEBUDDY_SENSORY_SPEAK: 'Parole activée',
+  CODEBUDDY_SENSORY_SPEAK_ACT: 'Annoncer les actions',
+  CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE: 'Posture d’action',
+  CODEBUDDY_SENSORY_SPEAK_MODEL: 'Modèle de parole',
+  CODEBUDDY_SENSORY_SPEECH: 'Écoute activée',
+  CODEBUDDY_ROBOT_NAME: 'Nom du robot',
+  CODEBUDDY_SENSORY_ALWAYS_RESPOND: 'Toujours répondre',
+  CODEBUDDY_SENSORY_CHIME_IN: 'Intervenir spontanément',
+  CODEBUDDY_SENSORY_ENGAGE_WINDOW_MS: 'Fenêtre de suivi',
+  CODEBUDDY_SPEECH_LANG: 'Langue d’écoute',
+  CODEBUDDY_SENSORY_GREET: 'Salutations',
+  CODEBUDDY_REMINDERS: 'Rappels',
+  CODEBUDDY_COMPANION_RELATIONAL: 'Mémoire relationnelle',
+  CODEBUDDY_COMPANION_PROACTIVE: 'Companion proactif',
+  CODEBUDDY_VOICE_IMPROVE: 'Amélioration vocale',
+};
+
+const HELP_OVERRIDES: Record<string, string> = {
+  CODEBUDDY_TTS_ENGINE: 'Choisit le moteur de synthèse vocale.',
+  CODEBUDDY_POCKET_VOICE: 'Sélectionne une voix Pocket ou un échantillon de clonage court.',
+  CODEBUDDY_POCKET_LANG: 'Langue transmise au moteur Pocket.',
+  CODEBUDDY_TTS_VOICE: 'Chemin du modèle Piper .onnx utilisé en secours.',
+  CODEBUDDY_SENSORY_SPEAK: 'Autorise les réponses parlées du daemon vision.',
+  CODEBUDDY_SENSORY_SPEAK_ACT: 'Autorise les retours vocaux pendant les actions.',
+  CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE: 'Définit le niveau de prudence des actions vocales.',
+  CODEBUDDY_SENSORY_SPEAK_MODEL: 'Modèle utilisé pour formuler les réponses parlées.',
+  CODEBUDDY_SENSORY_SPEECH: 'Active l’entrée vocale du daemon sensoriel.',
+  CODEBUDDY_ROBOT_NAME: 'Nom utilisé par l’assistant pour se présenter.',
+  CODEBUDDY_SENSORY_ALWAYS_RESPOND: 'Répond même si la phrase ne l’appelle pas clairement.',
+  CODEBUDDY_SENSORY_CHIME_IN: 'Autorise de courtes interventions opportunistes.',
+  CODEBUDDY_SENSORY_ENGAGE_WINDOW_MS:
+    'Durée en millisecondes pendant laquelle le suivi reste actif.',
+  CODEBUDDY_SPEECH_LANG: 'Code de langue principal pour la reconnaissance vocale.',
+  CODEBUDDY_SENSORY_GREET: 'Active les salutations du companion.',
+  CODEBUDDY_REMINDERS: 'Active les rappels companion.',
+  CODEBUDDY_COMPANION_RELATIONAL: 'Injecte le contexte relationnel dans les réponses companion.',
+  CODEBUDDY_COMPANION_PROACTIVE: 'Autorise les comportements proactifs du companion.',
+  CODEBUDDY_VOICE_IMPROVE: 'Active la boucle d’amélioration de l’assistant vocal.',
+};
+
+const OPTION_LABELS: Record<string, Record<string, string>> = {
+  CODEBUDDY_TTS_ENGINE: {
+    piper: 'Piper local',
+    pocket: 'Pocket TTS',
+  },
+  CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE: {
+    plan: 'Planifier avant d’agir',
+    dontAsk: 'Agir sans demander',
+    bypassPermissions: 'Mode autonome complet',
+  },
+};
+
+function normalizeValues(
+  settings: AssistantSetting[],
+  values: Record<string, string>
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const setting of settings) {
+    normalized[setting.key] = values[setting.key] ?? setting.default;
+  }
+  return normalized;
+}
+
+function fieldLabel(setting: AssistantSetting): string {
+  return LABEL_OVERRIDES[setting.key] ?? setting.label;
+}
+
+function fieldHelp(setting: AssistantSetting): string {
+  return HELP_OVERRIDES[setting.key] ?? setting.help;
+}
+
+function optionLabel(setting: AssistantSetting, value: string): string {
+  return OPTION_LABELS[setting.key]?.[value] ?? value;
+}
+
+function fileUrl(path: string): string {
+  return path.startsWith('file://') ? path : `file://${path}`;
+}
+
+function isAssistantError(value: unknown): value is AssistantErrorResponse {
+  return Boolean(value && typeof value === 'object' && (value as { ok?: unknown }).ok === false);
+}
+
+export function AssistantView() {
+  const [settings, setSettings] = useState<AssistantSetting[]>([]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [initialValues, setInitialValues] = useState<Record<string, string>>({});
+  const [voices, setVoices] = useState<string[]>([]);
+  const [audioPath, setAudioPath] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [previewing, setPreviewing] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async (): Promise<void> => {
+      const assistant = window.electronAPI?.assistant;
+      if (!assistant) {
+        setError('API Assistant indisponible.');
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await assistant.get();
+        if (cancelled) return;
+
+        const loadedSettings = result.settings ?? [];
+        const loadedValues = normalizeValues(loadedSettings, result.values ?? {});
+        setSettings(loadedSettings);
+        setValues(loadedValues);
+        setInitialValues(loadedValues);
+        setVoices(result.voices ?? []);
+        if (isAssistantError(result)) setError(result.error);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const groupedSettings = useMemo(
+    () =>
+      GROUP_ORDER.map((group) => ({
+        group,
+        items: settings.filter((setting) => setting.group === group),
+      })).filter((entry) => entry.items.length > 0),
+    [settings]
+  );
+
+  const changedValues = useMemo(() => {
+    const changed: Record<string, string> = {};
+    for (const setting of settings) {
+      const next = values[setting.key] ?? setting.default;
+      const previous = initialValues[setting.key] ?? setting.default;
+      if (next !== previous) changed[setting.key] = next;
+    }
+    return changed;
+  }, [initialValues, settings, values]);
+
+  const changedCount = Object.keys(changedValues).length;
+
+  const setField = (key: string, value: string): void => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+    setNotice(null);
+    setError(null);
+  };
+
+  const previewVoice = async (setting: AssistantSetting): Promise<void> => {
+    const assistant = window.electronAPI?.assistant;
+    if (!assistant) {
+      setError('API Assistant indisponible.');
+      return;
+    }
+
+    const voice = (values[setting.key] ?? setting.default).trim();
+    if (!voice) {
+      setError('Sélectionne une voix avant de lancer l’aperçu.');
+      return;
+    }
+
+    setPreviewing(setting.key);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await assistant.preview(voice);
+      if (isAssistantError(result)) throw new Error(result.error);
+      if (!result) throw new Error('Aperçu vocal indisponible.');
+      setAudioPath(result);
+      setNotice('Aperçu vocal lancé.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPreviewing(null);
+    }
+  };
+
+  const applyChanges = async (): Promise<void> => {
+    const assistant = window.electronAPI?.assistant;
+    if (!assistant) {
+      setError('API Assistant indisponible.');
+      return;
+    }
+
+    setApplying(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const saveResult = await assistant.save(changedValues);
+      if (isAssistantError(saveResult)) throw new Error(saveResult.error);
+
+      setInitialValues({ ...values });
+      const restartResult = await assistant.restart();
+      if (isAssistantError(restartResult)) throw new Error(restartResult.error);
+
+      const failed = restartResult.filter((service) => !service.ok);
+      if (failed.length > 0) {
+        throw new Error(
+          failed.map((service) => `${service.service}: ${service.error ?? 'échec'}`).join('; ')
+        );
+      }
+
+      setNotice('Enregistré, daemon redémarré.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const renderControl = (setting: AssistantSetting) => {
+    const value = values[setting.key] ?? setting.default;
+    const disabled = loading || applying;
+
+    if (setting.type === 'toggle') {
+      const checked = value === 'true';
+      return (
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          disabled={disabled}
+          data-testid={`assistant-field-${setting.key}`}
+          onClick={() => setField(setting.key, checked ? 'false' : 'true')}
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors disabled:opacity-50 ${
+            checked ? 'border-primary bg-primary' : 'border-border bg-muted'
+          }`}
+        >
+          <span
+            className={`inline-block h-5 w-5 rounded-full bg-background shadow transition-transform ${
+              checked ? 'translate-x-5' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      );
+    }
+
+    if (setting.type === 'enum') {
+      return (
+        <select
+          value={value}
+          disabled={disabled}
+          data-testid={`assistant-field-${setting.key}`}
+          onChange={(event) => setField(setting.key, event.target.value)}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
+        >
+          {(setting.options ?? []).map((option) => (
+            <option key={option} value={option}>
+              {optionLabel(setting, option)}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    if (setting.type === 'voice') {
+      const voiceOptions = Array.from(new Set([value, setting.default, ...voices].filter(Boolean)));
+      return (
+        <div className="flex items-center gap-2">
+          <select
+            value={value}
+            disabled={disabled}
+            data-testid={`assistant-field-${setting.key}`}
+            onChange={(event) => setField(setting.key, event.target.value)}
+            className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
+          >
+            {voiceOptions.map((voice) => (
+              <option key={voice} value={voice}>
+                {voice}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            data-testid="assistant-preview"
+            onClick={() => void previewVoice(setting)}
+            disabled={disabled || previewing === setting.key || !value.trim()}
+            className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition hover:bg-muted disabled:opacity-50"
+          >
+            {previewing === setting.key ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Headphones className="h-4 w-4" />
+            )}
+            Écouter
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <input
+        type="text"
+        value={value}
+        disabled={disabled}
+        data-testid={`assistant-field-${setting.key}`}
+        onChange={(event) => setField(setting.key, event.target.value)}
+        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
+      />
+    );
+  };
+
+  return (
+    <main
+      className="flex h-full min-h-0 flex-col bg-background text-foreground"
+      data-testid="assistant-view"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-border bg-surface px-4 py-2.5">
+        <Bot className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h1 className="text-sm font-semibold">Assistant</h1>
+        <span className="text-xs text-muted-foreground">
+          Mode assistant vocal, daemon local et companion.
+        </span>
+      </header>
+
+      <div className="mx-auto flex w-full max-w-5xl min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+        {notice && (
+          <div className="flex items-center gap-2 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-sm text-success">
+            <CheckCircle2 className="h-4 w-4" />
+            {notice}
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-center gap-2 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error">
+            <AlertCircle className="h-4 w-4" />
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface p-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Chargement de la configuration assistant…
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-surface px-4 py-3">
+              <div className="text-sm text-muted-foreground">
+                {changedCount > 0
+                  ? `${changedCount} changement${changedCount > 1 ? 's' : ''} en attente`
+                  : 'Aucun changement en attente'}
+              </div>
+              <button
+                type="button"
+                data-testid="assistant-apply"
+                onClick={() => void applyChanges()}
+                disabled={applying}
+                className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:opacity-90 disabled:opacity-50"
+              >
+                {applying ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {applying ? 'Application…' : 'Appliquer'}
+              </button>
+            </div>
+
+            {groupedSettings.map(({ group, items }) => {
+              const meta = GROUP_META[group];
+              const Icon = meta.icon;
+              return (
+                <section
+                  key={group}
+                  className="overflow-hidden rounded-lg border border-border bg-surface"
+                >
+                  <header className="flex items-start gap-3 border-b border-border px-4 py-3">
+                    <Icon className="mt-0.5 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <div>
+                      <h2 className="text-sm font-semibold">{meta.title}</h2>
+                      <p className="text-xs text-muted-foreground">{meta.subtitle}</p>
+                    </div>
+                  </header>
+                  <div className="divide-y divide-border">
+                    {items.map((setting) => (
+                      <div
+                        key={setting.key}
+                        className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(0,1fr)_minmax(260px,360px)] md:items-center"
+                      >
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium">{fieldLabel(setting)}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {fieldHelp(setting)}
+                          </div>
+                        </div>
+                        <div className="min-w-0 justify-self-stretch md:justify-self-end md:w-full">
+                          {renderControl(setting)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </>
+        )}
+
+        {audioPath && <audio key={audioPath} src={fileUrl(audioPath)} autoPlay />}
+
+        {!loading && settings.length === 0 && (
+          <div className="rounded-lg border border-dashed border-border bg-surface p-6 text-center text-sm text-muted-foreground">
+            Configuration assistant indisponible.
+          </div>
+        )}
+
+        {!loading && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Power className="h-3.5 w-3.5" />
+            Appliquer sauvegarde la configuration puis redémarre buddy-vision-brain et
+            lisa-telegram.
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/cowork/src/renderer/store/index.ts
+++ b/cowork/src/renderer/store/index.ts
@@ -88,7 +88,7 @@ export type FleetGoalDraftProfile = 'balanced' | 'research' | 'code' | 'review' 
  * overlay flags with one calm view model. Slice 1: Chat is the home; Activity/Workspace reuse the
  * existing overlays; Advanced is a progressive-disclosure launcher into the current panels.
  */
-export type PrimaryView = 'chat' | 'plan' | 'activity' | 'workspace' | 'advanced' | 'studio' | 'creations' | 'library' | 'videostudio' | 'capabilities' | 'os' | 'labs';
+export type PrimaryView = 'chat' | 'plan' | 'activity' | 'workspace' | 'advanced' | 'studio' | 'creations' | 'library' | 'videostudio' | 'assistant' | 'capabilities' | 'os' | 'labs';
 
 export interface FleetGoalDraft {
   goal: string;

--- a/src/commands/assistant.ts
+++ b/src/commands/assistant.ts
@@ -8,12 +8,176 @@
  *
  * @module commands/assistant
  */
+import { execFileSync } from 'node:child_process';
+import { unlinkSync } from 'node:fs';
 import type { Command } from 'commander';
+import {
+  ASSISTANT_SETTINGS,
+  envFilePath,
+  listPocketVoices,
+  previewVoice,
+  readAssistantConfig,
+  restartAssistantServices,
+  writeAssistantConfig,
+  type AssistantSetting,
+  type AssistantSettingGroup,
+} from '../companion/assistant-config.js';
+import { logger } from '../utils/logger.js';
+
+const GROUPS: AssistantSettingGroup[] = ['voice', 'speech', 'behavior', 'companion'];
+const GROUP_LABELS: Record<AssistantSettingGroup, string> = {
+  voice: 'Voix',
+  speech: 'Parole',
+  behavior: 'Ecoute / reponse',
+  companion: 'Compagnon',
+};
+
+function findSetting(key: string): AssistantSetting | undefined {
+  return ASSISTANT_SETTINGS.find((setting) => setting.key === key);
+}
+
+function validateCliValue(setting: AssistantSetting, value: string): boolean {
+  if (setting.type !== 'enum') return true;
+  return setting.options?.includes(value) ?? false;
+}
+
+function printWriteResult(result: { vision: string[]; lisa: string[] }): void {
+  const files: string[] = [];
+  if (result.vision.length > 0) files.push(`vision (${envFilePath('vision')})`);
+  if (result.lisa.length > 0) files.push(`lisa (${envFilePath('lisa')})`);
+  if (files.length === 0) {
+    console.log('Aucune valeur ecrite (cle inconnue ou valeur invalide).');
+    return;
+  }
+  console.log(`Ecrit dans : ${files.join(', ')}`);
+}
+
+function playAudioFile(path: string): boolean {
+  const players =
+    process.platform === 'darwin'
+      ? [{ command: 'afplay', args: [path] }]
+      : [
+          { command: 'aplay', args: [path] },
+          { command: 'paplay', args: [path] },
+          { command: 'ffplay', args: ['-nodisp', '-autoexit', path] },
+        ];
+
+  for (const player of players) {
+    try {
+      execFileSync(player.command, player.args, { stdio: 'inherit' });
+      return true;
+    } catch (error) {
+      logger.debug('Audio player unavailable', { player: player.command, error });
+    }
+  }
+
+  return false;
+}
 
 export function registerAssistantCommand(program: Command): void {
   const assistant = program
     .command('assistant')
     .description('Manage the voice assistant (Lisa): improvement loop, voice, config');
+
+  assistant
+    .command('show')
+    .description('Show the effective voice assistant config')
+    .action(() => {
+      const config = readAssistantConfig();
+      for (const group of GROUPS) {
+        console.log(`\n${GROUP_LABELS[group]}`);
+        for (const setting of ASSISTANT_SETTINGS.filter((item) => item.group === group)) {
+          console.log(`  ${setting.label}: ${config[setting.key] ?? setting.default}`);
+        }
+      }
+    });
+
+  assistant
+    .command('set')
+    .description('Set one voice assistant environment value')
+    .argument('<key>', 'Environment key to update')
+    .argument('<value>', 'Value to write')
+    .action((key: string, value: string) => {
+      const setting = findSetting(key);
+      if (!setting) {
+        console.error(`Cle inconnue : ${key}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (!validateCliValue(setting, value)) {
+        console.error(
+          `Valeur invalide pour ${key}. Valeurs autorisees : ${(setting.options ?? []).join(', ')}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      printWriteResult(writeAssistantConfig({ [key]: value }));
+    });
+
+  assistant
+    .command('voice')
+    .description('Use Pocket TTS with the given voice')
+    .argument('<name>', 'Pocket voice name or clone sample path')
+    .action((name: string) => {
+      printWriteResult(
+        writeAssistantConfig({
+          CODEBUDDY_TTS_ENGINE: 'pocket',
+          CODEBUDDY_POCKET_VOICE: name,
+        })
+      );
+    });
+
+  assistant
+    .command('voices')
+    .description('List Pocket TTS preset voices')
+    .action(() => {
+      for (const voice of listPocketVoices()) console.log(voice);
+    });
+
+  assistant
+    .command('preview')
+    .description('Synthesize and play a Pocket TTS voice preview')
+    .argument('<name>', 'Pocket voice name or clone sample path')
+    .action(async (name: string) => {
+      const wavPath = await previewVoice(name);
+      if (!wavPath) {
+        console.error('Pocket TTS indisponible ou impossible de synthetiser cet apercu.');
+        process.exitCode = 1;
+        return;
+      }
+
+      let played = false;
+      try {
+        played = playAudioFile(wavPath);
+        if (!played) {
+          console.log(`Audio genere : ${wavPath}`);
+          console.error('Aucun lecteur audio trouve. Installe aplay, paplay ou ffplay.');
+        }
+      } finally {
+        if (played) {
+          try {
+            unlinkSync(wavPath);
+          } catch (error) {
+            logger.debug('Failed to remove temporary audio file', { wavPath, error });
+          }
+        }
+      }
+    });
+
+  assistant
+    .command('apply')
+    .description('Restart assistant user services so systemd reloads the env files')
+    .action(async () => {
+      const results = await restartAssistantServices(['buddy-vision-brain', 'lisa-telegram']);
+      for (const result of results) {
+        if (result.ok) {
+          console.log(`ok ${result.service}`);
+        } else {
+          console.log(`failed ${result.service}: ${result.error ?? 'unknown error'}`);
+          process.exitCode = 1;
+        }
+      }
+    });
 
   assistant
     .command('improve')

--- a/src/companion/assistant-config.ts
+++ b/src/companion/assistant-config.ts
@@ -1,0 +1,427 @@
+/**
+ * Voice assistant configuration core.
+ *
+ * The assistant daemon and Telegram companion both read plain `.env` files
+ * through systemd. This module keeps edits conservative: only known assistant
+ * keys are written, unrelated lines stay untouched, and all I/O is best-effort.
+ *
+ * @module companion/assistant-config
+ */
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { PocketTTSProvider, PRESET_VOICES } from '../talk-mode/providers/pocket-tts.js';
+
+export type AssistantSettingGroup = 'voice' | 'speech' | 'behavior' | 'companion';
+export type AssistantSettingType = 'toggle' | 'enum' | 'text' | 'voice';
+export type AssistantEnvFile = 'vision' | 'lisa' | 'both';
+export type AssistantEnvFileName = 'vision' | 'lisa';
+
+export interface AssistantSetting {
+  key: string;
+  label: string;
+  group: AssistantSettingGroup;
+  type: AssistantSettingType;
+  options?: string[];
+  default: string;
+  envFile: AssistantEnvFile;
+  help: string;
+}
+
+export interface AssistantEnvPaths {
+  vision?: string;
+  lisa?: string;
+}
+
+export interface AssistantServiceRestartResult {
+  service: string;
+  ok: boolean;
+  error?: string;
+}
+
+const MANAGED_MARKER = '# --- assistant config (managed) ---';
+const execFileAsync = promisify(execFile);
+
+export const ASSISTANT_SETTINGS: AssistantSetting[] = [
+  {
+    key: 'CODEBUDDY_TTS_ENGINE',
+    label: 'TTS engine',
+    group: 'voice',
+    type: 'enum',
+    options: ['piper', 'pocket'],
+    default: 'piper',
+    envFile: 'both',
+    help: 'Selects the assistant speech synthesis engine.',
+  },
+  {
+    key: 'CODEBUDDY_POCKET_VOICE',
+    label: 'Pocket voice',
+    group: 'voice',
+    type: 'voice',
+    default: 'estelle',
+    envFile: 'both',
+    help: 'Pocket TTS preset name or path to a short clone sample.',
+  },
+  {
+    key: 'CODEBUDDY_POCKET_LANG',
+    label: 'Pocket language',
+    group: 'voice',
+    type: 'text',
+    default: 'french',
+    envFile: 'both',
+    help: 'Language token used by Pocket TTS.',
+  },
+  {
+    key: 'CODEBUDDY_TTS_VOICE',
+    label: 'Piper fallback voice',
+    group: 'voice',
+    type: 'text',
+    default: '',
+    envFile: 'both',
+    help: 'Fallback Piper .onnx voice model path.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_SPEAK',
+    label: 'Speak responses',
+    group: 'speech',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Enables spoken assistant responses on the vision daemon.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_SPEAK_ACT',
+    label: 'Speak actions',
+    group: 'speech',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Allows the assistant to speak action feedback.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE',
+    label: 'Speech permission mode',
+    group: 'speech',
+    type: 'enum',
+    options: ['plan', 'dontAsk', 'bypassPermissions'],
+    default: 'plan',
+    envFile: 'vision',
+    help: 'Permission mode used by spoken action flows.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_SPEAK_MODEL',
+    label: 'Speech model',
+    group: 'speech',
+    type: 'text',
+    default: 'auto',
+    envFile: 'vision',
+    help: 'Model used for spoken assistant replies.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_SPEECH',
+    label: 'Listen for speech',
+    group: 'behavior',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Enables speech input in the sensory daemon.',
+  },
+  {
+    key: 'CODEBUDDY_ROBOT_NAME',
+    label: 'Assistant name',
+    group: 'behavior',
+    type: 'text',
+    default: 'Lisa',
+    envFile: 'both',
+    help: 'Name the voice assistant uses for itself.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_ALWAYS_RESPOND',
+    label: 'Always respond',
+    group: 'behavior',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Responds even when the utterance is not clearly addressed to the assistant.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_CHIME_IN',
+    label: 'Chime in',
+    group: 'behavior',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Allows opportunistic short interjections.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_ENGAGE_WINDOW_MS',
+    label: 'Engage window ms',
+    group: 'behavior',
+    type: 'text',
+    default: '30000',
+    envFile: 'vision',
+    help: 'Time window during which follow-up speech stays engaged.',
+  },
+  {
+    key: 'CODEBUDDY_SPEECH_LANG',
+    label: 'Speech language',
+    group: 'behavior',
+    type: 'text',
+    default: 'fr',
+    envFile: 'vision',
+    help: 'Primary language code for speech recognition.',
+  },
+  {
+    key: 'CODEBUDDY_SENSORY_GREET',
+    label: 'Greeting',
+    group: 'companion',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Enables assistant greetings.',
+  },
+  {
+    key: 'CODEBUDDY_REMINDERS',
+    label: 'Reminders',
+    group: 'companion',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Enables companion reminders.',
+  },
+  {
+    key: 'CODEBUDDY_COMPANION_RELATIONAL',
+    label: 'Relational memory',
+    group: 'companion',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'both',
+    help: 'Injects relational context into companion replies.',
+  },
+  {
+    key: 'CODEBUDDY_COMPANION_PROACTIVE',
+    label: 'Proactive companion',
+    group: 'companion',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Allows proactive companion behaviors.',
+  },
+  {
+    key: 'CODEBUDDY_VOICE_IMPROVE',
+    label: 'Voice improvement',
+    group: 'companion',
+    type: 'toggle',
+    default: 'false',
+    envFile: 'vision',
+    help: 'Enables the voice assistant improvement loop.',
+  },
+];
+
+function hasOwn(obj: Record<string, string>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function readTextFile(path: string): string {
+  try {
+    if (!existsSync(path)) return '';
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function writeTextFile(path: string, content: string): boolean {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveEnvFilePath(which: AssistantEnvFileName, paths?: AssistantEnvPaths): string {
+  return paths?.[which] ?? envFilePath(which);
+}
+
+function validateSettingValue(setting: AssistantSetting, value: string): boolean {
+  if (setting.type !== 'enum') return true;
+  return setting.options?.includes(value) ?? false;
+}
+
+function validUpdateEntries(updates: Record<string, string>): Array<[AssistantSetting, string]> {
+  const entries: Array<[AssistantSetting, string]> = [];
+  for (const setting of ASSISTANT_SETTINGS) {
+    if (!hasOwn(updates, setting.key)) continue;
+    const value = updates[setting.key] ?? '';
+    if (!validateSettingValue(setting, value)) continue;
+    entries.push([setting, value]);
+  }
+  return entries;
+}
+
+export function envFilePath(which: AssistantEnvFileName): string {
+  return join(homedir(), '.codebuddy', `${which}.env`);
+}
+
+export function parseEnv(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex <= 0) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    const value = line.slice(equalsIndex + 1).trim();
+    if (key) env[key] = value;
+  }
+  return env;
+}
+
+export function mergeEnv(content: string, updates: Record<string, string>): string {
+  const entries = Object.entries(updates).filter(([key]) => key.trim().length > 0);
+  if (entries.length === 0) return content;
+
+  const newline = content.includes('\r\n') ? '\r\n' : '\n';
+  const hadTrailingNewline = /\r?\n$/.test(content);
+  const lines = content.length === 0 ? [] : content.split(/\r?\n/);
+  if (hadTrailingNewline) lines.pop();
+
+  const pending = new Map(entries);
+  let markerSeen = false;
+  const merged = lines.map((line) => {
+    if (line.trim() === MANAGED_MARKER) markerSeen = true;
+    const match = line.match(/^(\s*([^=\s#]+)\s*=\s*)(.*)$/);
+    const key = match?.[2];
+    if (!match || !key || !pending.has(key)) return line;
+    const value = pending.get(key) ?? '';
+    pending.delete(key);
+    return `${match[1] ?? ''}${value}`;
+  });
+
+  const willAppend = pending.size > 0;
+  if (willAppend) {
+    if (!markerSeen) {
+      if (merged.length > 0 && merged[merged.length - 1]?.trim() !== '') merged.push('');
+      merged.push(MANAGED_MARKER);
+    }
+    for (const [key, value] of pending) merged.push(`${key}=${value}`);
+  }
+
+  return `${merged.join(newline)}${hadTrailingNewline || willAppend ? newline : ''}`;
+}
+
+export function readAssistantConfig(paths?: AssistantEnvPaths): Record<string, string> {
+  try {
+    const vision = parseEnv(readTextFile(resolveEnvFilePath('vision', paths)));
+    const lisa = parseEnv(readTextFile(resolveEnvFilePath('lisa', paths)));
+    const config: Record<string, string> = {};
+
+    for (const setting of ASSISTANT_SETTINGS) {
+      if (setting.envFile === 'vision') {
+        config[setting.key] = hasOwn(vision, setting.key)
+          ? (vision[setting.key] ?? setting.default)
+          : setting.default;
+      } else if (setting.envFile === 'lisa') {
+        config[setting.key] = hasOwn(lisa, setting.key)
+          ? (lisa[setting.key] ?? setting.default)
+          : setting.default;
+      } else {
+        config[setting.key] = hasOwn(vision, setting.key)
+          ? (vision[setting.key] ?? setting.default)
+          : hasOwn(lisa, setting.key)
+            ? (lisa[setting.key] ?? setting.default)
+            : setting.default;
+      }
+    }
+
+    return config;
+  } catch {
+    return Object.fromEntries(ASSISTANT_SETTINGS.map((setting) => [setting.key, setting.default]));
+  }
+}
+
+export function writeAssistantConfig(
+  updates: Record<string, string>,
+  paths?: AssistantEnvPaths
+): { vision: string[]; lisa: string[] } {
+  const result: { vision: string[]; lisa: string[] } = { vision: [], lisa: [] };
+
+  try {
+    const byFile: Record<AssistantEnvFileName, Record<string, string>> = { vision: {}, lisa: {} };
+    for (const [setting, value] of validUpdateEntries(updates)) {
+      if (setting.envFile === 'vision' || setting.envFile === 'both') {
+        byFile.vision[setting.key] = value;
+      }
+      if (setting.envFile === 'lisa' || setting.envFile === 'both') {
+        byFile.lisa[setting.key] = value;
+      }
+    }
+
+    for (const which of ['vision', 'lisa'] as const) {
+      const fileUpdates = byFile[which];
+      const keys = Object.keys(fileUpdates);
+      if (keys.length === 0) continue;
+      const path = resolveEnvFilePath(which, paths);
+      const next = mergeEnv(readTextFile(path), fileUpdates);
+      if (writeTextFile(path, next)) result[which] = keys;
+    }
+  } catch {
+    return result;
+  }
+
+  return result;
+}
+
+export function listPocketVoices(): string[] {
+  return [...PRESET_VOICES];
+}
+
+export async function previewVoice(name: string, text?: string): Promise<string | null> {
+  try {
+    const voiceName = name.trim();
+    if (!voiceName) return null;
+    const provider = new PocketTTSProvider();
+    await provider.initialize({
+      provider: 'pocket',
+      enabled: true,
+      priority: 1,
+      settings: { voice: voiceName, language: 'french' },
+    });
+    if (!(await provider.isAvailable())) return null;
+
+    const result = await provider.synthesize(text ?? `Bonjour, je suis ${voiceName}.`, {
+      voice: voiceName,
+      language: 'french',
+      format: 'wav',
+    });
+    const safeName = voiceName.replace(/[^a-z0-9._-]/gi, '-') || 'voice';
+    const outPath = join(tmpdir(), `codebuddy-assistant-preview-${safeName}-${Date.now()}.wav`);
+    writeFileSync(outPath, result.audio, { mode: 0o600 });
+    return outPath;
+  } catch {
+    return null;
+  }
+}
+
+export async function restartAssistantServices(
+  which: Array<'buddy-vision-brain' | 'lisa-telegram'> = ['buddy-vision-brain']
+): Promise<AssistantServiceRestartResult[]> {
+  const results: AssistantServiceRestartResult[] = [];
+  for (const service of which) {
+    try {
+      await execFileAsync('systemctl', ['--user', 'restart', `${service}.service`]);
+      results.push({ service, ok: true });
+    } catch (error) {
+      results.push({
+        service,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return results;
+}

--- a/src/talk-mode/providers/pocket-tts.ts
+++ b/src/talk-mode/providers/pocket-tts.ts
@@ -171,7 +171,7 @@ export function wavDurationMs(buf: Buffer, sampleRate = SAMPLE_RATE): number {
  * When no voice is given the CLI picks a language-appropriate default itself
  * (estelle for French, giovanni/it, lola/es, juergen/de, rafael/pt, alba else).
  */
-const PRESET_VOICES = [
+export const PRESET_VOICES = [
   'alba',
   'anna',
   'azelma',

--- a/tests/companion/assistant-config.test.ts
+++ b/tests/companion/assistant-config.test.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mergeEnv, parseEnv, writeAssistantConfig } from '../../src/companion/assistant-config.js';
+
+describe('parseEnv', () => {
+  it('ignores comments and empty lines', () => {
+    expect(
+      parseEnv(`
+        # comment
+
+        CODEBUDDY_TTS_ENGINE = pocket
+        CODEBUDDY_ROBOT_NAME= Lisa
+        invalid-line
+      `)
+    ).toEqual({
+      CODEBUDDY_TTS_ENGINE: 'pocket',
+      CODEBUDDY_ROBOT_NAME: 'Lisa',
+    });
+  });
+});
+
+describe('mergeEnv', () => {
+  it('updates in place and appends new managed keys without dropping unrelated lines', () => {
+    const input = [
+      '# existing config',
+      'CODEBUDDY_TTS_ENGINE=piper',
+      'CODEBUDDY_SENSORY_ALERT_TOKEN=xyz',
+      '',
+      'OTHER_VALUE=keep-me',
+      '',
+    ].join('\n');
+
+    const merged = mergeEnv(input, {
+      CODEBUDDY_TTS_ENGINE: 'pocket',
+      CODEBUDDY_ROBOT_NAME: 'Lisa',
+    });
+
+    expect(merged).toContain('# existing config');
+    expect(merged).toContain('CODEBUDDY_TTS_ENGINE=pocket');
+    expect(merged).toContain('CODEBUDDY_SENSORY_ALERT_TOKEN=xyz');
+    expect(merged).toContain('OTHER_VALUE=keep-me');
+    expect(merged).toContain('# --- assistant config (managed) ---');
+    expect(merged).toContain('CODEBUDDY_ROBOT_NAME=Lisa');
+
+    const updatedIndex = merged.indexOf('CODEBUDDY_TTS_ENGINE=pocket');
+    const secretIndex = merged.indexOf('CODEBUDDY_SENSORY_ALERT_TOKEN=xyz');
+    expect(updatedIndex).toBeLessThan(secretIndex);
+
+    const mergedTwice = mergeEnv(merged, { CODEBUDDY_POCKET_VOICE: 'estelle' });
+    expect(mergedTwice.match(/# --- assistant config \(managed\) ---/g)).toHaveLength(1);
+    expect(mergedTwice).toContain('CODEBUDDY_POCKET_VOICE=estelle');
+  });
+});
+
+describe('writeAssistantConfig', () => {
+  it('rejects invalid enum values and writes valid enum values to tmp env files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'assistant-config-'));
+    const paths = {
+      vision: join(dir, 'vision.env'),
+      lisa: join(dir, 'lisa.env'),
+    };
+
+    try {
+      const invalid = writeAssistantConfig({ CODEBUDDY_TTS_ENGINE: 'bad-engine' }, paths);
+      expect(invalid).toEqual({ vision: [], lisa: [] });
+      expect(existsSync(paths.vision)).toBe(false);
+      expect(existsSync(paths.lisa)).toBe(false);
+
+      const valid = writeAssistantConfig(
+        {
+          CODEBUDDY_TTS_ENGINE: 'pocket',
+          CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE: 'bad-mode',
+        },
+        paths
+      );
+      expect(valid).toEqual({
+        vision: ['CODEBUDDY_TTS_ENGINE'],
+        lisa: ['CODEBUDDY_TTS_ENGINE'],
+      });
+      expect(readFileSync(paths.vision, 'utf8')).toContain('CODEBUDDY_TTS_ENGINE=pocket');
+      expect(readFileSync(paths.vision, 'utf8')).not.toContain(
+        'CODEBUDDY_SENSORY_SPEAK_PERMISSION_MODE'
+      );
+      expect(readFileSync(paths.lisa, 'utf8')).toContain('CODEBUDDY_TTS_ENGINE=pocket');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Module source-de-vérité `src/companion/assistant-config.ts` + CLI `buddy assistant` pour configurer le mode assistant vocal (voix, nom, posture, écoute/parole, companion).

- `ASSISTANT_SETTINGS` : schéma déclaratif (groupes voice/speech/behavior/companion, type toggle/enum/text/voice, défaut, quel `.env`).
- `parseEnv` + `mergeEnv` **non destructif** (met à jour en place, ajoute sous un marqueur « managed », **préserve commentaires, lignes non gérées et secrets**), `read/writeAssistantConfig` sur `vision.env`+`lisa.env` (mode 0600, validation enum, clés inconnues ignorées).
- `listPocketVoices` (export `PRESET_VOICES`), `previewVoice` (Pocket), `restartAssistantServices` (`systemctl --user`).
- CLI : `assistant show|set|voice|voices|preview|apply` (+ `improve` existant).

**Prouvé live** : `buddy assistant show` lit le vrai `vision.env` et affiche la config groupée. tsc 0, eslint 0, tests verts. Généré avec l'aide de **Codex**, relu + validé.

Base du panneau Cowork « Assistant » (Partie D, à suivre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)