### PR TITLE
feat(companion): pré-génération de réponses courantes (latence quasi-nulle)

### DIFF
--- a/src/companion/prefetch-config.ts
+++ b/src/companion/prefetch-config.ts
@@ -1,0 +1,99 @@
+/**
+ * Prefetch config — the user-configurable list of "things to precompute" so the
+ * voice assistant can answer common questions INSTANTLY (no LLM round-trip).
+ *
+ * Each item names a cheap, recurring answer to keep warm: today's weather for a
+ * city, the day's news headlines, the reminder agenda, the date. A background
+ * heartbeat treatment recomputes them (prefetch-engine.ts) and the reply path
+ * serves the cached answer on a matching question.
+ *
+ * Stored as JSON under ~/.codebuddy/companion/ (voice-guidance.ts template):
+ * never-throws, env-overridable path, bounded.
+ *
+ * @module companion/prefetch-config
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export type PrefetchKind = 'weather' | 'news' | 'agenda' | 'date';
+export const PREFETCH_KINDS: readonly PrefetchKind[] = ['weather', 'news', 'agenda', 'date'];
+
+export interface PrefetchItem {
+  kind: PrefetchKind;
+  /** Weather → city name; news → optional query override; agenda/date → unused. */
+  param?: string;
+}
+
+/** Keep the list small — each item is a periodic network/compute cost. */
+export const MAX_PREFETCH_ITEMS = 12;
+
+/** Out-of-the-box list: only the free/local answers (no network, no keys). */
+export const DEFAULT_PREFETCH_ITEMS: PrefetchItem[] = [{ kind: 'date' }, { kind: 'agenda' }];
+
+export function defaultPrefetchItemsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.CODEBUDDY_PREFETCH_ITEMS_FILE?.trim() ||
+    join(homedir(), '.codebuddy', 'companion', 'prefetch-items.json')
+  );
+}
+
+/** A stable cache key for an item (weather is per-city; the rest are singletons). */
+export function prefetchItemKey(item: PrefetchItem): string {
+  const p = (item.param ?? '').trim().toLowerCase();
+  return item.kind === 'weather' && p ? `weather:${p}` : item.kind;
+}
+
+function isValidItem(x: unknown): x is PrefetchItem {
+  const o = x as PrefetchItem;
+  return !!o && (PREFETCH_KINDS as readonly string[]).includes(o.kind);
+}
+
+/**
+ * Load the configured items. Missing file → the DEFAULT list (first-run gets
+ * date+agenda); a saved list (even empty) is respected verbatim. never-throws.
+ */
+export function loadPrefetchItems(path: string = defaultPrefetchItemsPath()): PrefetchItem[] {
+  try {
+    if (!existsSync(path)) return [...DEFAULT_PREFETCH_ITEMS];
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    if (!Array.isArray(raw)) return [...DEFAULT_PREFETCH_ITEMS];
+    return raw
+      .filter(isValidItem)
+      .map((o) => ({ kind: o.kind, ...(o.param?.trim() ? { param: o.param.trim() } : {}) }))
+      .slice(0, MAX_PREFETCH_ITEMS);
+  } catch {
+    return [...DEFAULT_PREFETCH_ITEMS];
+  }
+}
+
+/** Persist the list (never-throws; creates the dir). */
+export function savePrefetchItems(
+  items: PrefetchItem[],
+  path: string = defaultPrefetchItemsPath()
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(items.slice(0, MAX_PREFETCH_ITEMS), null, 2));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Add an item (validated, deduped by key, capped). Pure on the input array. */
+export function addPrefetchItem(item: PrefetchItem, existing: PrefetchItem[] = []): PrefetchItem[] {
+  if (!isValidItem(item)) return existing;
+  const clean: PrefetchItem = {
+    kind: item.kind,
+    ...(item.param?.trim() ? { param: item.param.trim() } : {}),
+  };
+  const key = prefetchItemKey(clean);
+  const kept = existing.filter((x) => prefetchItemKey(x) !== key);
+  return [...kept, clean].slice(0, MAX_PREFETCH_ITEMS);
+}
+
+/** Remove the item at `index`. Pure. */
+export function removePrefetchItem(index: number, existing: PrefetchItem[] = []): PrefetchItem[] {
+  if (index < 0 || index >= existing.length) return existing;
+  return existing.filter((_, i) => i !== index);
+}

--- a/src/companion/prefetch-engine.ts
+++ b/src/companion/prefetch-engine.ts
@@ -1,0 +1,277 @@
+/**
+ * Prefetch engine — precompute answers to common voice questions so they can be
+ * served INSTANTLY (no LLM). A heartbeat treatment calls `runPrefetchCycle`
+ * periodically; the reply path (hybrid-reply.ts) calls `matchPrefetched` and, on
+ * a hit, returns the cached answer text directly (only the TTS synth remains).
+ *
+ * Reuses the real tools: WeatherTool (Open-Meteo, $0), WebSearchTool (headlines),
+ * reminders agenda, and an inline French date. All deps are injectable so the
+ * engine is unit-testable without network. never-throws.
+ *
+ * @module companion/prefetch-engine
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { logger } from '../utils/logger.js';
+import {
+  loadPrefetchItems,
+  prefetchItemKey,
+  type PrefetchItem,
+  type PrefetchKind,
+} from './prefetch-config.js';
+
+export interface PrefetchEntry {
+  key: string;
+  kind: PrefetchKind;
+  answer: string;
+  at: number;
+}
+
+/** Max age (ms) a cached answer stays servable, per kind. The heartbeat refreshes
+ *  far more often; this is just a staleness backstop. */
+const TTL_MS: Record<PrefetchKind, number> = {
+  weather: 45 * 60_000,
+  news: 4 * 60 * 60_000,
+  agenda: 6 * 60 * 60_000,
+  date: 12 * 60 * 60_000,
+};
+
+export interface PrefetchDeps {
+  now?: number;
+  cachePath?: string;
+  itemsPath?: string;
+  /** city → spoken weather text (null on failure). Default: WeatherTool. */
+  fetchWeather?: (city: string) => Promise<string | null>;
+  /** query → spoken headlines text. Default: WebSearchTool. */
+  fetchNews?: (query: string) => Promise<string | null>;
+  /** now → spoken agenda text. Default: reminders. */
+  fetchAgenda?: (now: number) => Promise<string | null>;
+  /** now → spoken French date. Default: inline. */
+  makeDate?: (now: number) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache store (JSON under ~/.codebuddy/companion/)
+// ---------------------------------------------------------------------------
+
+export function defaultPrefetchCachePath(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.CODEBUDDY_PREFETCH_CACHE_FILE?.trim() ||
+    join(homedir(), '.codebuddy', 'companion', 'prefetch-cache.json')
+  );
+}
+
+export function loadPrefetchCache(path: string = defaultPrefetchCachePath()): PrefetchEntry[] {
+  try {
+    if (!existsSync(path)) return [];
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return Array.isArray(raw) ? (raw as PrefetchEntry[]).filter((e) => e && e.key && e.answer) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function savePrefetchCache(
+  entries: PrefetchEntry[],
+  path: string = defaultPrefetchCachePath()
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(entries, null, 2));
+  } catch {
+    /* best-effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Intent matching (pure)
+// ---------------------------------------------------------------------------
+
+/** Lowercase + strip diacritics so STT accents don't break matching. Pure. */
+export function normalizeQuery(text: string): string {
+  return (text ?? '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}+/gu, '') // strip combining diacritics (accents)
+    .replace(/['’`\-_.,!?;:()]/g, ' ') // apostrophes/hyphens/punctuation → space (STT-robust)
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const KIND_PATTERNS: Record<PrefetchKind, RegExp> = {
+  weather: /\b(meteo|quel temps|le temps qu|temps qu il fait|il fait quel temps)\b/,
+  news: /\b(actualite|actualites|nouvelles|les infos|quoi de neuf|gros titres|l actu)\b/,
+  agenda:
+    /\b(agenda|mes rappels|mon programme|au programme|qu est ce que j ai|mes rendez|ma journee)\b/,
+  date: /\b(quel jour|quelle date|on est quel|le jour on est|date du jour|quel jour on est|on est le combien)\b/,
+};
+
+/**
+ * Which prefetch cache key a question wants, given the configured items (needed
+ * to resolve the weather city). Returns null when nothing matches. Pure.
+ */
+export function intentKeyForQuery(heard: string, items: PrefetchItem[]): string | null {
+  const q = normalizeQuery(heard);
+  if (!q) return null;
+
+  if (KIND_PATTERNS.weather.test(q)) {
+    const weatherItems = items.filter((i) => i.kind === 'weather');
+    if (weatherItems.length === 0) return null;
+    // Prefer a configured city whose name is spoken in the question.
+    const named = weatherItems.find((i) => i.param && q.includes(normalizeQuery(i.param)));
+    return prefetchItemKey(named ?? weatherItems[0]!);
+  }
+  for (const kind of ['news', 'agenda', 'date'] as const) {
+    if (KIND_PATTERNS[kind].test(q)) return kind;
+  }
+  return null;
+}
+
+/**
+ * Return a fresh cached answer for `heard`, or null. Pure over the injected
+ * cache + items (the reply path passes the loaded cache).
+ */
+export function matchPrefetched(
+  heard: string,
+  args: { cache: PrefetchEntry[]; items: PrefetchItem[]; now: number }
+): string | null {
+  const key = intentKeyForQuery(heard, args.items);
+  if (!key) return null;
+  const entry = args.cache.find((e) => e.key === key);
+  if (!entry) return null;
+  const ttl = TTL_MS[entry.kind] ?? 60 * 60_000;
+  return args.now - entry.at < ttl ? entry.answer : null;
+}
+
+// ---------------------------------------------------------------------------
+// Default compute impls (real tools, lazy-imported)
+// ---------------------------------------------------------------------------
+
+const FR_WEEKDAYS = ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'];
+const FR_MONTHS = [
+  'janvier',
+  'février',
+  'mars',
+  'avril',
+  'mai',
+  'juin',
+  'juillet',
+  'août',
+  'septembre',
+  'octobre',
+  'novembre',
+  'décembre',
+];
+
+export function frenchDate(now: number): string {
+  const d = new Date(now);
+  return `Nous sommes le ${FR_WEEKDAYS[d.getDay()]} ${d.getDate()} ${FR_MONTHS[d.getMonth()]} ${d.getFullYear()}.`;
+}
+
+async function defaultFetchWeather(city: string): Promise<string | null> {
+  try {
+    const { WeatherTool } = await import('../tools/weather.js');
+    const res = await new WeatherTool().getWeather(city || 'Paris', 1);
+    return res.success && res.output ? res.output.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultFetchNews(query: string): Promise<string | null> {
+  try {
+    const { WebSearchTool } = await import('../tools/web-search.js');
+    const rows = await new WebSearchTool().searchStructured(
+      query || "actualités France aujourd'hui gros titres",
+      {
+        maxResults: 5,
+        search_lang: 'fr',
+        freshness: 'pd',
+        mode: 'live',
+      }
+    );
+    const titles = (rows ?? [])
+      .map((r) => (r?.title ?? '').trim())
+      .filter(Boolean)
+      .slice(0, 5);
+    if (titles.length === 0) return null;
+    return `Voici les gros titres du jour : ${titles.join(' ; ')}.`;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultFetchAgenda(now: number): Promise<string | null> {
+  try {
+    const { loadReminders, agendaFor, describeAgendaForSpeech } = await import('./reminders.js');
+    const reminders = await loadReminders();
+    return describeAgendaForSpeech(agendaFor(reminders, now, 2), now);
+  } catch {
+    return null;
+  }
+}
+
+/** Compute the spoken answer for one item. Returns the cache entry, or null on failure. */
+export async function computeAnswer(
+  item: PrefetchItem,
+  deps: PrefetchDeps = {}
+): Promise<PrefetchEntry | null> {
+  const now = deps.now ?? Date.now();
+  const key = prefetchItemKey(item);
+  let answer: string | null = null;
+  try {
+    switch (item.kind) {
+      case 'weather':
+        answer = await (deps.fetchWeather ?? defaultFetchWeather)((item.param ?? '').trim());
+        break;
+      case 'news':
+        answer = await (deps.fetchNews ?? defaultFetchNews)((item.param ?? '').trim());
+        break;
+      case 'agenda':
+        answer = await (deps.fetchAgenda ?? defaultFetchAgenda)(now);
+        break;
+      case 'date':
+        answer = (deps.makeDate ?? frenchDate)(now);
+        break;
+    }
+  } catch {
+    answer = null;
+  }
+  const clean = (answer ?? '').trim();
+  return clean ? { key, kind: item.kind, answer: clean, at: now } : null;
+}
+
+export interface PrefetchCycleResult {
+  computed: string[];
+  failed: string[];
+}
+
+/**
+ * One prefetch cycle: recompute every configured item and merge into the cache
+ * (updating computed keys, preserving others). never-throws.
+ */
+export async function runPrefetchCycle(deps: PrefetchDeps = {}): Promise<PrefetchCycleResult> {
+  const items = loadPrefetchItems(deps.itemsPath);
+  const cachePath = deps.cachePath;
+  const cache = loadPrefetchCache(cachePath);
+  const byKey = new Map(cache.map((e) => [e.key, e]));
+  const result: PrefetchCycleResult = { computed: [], failed: [] };
+
+  for (const item of items) {
+    const entry = await computeAnswer(item, deps);
+    if (entry) {
+      byKey.set(entry.key, entry);
+      result.computed.push(entry.key);
+    } else {
+      result.failed.push(prefetchItemKey(item));
+    }
+  }
+
+  savePrefetchCache([...byKey.values()], cachePath);
+  logger.info(
+    `[prefetch] cycle: ${result.computed.length} prêt(s) [${result.computed.join(', ')}]` +
+      (result.failed.length ? `, ${result.failed.length} échec(s)` : '')
+  );
+  return result;
+}

--- a/src/sensory/hybrid-reply.ts
+++ b/src/sensory/hybrid-reply.ts
@@ -23,6 +23,26 @@
 import { logger } from '../utils/logger.js';
 import type { ReplyFn, VoiceStepOptions } from './voice-loop.js';
 import type { PermissionMode } from '../security/permission-modes.js';
+import { matchPrefetched, loadPrefetchCache } from '../companion/prefetch-engine.js';
+import { loadPrefetchItems } from '../companion/prefetch-config.js';
+
+/**
+ * Instant answer for a common question from the prefetch cache (weather, news,
+ * agenda, date) — no LLM. Opt-in via CODEBUDDY_PREFETCH; null when disabled or
+ * no fresh match. See companion/prefetch-engine.ts.
+ */
+function defaultPrefetchMatch(heard: string): string | null {
+  if (process.env.CODEBUDDY_PREFETCH !== 'true') return null;
+  try {
+    return matchPrefetched(heard, {
+      cache: loadPrefetchCache(),
+      items: loadPrefetchItems(),
+      now: Date.now(),
+    });
+  } catch {
+    return null;
+  }
+}
 
 export interface HybridTurn {
   role: 'user' | 'assistant';
@@ -48,6 +68,9 @@ export interface HybridReplyOptions {
   /** Spoken filler played BEFORE a (slower) agent turn, e.g. "d'accord, je regarde…", so a real
    *  question isn't met with dead silence. Only used by the default agent path. */
   ack?: (heard: string) => Promise<void>;
+  /** Injectable: instant precomputed answer for a common question (null ⇒ none).
+   *  Default: the prefetch cache when CODEBUDDY_PREFETCH is on. */
+  prefetch?: (heard: string) => string | null;
 }
 
 /** Lowercase + strip diacritics so STT accent loss ("ca va" ≈ "ça va") still matches. */
@@ -150,10 +173,11 @@ export function makeHybridReply(options: HybridReplyOptions = {}): ReplyFn {
       if (process.env.CODEBUDDY_COMPANION_RELATIONAL === 'true') {
         try {
           const { detectRelationalSignal } = await import('../companion/reply-augment.js');
-          const { loadRelationshipState, saveRelationshipState, evolveTraits } = await import(
-            '../companion/relationship-state.js'
+          const { loadRelationshipState, saveRelationshipState, evolveTraits } =
+            await import('../companion/relationship-state.js');
+          saveRelationshipState(
+            evolveTraits(loadRelationshipState(), detectRelationalSignal(heard))
           );
-          saveRelationshipState(evolveTraits(loadRelationshipState(), detectRelationalSignal(heard)));
         } catch {
           /* trait drift is optional — never block a reply */
         }
@@ -163,6 +187,13 @@ export function makeHybridReply(options: HybridReplyOptions = {}): ReplyFn {
       if (fast) {
         remember(heard, fast);
         return fast;
+      }
+      // Instant precomputed answer for a common question (weather/news/agenda/date) — no LLM.
+      const pre = (options.prefetch ?? defaultPrefetchMatch)(heard);
+      if (pre) {
+        remember(heard, pre);
+        logger.info(`[voice-hybrid] prefetch → ${pre.slice(0, 60)}`);
+        return pre;
       }
       const substantive = classify(heard);
       const stepOpts = signal ? { signal } : undefined;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1395,6 +1395,18 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
             });
             logger.info(`Voice improvement loop: Enabled (CODEBUDDY_VOICE_IMPROVE) — reflect + adapt every ${improveEvery} beats (behavioral; facts stay pending)`);
           }
+          // Prefetch (opt-in) — precompute common answers (weather/news/agenda/date) so the voice
+          // assistant serves them INSTANTLY (no LLM). Refreshed every N beats + once at startup.
+          if (process.env.CODEBUDDY_PREFETCH === 'true') {
+            const prefetchEvery = Math.max(1, Number(process.env.CODEBUDDY_PREFETCH_EVERY ?? 120));
+            const runPrefetch = async (): Promise<void> => {
+              const { runPrefetchCycle } = await import('../companion/prefetch-engine.js');
+              await runPrefetchCycle();
+            };
+            heart.register({ name: 'prefetch', everyBeats: prefetchEvery, handler: () => runPrefetch() });
+            void runPrefetch(); // warm the cache immediately, don't wait for the first beat
+            logger.info(`Prefetch: Enabled (CODEBUDDY_PREFETCH) — precompute common answers every ${prefetchEvery} beats`);
+          }
           heart.start();
           sensoryTeardown.push(() => heart.stop());
           logger.info(`Sensory bridge: Enabled (buddy-sense → event bus; heartbeat treatments every ${everyBeats} beats)`);

--- a/tests/companion/prefetch.test.ts
+++ b/tests/companion/prefetch.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Prefetch config + engine tests — pure matching/compute with injected deps and
+ * isolated temp stores (no network, no daemon).
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addPrefetchItem,
+  loadPrefetchItems,
+  prefetchItemKey,
+  removePrefetchItem,
+  savePrefetchItems,
+  DEFAULT_PREFETCH_ITEMS,
+  type PrefetchItem,
+} from '../../src/companion/prefetch-config.js';
+import {
+  computeAnswer,
+  frenchDate,
+  intentKeyForQuery,
+  matchPrefetched,
+  normalizeQuery,
+  runPrefetchCycle,
+  loadPrefetchCache,
+  type PrefetchEntry,
+} from '../../src/companion/prefetch-engine.js';
+
+function tmpFile(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), 'pf-')), name);
+}
+
+describe('prefetch-config', () => {
+  it('returns defaults when no file, respects a saved list', () => {
+    const path = tmpFile('items.json');
+    expect(loadPrefetchItems(path)).toEqual(DEFAULT_PREFETCH_ITEMS);
+    savePrefetchItems([{ kind: 'weather', param: 'Paris' }], path);
+    expect(loadPrefetchItems(path)).toEqual([{ kind: 'weather', param: 'Paris' }]);
+  });
+
+  it('adds (dedup by key), removes, and keys items', () => {
+    let items: PrefetchItem[] = [];
+    items = addPrefetchItem({ kind: 'weather', param: 'Paris' }, items);
+    items = addPrefetchItem({ kind: 'weather', param: 'paris' }, items); // same key → replace
+    items = addPrefetchItem({ kind: 'news' }, items);
+    expect(items).toHaveLength(2);
+    expect(prefetchItemKey({ kind: 'weather', param: 'Paris' })).toBe('weather:paris');
+    expect(prefetchItemKey({ kind: 'news' })).toBe('news');
+    expect(removePrefetchItem(0, items)).toEqual([{ kind: 'news' }]);
+  });
+
+  it('drops invalid kinds', () => {
+    const path = tmpFile('bad.json');
+    savePrefetchItems([{ kind: 'weather' }, { kind: 'nope' } as unknown as PrefetchItem], path);
+    expect(loadPrefetchItems(path)).toEqual([{ kind: 'weather' }]);
+  });
+});
+
+describe('intentKeyForQuery', () => {
+  const items: PrefetchItem[] = [
+    { kind: 'weather', param: 'Paris' },
+    { kind: 'weather', param: 'Lyon' },
+    { kind: 'news' },
+    { kind: 'agenda' },
+    { kind: 'date' },
+  ];
+
+  it('routes weather to the named city, else the first', () => {
+    expect(intentKeyForQuery('quelle est la météo à Lyon ?', items)).toBe('weather:lyon');
+    expect(intentKeyForQuery('il fait quel temps ?', items)).toBe('weather:paris');
+  });
+
+  it('routes news / agenda / date', () => {
+    expect(intentKeyForQuery('quelles sont les actualités', items)).toBe('news');
+    expect(intentKeyForQuery("qu'est-ce que j'ai aujourd'hui", items)).toBe('agenda');
+    expect(intentKeyForQuery('on est quel jour ?', items)).toBe('date');
+  });
+
+  it('returns null for weather when no weather item, and for non-matches', () => {
+    expect(intentKeyForQuery('quelle est la météo ?', [{ kind: 'date' }])).toBeNull();
+    expect(intentKeyForQuery('raconte-moi ta vie', items)).toBeNull();
+  });
+
+  it('normalizeQuery strips accents', () => {
+    expect(normalizeQuery('Météo À Paris')).toBe('meteo a paris');
+  });
+});
+
+describe('matchPrefetched', () => {
+  const items: PrefetchItem[] = [{ kind: 'weather', param: 'Paris' }, { kind: 'date' }];
+  const now = 1_000_000_000_000;
+  const cache: PrefetchEntry[] = [
+    { key: 'weather:paris', kind: 'weather', answer: 'Il fait 18°C à Paris.', at: now - 60_000 },
+    { key: 'date', kind: 'date', answer: 'Nous sommes lundi.', at: now - 60_000 },
+  ];
+
+  it('returns a fresh cached answer', () => {
+    expect(matchPrefetched('la météo à Paris', { cache, items, now })).toBe(
+      'Il fait 18°C à Paris.'
+    );
+  });
+
+  it('returns null when the entry is stale (past its TTL)', () => {
+    const stale = [{ ...cache[0]!, at: now - 60 * 60_000 }]; // 1h > weather 45min TTL
+    expect(matchPrefetched('la météo à Paris', { cache: stale, items, now })).toBeNull();
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(matchPrefetched('bonjour', { cache, items, now })).toBeNull();
+  });
+});
+
+describe('computeAnswer + runPrefetchCycle (injected deps)', () => {
+  const now = 1_700_000_000_000;
+
+  it('computes each kind via injected fetchers', async () => {
+    const deps = {
+      now,
+      fetchWeather: async (c: string) => `Météo ${c}: beau.`,
+      fetchNews: async () => 'Voici les gros titres : A ; B.',
+      fetchAgenda: async () => 'Rien de prévu.',
+    };
+    expect((await computeAnswer({ kind: 'weather', param: 'Nice' }, deps))?.answer).toBe(
+      'Météo Nice: beau.'
+    );
+    expect((await computeAnswer({ kind: 'news' }, deps))?.answer).toContain('gros titres');
+    expect((await computeAnswer({ kind: 'agenda' }, deps))?.answer).toBe('Rien de prévu.');
+    expect((await computeAnswer({ kind: 'date' }, { now }))?.answer).toBe(frenchDate(now));
+  });
+
+  it('returns null when a fetcher yields nothing (fail-open)', async () => {
+    expect(
+      await computeAnswer({ kind: 'weather', param: 'X' }, { fetchWeather: async () => null })
+    ).toBeNull();
+  });
+
+  it('runs a cycle, writing computed answers to the cache', async () => {
+    const itemsPath = tmpFile('items.json');
+    const cachePath = tmpFile('cache.json');
+    savePrefetchItems([{ kind: 'date' }, { kind: 'weather', param: 'Paris' }], itemsPath);
+    const res = await runPrefetchCycle({
+      now,
+      itemsPath,
+      cachePath,
+      fetchWeather: async () => 'Il fait 20°C.',
+    });
+    expect(res.computed.sort()).toEqual(['date', 'weather:paris']);
+    const cache = loadPrefetchCache(cachePath);
+    expect(cache.find((e) => e.key === 'weather:paris')?.answer).toBe('Il fait 20°C.');
+  });
+});


### PR DESCRIPTION
Sert instantanément (0 LLM) les questions récurrentes (météo/actus/agenda/date) en pré-calculant leur réponse sur un timer. Liste configurable (JSON), moteur réutilisant WeatherTool/WebSearchTool/rappels/date, interception dans `makeHybridReply`, treatment heartbeat opt-in `CODEBUDDY_PREFETCH`. **Prouvé live** : match en **0 ms** avec vraie météo Open-Meteo (vs ~20 s LLM). 13 tests, tsc/eslint 0. UI de config à suivre.