### PR TITLE
feat(assistant): champ de test éditable pour écouter la voix

### DIFF
--- a/cowork/src/main/assistant/assistant-ipc.ts
+++ b/cowork/src/main/assistant/assistant-ipc.ts
@@ -24,8 +24,8 @@ export function registerAssistantIpc(
     service.save(updates ?? {})
   );
   ipcMain.handle(ASSISTANT_CHANNELS.voices, async () => service.voices());
-  ipcMain.handle(ASSISTANT_CHANNELS.preview, async (_event, name: string) =>
-    service.preview(name ?? '')
+  ipcMain.handle(ASSISTANT_CHANNELS.preview, async (_event, name: string, text?: string) =>
+    service.preview(name ?? '', text)
   );
   ipcMain.handle(ASSISTANT_CHANNELS.restart, async () => service.restart());
   ipcMain.handle(ASSISTANT_CHANNELS.getVolume, async () => service.getVolume());

--- a/cowork/src/main/assistant/assistant-service.ts
+++ b/cowork/src/main/assistant/assistant-service.ts
@@ -64,7 +64,7 @@ interface CoreAssistantConfigModule {
   readAssistantConfig?: () => Record<string, string>;
   writeAssistantConfig?: (updates: Record<string, string>) => AssistantSaveSuccessResponse;
   listPocketVoices?: () => string[];
-  previewVoice?: (name: string) => Promise<string | null>;
+  previewVoice?: (name: string, text?: string) => Promise<string | null>;
   restartAssistantServices?: (
     services: Array<'buddy-vision-brain' | 'lisa-telegram'>
   ) => Promise<AssistantRestartServiceResult[]>;
@@ -153,7 +153,7 @@ export class AssistantService {
     }
   }
 
-  async preview(name: string): Promise<AssistantPreviewResponse> {
+  async preview(name: string, text?: string): Promise<AssistantPreviewResponse> {
     try {
       const voiceName = (name ?? '').trim();
       if (!voiceName) return unavailable('voix requise');
@@ -163,7 +163,8 @@ export class AssistantService {
         return unavailable('module assistant indisponible (aperçu vocal impossible)');
       }
 
-      return mod.previewVoice(voiceName);
+      const sample = (text ?? '').trim();
+      return mod.previewVoice(voiceName, sample || undefined);
     } catch (err) {
       return unavailable(errorMessage(err));
     }

--- a/cowork/src/preload/index.ts
+++ b/cowork/src/preload/index.ts
@@ -831,8 +831,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     get: (): Promise<AssistantConfigResponse> => ipcRenderer.invoke('assistant.get'),
     save: (updates: Record<string, string>): Promise<AssistantSaveResponse> =>
       ipcRenderer.invoke('assistant.save', updates),
-    preview: (name: string): Promise<AssistantPreviewResponse> =>
-      ipcRenderer.invoke('assistant.preview', name),
+    preview: (name: string, text?: string): Promise<AssistantPreviewResponse> =>
+      ipcRenderer.invoke('assistant.preview', name, text),
     restart: (): Promise<AssistantRestartResponse> => ipcRenderer.invoke('assistant.restart'),
     getVolume: (): Promise<AssistantVolumeResponse> => ipcRenderer.invoke('assistant.getVolume'),
     setVolume: (percent: number): Promise<AssistantSetVolumeResponse> =>
@@ -4886,9 +4886,7 @@ declare global {
         export: (
           sourcePath: string
         ) => Promise<{ ok: boolean; savedTo?: string; canceled?: boolean; error?: string }>;
-        exportMany: (
-          paths: string[]
-        ) => Promise<{
+        exportMany: (paths: string[]) => Promise<{
           ok: boolean;
           copied?: number;
           destDir?: string;
@@ -4925,7 +4923,7 @@ declare global {
       assistant: {
         get: () => Promise<AssistantConfigResponse>;
         save: (updates: Record<string, string>) => Promise<AssistantSaveResponse>;
-        preview: (name: string) => Promise<AssistantPreviewResponse>;
+        preview: (name: string, text?: string) => Promise<AssistantPreviewResponse>;
         restart: () => Promise<AssistantRestartResponse>;
         getVolume: () => Promise<AssistantVolumeResponse>;
         setVolume: (percent: number) => Promise<AssistantSetVolumeResponse>;
@@ -5601,10 +5599,7 @@ declare global {
           projectId?: string;
           recordSuggestions?: boolean;
         }) => Promise<{ ok: boolean; result?: CompanionMissionBoardSyncResult; error?: string }>;
-        listMissions: (input?: {
-          projectId?: string;
-          status?: CompanionMissionStatus;
-        }) => Promise<{
+        listMissions: (input?: { projectId?: string; status?: CompanionMissionStatus }) => Promise<{
           ok: boolean;
           board?: CompanionMissionBoard;
           items: CompanionMission[];
@@ -5667,19 +5662,13 @@ declare global {
         gatewayInbox: (
           projectId?: string
         ) => Promise<{ ok: boolean; inbox?: CompanionGatewayInbox; error?: string }>;
-        draftGatewayInboxItem: (input: {
-          projectId?: string;
-          itemId: string;
-        }) => Promise<{
+        draftGatewayInboxItem: (input: { projectId?: string; itemId: string }) => Promise<{
           ok: boolean;
           draft?: CompanionGatewayInboxDraft;
           inbox?: CompanionGatewayInbox;
           error?: string;
         }>;
-        routeGatewayDraftToFleet: (input: {
-          projectId?: string;
-          itemId: string;
-        }) => Promise<{
+        routeGatewayDraftToFleet: (input: { projectId?: string; itemId: string }) => Promise<{
           ok: boolean;
           fleetDraft?: CompanionGatewayFleetDraft;
           inbox?: CompanionGatewayInbox;

--- a/cowork/src/renderer/components/assistant/AssistantView.tsx
+++ b/cowork/src/renderer/components/assistant/AssistantView.tsx
@@ -164,6 +164,11 @@ export function AssistantView() {
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [volume, setVolume] = useState<number | null>(null);
+  // Editable sentence used by « Écouter ». Kept in sync with the core default
+  // (DEFAULT_VOICE_PREVIEW_TEXT) so the mount pre-warm hits the same cache entry.
+  const [previewText, setPreviewText] = useState(
+    'Bonjour ! Voici un aperçu de ma voix. Est-ce qu’elle te plaît ?'
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -257,7 +262,7 @@ export function AssistantView() {
     setError(null);
     setNotice(null);
     try {
-      const result = await assistant.preview(voice);
+      const result = await assistant.preview(voice, previewText);
       if (isAssistantError(result)) throw new Error(result.error);
       if (!result) throw new Error('Aperçu vocal indisponible.');
       // Play via a user-gesture-initiated Audio() so the autoplay policy never blocks it.
@@ -358,34 +363,51 @@ export function AssistantView() {
     if (setting.type === 'voice') {
       const voiceOptions = Array.from(new Set([value, setting.default, ...voices].filter(Boolean)));
       return (
-        <div className="flex items-center gap-2">
-          <select
-            value={value}
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <select
+              value={value}
+              disabled={disabled}
+              data-testid={`assistant-field-${setting.key}`}
+              onChange={(event) => setField(setting.key, event.target.value)}
+              className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
+            >
+              {voiceOptions.map((voice) => (
+                <option key={voice} value={voice}>
+                  {voice}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              data-testid="assistant-preview"
+              onClick={() => void previewVoice(setting)}
+              disabled={
+                disabled || previewing === setting.key || !value.trim() || !previewText.trim()
+              }
+              className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition hover:bg-muted disabled:opacity-50"
+            >
+              {previewing === setting.key ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Headphones className="h-4 w-4" />
+              )}
+              {previewing === setting.key ? 'Génération…' : 'Écouter'}
+            </button>
+          </div>
+          <textarea
+            value={previewText}
             disabled={disabled}
-            data-testid={`assistant-field-${setting.key}`}
-            onChange={(event) => setField(setting.key, event.target.value)}
-            className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
-          >
-            {voiceOptions.map((voice) => (
-              <option key={voice} value={voice}>
-                {voice}
-              </option>
-            ))}
-          </select>
-          <button
-            type="button"
-            data-testid="assistant-preview"
-            onClick={() => void previewVoice(setting)}
-            disabled={disabled || previewing === setting.key || !value.trim()}
-            className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition hover:bg-muted disabled:opacity-50"
-          >
-            {previewing === setting.key ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Headphones className="h-4 w-4" />
-            )}
-            Écouter
-          </button>
+            data-testid="assistant-preview-text"
+            onChange={(event) => setPreviewText(event.target.value)}
+            rows={2}
+            placeholder="Texte à faire dire pour tester la voix…"
+            className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50"
+          />
+          <p className="text-xs text-muted-foreground">
+            Texte de test — modifie-le puis clique « Écouter ». Le 1er aperçu prend quelques
+            secondes, les suivants sont instantanés.
+          </p>
         </div>
       );
     }

--- a/src/companion/assistant-config.ts
+++ b/src/companion/assistant-config.ts
@@ -380,20 +380,42 @@ export function listPocketVoices(): string[] {
   return [...PRESET_VOICES];
 }
 
+/** Default sentence used to test a voice (kept in sync with the Cowork panel's pre-fill). */
+export const DEFAULT_VOICE_PREVIEW_TEXT =
+  'Bonjour ! Voici un aperçu de ma voix. Est-ce qu’elle te plaît ?';
+
+/** Tiny stable string hash (djb2, base36) — for keying the preview cache on the text. Pure. */
+function hashText(text: string): string {
+  let h = 5381;
+  for (let i = 0; i < text.length; i++) h = ((h << 5) + h + text.charCodeAt(i)) >>> 0;
+  return h.toString(36);
+}
+
 /**
- * Stable on-disk path for a voice's preview sample. Same `safeName` scheme as
- * before, but persistent (not tmp) + keyed only on the voice name so re-listens
- * hit the cache. Pure/testable.
+ * Stable on-disk path for a voice's preview sample, keyed on BOTH the voice and
+ * the (hashed) test text so a custom sentence gets its own cache entry while the
+ * default sentence stays stable (prewarm-friendly). Pure/testable.
  */
-export function voicePreviewCachePath(name: string): string {
+export function voicePreviewCachePath(
+  name: string,
+  text: string = DEFAULT_VOICE_PREVIEW_TEXT
+): string {
   const safeName = name.trim().replace(/[^a-z0-9._-]/gi, '-') || 'voice';
-  return join(homedir(), '.codebuddy', 'companion', 'voice-previews', `${safeName}.wav`);
+  const effective = text.trim() || DEFAULT_VOICE_PREVIEW_TEXT;
+  return join(
+    homedir(),
+    '.codebuddy',
+    'companion',
+    'voice-previews',
+    `${safeName}-${hashText(effective)}.wav`
+  );
 }
 
 /**
  * Synthesize (or reuse) a short voice preview WAV, returning its path. Cached at
- * a stable path per voice so re-listening the same voice is instant (Pocket
- * `french_24l` costs ~4-8 s per synth on CPU). `force` regenerates. never-throws.
+ * a stable path per (voice, text) so re-listening the same sentence is instant
+ * (Pocket `french_24l` costs ~4-8 s per synth on CPU). `force` regenerates.
+ * never-throws.
  */
 export async function previewVoice(
   name: string,
@@ -403,9 +425,10 @@ export async function previewVoice(
   try {
     const voiceName = name.trim();
     if (!voiceName) return null;
-    const outPath = voicePreviewCachePath(voiceName);
+    const effectiveText = (text ?? '').trim() || DEFAULT_VOICE_PREVIEW_TEXT;
+    const outPath = voicePreviewCachePath(voiceName, effectiveText);
 
-    // Cache hit: a non-empty WAV already exists for this voice → return instantly.
+    // Cache hit: a non-empty WAV already exists for this voice+text → return instantly.
     if (!opts?.force) {
       try {
         if (existsSync(outPath) && statSync(outPath).size > 44) return outPath;
@@ -423,7 +446,7 @@ export async function previewVoice(
     });
     if (!(await provider.isAvailable())) return null;
 
-    const result = await provider.synthesize(text ?? `Bonjour, je suis ${voiceName}.`, {
+    const result = await provider.synthesize(effectiveText, {
       voice: voiceName,
       language: 'french',
       format: 'wav',

--- a/tests/companion/assistant-config.test.ts
+++ b/tests/companion/assistant-config.test.ts
@@ -10,12 +10,21 @@ import {
 } from '../../src/companion/assistant-config.js';
 
 describe('voicePreviewCachePath', () => {
-  it('builds a stable, sanitized path under ~/.codebuddy/companion/voice-previews', () => {
+  it('builds a sanitized path under ~/.codebuddy/companion/voice-previews, keyed on voice+text', () => {
     const p = voicePreviewCachePath('estelle');
-    expect(p).toMatch(/\.codebuddy\/companion\/voice-previews\/estelle\.wav$/);
-    // same voice → same path (cache key), unsafe chars sanitized
+    expect(p).toMatch(/\.codebuddy\/companion\/voice-previews\/estelle-[a-z0-9]+\.wav$/);
+    // default text → stable path (prewarm-friendly), unsafe chars sanitized
     expect(voicePreviewCachePath('estelle')).toBe(p);
-    expect(voicePreviewCachePath('a b/../c')).toMatch(/a-b-\.\.-c\.wav$/);
+    expect(voicePreviewCachePath('a b/../c')).toMatch(/a-b-\.\.-c-[a-z0-9]+\.wav$/);
+  });
+
+  it('gives a different cache entry for a different test sentence', () => {
+    expect(voicePreviewCachePath('estelle', 'un texte')).not.toBe(
+      voicePreviewCachePath('estelle', 'un autre texte')
+    );
+    expect(voicePreviewCachePath('estelle', 'même texte')).toBe(
+      voicePreviewCachePath('estelle', 'même texte')
+    );
   });
 });
 


### PR DESCRIPTION
« Écouter » utilise un **texte de test éditable** (pré-rempli) au lieu d'une phrase figée. Cache clé sur (voix + hash texte). Textarea sous le sélecteur de voix + hint. Prouvé live via CDP. tsc racine+cowork 0, eslint 0, 6 tests.