### PR TITLE
feat(companion): blagues instantanées + AI émotionnelle enrichie

### DIFF
--- a/src/companion/jokes.ts
+++ b/src/companion/jokes.ts
@@ -1,0 +1,201 @@
+/**
+ * Jokes — Lisa's humour capability. A curated list of clean, spoken-friendly
+ * French jokes served INSTANTLY (no LLM) when the user asks, with anti-repetition,
+ * plus an optional background LLM "top-up" pool for variety.
+ *
+ * Wired as an instant seam in the hybrid reply (before the slow agent path), so
+ * "raconte-moi une blague" is answered immediately. Stores under
+ * ~/.codebuddy/companion/ (voice-guidance.ts template): never-throws, bounded.
+ *
+ * @module companion/jokes
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** Curated, clean, audibly-working French jokes (no spelling-only puns). */
+export const CURATED_JOKES: string[] = [
+  'Quel est le comble pour un électricien ? De ne pas être au courant.',
+  'Que dit un escargot quand il croise une limace ? « Oh, un nudiste ! »',
+  "Comment appelle-t-on un chien sans pattes ? On ne l'appelle pas, on va le chercher.",
+  'Pourquoi les plongeurs plongent-ils toujours en arrière ? Parce que sinon, ils tombent dans le bateau.',
+  'Quel est le comble pour un jardinier ? De raconter des salades.',
+  "Qu'est-ce qui est jaune et qui attend ? Jonathan.",
+  "Pourquoi les poissons détestent-ils l'ordinateur ? Parce qu'ils ont peur du Net.",
+  'Que fait une fraise sur un cheval ? Tagada, tagada.',
+  'Quel est le sport le plus fruité ? La boxe : on y prend des pêches, des marrons et des pruneaux.',
+  "Monsieur et Madame Térieur ont un fils. Comment s'appelle-t-il ? Alain. Alain Térieur.",
+  'Pourquoi les vaches ferment-elles les yeux quand on les trait ? Pour garder le lait concentré.',
+  "Quelle est la femelle du hamster ? L'Amsterdam.",
+  "Qu'est-ce qui est vert et qui monte et descend ? Un petit pois dans un ascenseur.",
+  "Pourquoi les squelettes ne se battent-ils jamais ? Parce qu'ils n'ont pas de tripes.",
+  'Quel est le comble pour un joueur de bowling ? De perdre la boule.',
+  'Comment appelle-t-on un chat tombé dans un pot de peinture le jour de Noël ? Un chat-peint de Noël.',
+  "Deux frites discutent. L'une dit : « On est bien, dans l'huile ! » L'autre répond : « Oui… mais on va finir grillées. »",
+  "Qu'est-ce qu'un yaourt qui fait de la musique ? Un yaourt à boire.",
+  "Pourquoi le livre de mathématiques est-il triste ? Parce qu'il a trop de problèmes.",
+  "Quel est le comble pour un marin ? D'avoir le mal de terre.",
+  "Comment fait-on pleurer un légume ? On lui raconte une histoire d'oignons.",
+  "Que se disent deux chats amoureux ? « On est faits l'un pour l'autre, c'est félin. »",
+  "Pourquoi les canards sont-ils toujours à l'heure ? Parce qu'ils ont un bec… d'horloge.",
+  "Quel est l'animal le plus heureux ? Le hibou, parce que sa femme est chouette.",
+  "Qu'est-ce qui est petit, carré et jaune ? Un petit carré jaune.",
+  'Un zéro dit à un huit : « Joli, ta ceinture ! »',
+  "Pourquoi les abeilles ont-elles les cheveux collants ? Parce qu'elles utilisent du miel comme gel.",
+  'Quel est le comble pour un pêcheur ? De ne pas avoir un thon de voix.',
+  "Que dit un oignon quand il se cogne ? « Aïe… j'ai les larmes aux yeux. »",
+  'Comment appelle-t-on un dinosaure qui dort ? Un dino-ronfle.',
+];
+
+const MAX_TOLD = 20;
+const MAX_POOL = 60;
+
+// ---------------------------------------------------------------------------
+// Request detection (pure)
+// ---------------------------------------------------------------------------
+
+function norm(s: string): string {
+  return (s ?? '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}+/gu, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const JOKE_REQUEST =
+  /\b(raconte (moi )?(une |une autre )?blague|(fais|dis) moi (une |une autre )?blague|une (autre )?blague|tu connais (une |des )?blagues?|fais moi rire|raconte (moi )?(quelque chose de |un truc )?dr[oô]le|dis moi (quelque chose de |un truc )?dr[oô]le)\b/;
+
+/** True when the utterance asks for a joke. Pure, STT-robust. */
+export function isJokeRequest(heard: string): boolean {
+  const t = norm(heard);
+  return t.length > 0 && JOKE_REQUEST.test(t);
+}
+
+/** Pick a joke not in the recent ring (falls back to any if all are recent). Pure. */
+export function pickJoke(
+  pool: string[],
+  recent: string[] = [],
+  rng: () => number = Math.random
+): string | null {
+  const jokes = pool.filter((j) => j && j.trim());
+  if (jokes.length === 0) return null;
+  const fresh = jokes.filter((j) => !recent.includes(j));
+  const candidates = fresh.length > 0 ? fresh : jokes;
+  return candidates[Math.floor(rng() * candidates.length) % candidates.length] ?? candidates[0]!;
+}
+
+// ---------------------------------------------------------------------------
+// Stores (JSON under ~/.codebuddy/companion/)
+// ---------------------------------------------------------------------------
+
+function storePath(name: string, env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[`CODEBUDDY_JOKES_${name.toUpperCase().replace(/-/g, '_')}_FILE`];
+  return override?.trim() || join(homedir(), '.codebuddy', 'companion', `jokes-${name}.json`);
+}
+
+function loadList(path: string): string[] {
+  try {
+    if (!existsSync(path)) return [];
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return Array.isArray(raw)
+      ? raw.filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveList(path: string, items: string[]): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(items, null, 2));
+  } catch {
+    /* best-effort */
+  }
+}
+
+export function loadJokePool(env: NodeJS.ProcessEnv = process.env): string[] {
+  return loadList(storePath('pool', env));
+}
+
+/** The full pool to draw from: curated jokes + any background LLM top-ups. */
+export function effectiveJokePool(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [...CURATED_JOKES, ...loadJokePool(env)];
+}
+
+/**
+ * Pick the next joke (anti-repeat across sessions) and record it. never-throws.
+ * Returns null only if there is genuinely no joke available.
+ */
+export function nextJoke(env: NodeJS.ProcessEnv = process.env): string | null {
+  const toldPath = storePath('told', env);
+  const told = loadList(toldPath);
+  const joke = pickJoke(effectiveJokePool(env), told);
+  if (!joke) return null;
+  saveList(toldPath, [...told.filter((j) => j !== joke), joke].slice(-MAX_TOLD));
+  return joke;
+}
+
+export interface JokeTopupDeps {
+  /** Injectable LLM: returns raw JSON text {"jokes": string[]}. Default: ChatGPT-OAuth. */
+  chat?: (system: string, user: string) => Promise<string>;
+  env?: NodeJS.ProcessEnv;
+}
+
+const TOPUP_SYSTEM =
+  'Tu génères des blagues COURTES, PROPRES et en FRANÇAIS, adaptées à être DITES à voix haute ' +
+  "(pas de jeu de mots qui repose sur l'orthographe). Réponds STRICTEMENT en JSON : " +
+  '{"jokes": ["blague 1", "blague 2", "blague 3"]}. 3 à 5 blagues, aucune répétition, aucun contenu offensant.';
+
+/** Generate a few fresh jokes and append them to the pool (dedup, capped). never-throws. */
+export async function refreshJokePool(deps: JokeTopupDeps = {}): Promise<number> {
+  const env = deps.env ?? process.env;
+  try {
+    const chat = deps.chat ?? (await defaultChat());
+    if (!chat) return 0;
+    const { generateJsonWithRetry } = await import('../utils/llm-retry.js');
+    const gen = (p: string): Promise<string> => chat(TOPUP_SYSTEM, p);
+    const parsed = await generateJsonWithRetry<{ jokes?: unknown }>(
+      gen,
+      'Donne-moi de nouvelles blagues variées.'
+    );
+    const fresh = Array.isArray(parsed?.jokes)
+      ? parsed.jokes.map((j) => (typeof j === 'string' ? j.trim() : '')).filter(Boolean)
+      : [];
+    if (fresh.length === 0) return 0;
+    const poolPath = storePath('pool', env);
+    const existing = loadList(poolPath);
+    const seen = new Set([...CURATED_JOKES, ...existing].map((j) => j.toLowerCase()));
+    const added = fresh.filter((j) => !seen.has(j.toLowerCase()));
+    if (added.length === 0) return 0;
+    saveList(poolPath, [...existing, ...added].slice(-MAX_POOL));
+    return added.length;
+  } catch {
+    return 0;
+  }
+}
+
+async function defaultChat(): Promise<((s: string, u: string) => Promise<string>) | null> {
+  try {
+    const { resolveCommandProvider } = await import('../commands/llm-provider-resolution.js');
+    const resolved = resolveCommandProvider({});
+    if (!resolved) return null;
+    const { CodeBuddyClient } = await import('../codebuddy/client.js');
+    const client = new CodeBuddyClient(resolved.apiKey, resolved.model, resolved.baseURL);
+    return async (system: string, user: string) => {
+      const resp = await client.chat(
+        [
+          { role: 'system', content: system },
+          { role: 'user', content: user },
+        ],
+        undefined,
+        { responseFormat: 'json' }
+      );
+      return resp?.choices?.[0]?.message?.content ?? '';
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/companion/reply-augment.ts
+++ b/src/companion/reply-augment.ts
@@ -30,35 +30,167 @@ function norm(s: string): string {
     .trim();
 }
 
-// All patterns match against the normalized (accent-stripped) text.
-const RE = {
-  frustration: /\b(j en peux plus|marre|galere|bloque|coince|ca marche pas|enerve|fatigue|epuise|sais plus|stresse|angoisse|j y arrive pas|c est dur|trop dur)\b/,
-  affection: /\b(je t aime|tu me manques|bisous|mon amour|cheri|cherie|je pense a toi|je t embrasse|tu es adorable)\b/,
-  gratitude: /\b(merci|c est gentil|trop gentil|reconnaissant|tu m aides beaucoup)\b/,
-  joking: /\b(haha|mdr|lol|ptdr|blague|rigole|drole|marrant|tu deconnes)\b/,
-  deep: /\b(je me sens|honnetement|au fond de moi|je doute|je suis perdu|je suis triste|je me sens seul)\b/,
-};
-
 /**
- * The dominant emotional signal of an utterance. Frustration-first (so care isn't missed on a mixed
- * message), then the positive/relational colourings, else `neutral`. Pure.
+ * Finer-grained emotion than the coarse `RelationalSignal` used for trait drift.
+ * Drives the (richer) reply-time tone guidance; mapped back to a `RelationalSignal`
+ * for the persisted mood/traits so relationship-state stays stable.
  */
-export function detectRelationalSignal(heard: string): RelationalSignal {
-  const t = norm(heard);
-  if (!t) return 'neutral';
-  if (RE.frustration.test(t)) return 'frustration';
-  if (RE.affection.test(t)) return 'affection';
-  if (RE.gratitude.test(t)) return 'gratitude';
-  if (RE.joking.test(t)) return 'joking';
-  if (RE.deep.test(t)) return 'deep-talk';
-  return 'neutral';
+export type Emotion =
+  | 'frustration'
+  | 'sadness'
+  | 'anxiety'
+  | 'tired'
+  | 'affection'
+  | 'gratitude'
+  | 'joy'
+  | 'joking'
+  | 'deep-talk'
+  | 'neutral';
+
+export interface EmotionRead {
+  emotion: Emotion;
+  intensity: 'normal' | 'high';
 }
 
-/** One-line tone instruction for the reply system prompt. Empty string for a neutral signal. */
+// All patterns match against the normalized (accent-stripped) text.
+const ERE: Record<Exclude<Emotion, 'neutral'>, RegExp> = {
+  frustration:
+    /\b(j en peux plus|marre|ras le bol|galere|bloque|coince|ca marche pas|enerve|s enerve|j y arrive pas|c est dur|trop dur|je craque|a bout)\b/,
+  sadness:
+    /\b(triste|tristesse|cafard|deprime|deprimee|pas le moral|le moral a zero|le moral dans les chaussettes|malheureux|malheureuse|envie de pleurer|ca va pas fort|abattu|abattue)\b/,
+  anxiety:
+    /\b(stresse|stressee|angoisse|angoissee|anxieux|anxieuse|j ai peur|inquiet|inquiete|panique|ca m angoisse|tendu|tendue|nerveux|nerveuse)\b/,
+  tired:
+    /\b(fatigue|fatiguee|epuise|epuisee|creve|crevee|vanne|vannee|plus d energie|au bout du rouleau|envie de dormir|je suis mort|je suis morte)\b/,
+  affection:
+    /\b(je t aime|tu me manques|bisous|mon amour|cheri|cherie|je pense a toi|je t embrasse|tu es adorable)\b/,
+  gratitude: /\b(merci|c est gentil|trop gentil|reconnaissant|tu m aides beaucoup)\b/,
+  joy: /\b(genial|trop content|trop contente|quelle journee|c est top|excellent|j ai reussi|je suis heureux|je suis heureuse|trop bien|magnifique|super content)\b/,
+  joking: /\b(haha|mdr|lol|ptdr|blague|rigole|drole|marrant|tu deconnes)\b/,
+  'deep-talk':
+    /\b(je me sens|honnetement|au fond de moi|je doute|je suis perdu|je me sens seul|je me sens seule)\b/,
+};
+
+// Negatives first (so care isn't missed on a mixed message), then positives.
+const EMOTION_ORDER: Array<Exclude<Emotion, 'neutral'>> = [
+  'frustration',
+  'sadness',
+  'anxiety',
+  'tired',
+  'affection',
+  'gratitude',
+  'joy',
+  'joking',
+  'deep-talk',
+];
+
+const INTENSITY_RE =
+  /\b(vraiment|tellement|trop|completement|a bout|plus du tout|grave|hyper|extremement|tres)\b/;
+
+/** Detect the dominant emotion + its intensity. Pure, STT-robust. */
+export function detectEmotion(heard: string): EmotionRead {
+  const t = norm(heard);
+  if (!t) return { emotion: 'neutral', intensity: 'normal' };
+  const intensity: 'normal' | 'high' = INTENSITY_RE.test(t) ? 'high' : 'normal';
+  for (const emotion of EMOTION_ORDER) {
+    if (ERE[emotion].test(t)) return { emotion, intensity };
+  }
+  return { emotion: 'neutral', intensity };
+}
+
+/** Map a fine Emotion to the coarse RelationalSignal used for trait drift. Pure. */
+export function emotionToSignal(emotion: Emotion): RelationalSignal {
+  switch (emotion) {
+    case 'frustration':
+    case 'anxiety':
+    case 'tired':
+      return 'frustration'; // lowers mood/energy
+    case 'sadness':
+    case 'deep-talk':
+      return 'deep-talk'; // present, deeper
+    case 'joy':
+      return 'joking'; // mood + energy up
+    case 'affection':
+      return 'affection';
+    case 'gratitude':
+      return 'gratitude';
+    case 'joking':
+      return 'joking';
+    default:
+      return 'neutral';
+  }
+}
+
+/**
+ * The dominant emotional signal of an utterance (coarse, for trait drift). Delegates
+ * to `detectEmotion` so there is ONE emotion detector. Backward-compatible. Pure.
+ */
+export function detectRelationalSignal(heard: string): RelationalSignal {
+  return emotionToSignal(detectEmotion(heard).emotion);
+}
+
+/** Emotions where Lisa may gently offer to lighten the mood (a joke, a kind word). */
+const HUMOR_WELCOME: ReadonlySet<Emotion> = new Set(['frustration', 'sadness', 'tired']);
+
+/** Rich, emotion-aware tone instruction for the reply system prompt. Empty for neutral. */
+export function emotionGuidance(read: EmotionRead): string {
+  const { emotion, intensity } = read;
+  const strong = intensity === 'high';
+  let base = '';
+  switch (emotion) {
+    case 'frustration':
+      base =
+        "Il a l'air tendu ou bloqué. Douceur et présence d'abord, valide ce qu'il ressent, ne te précipite pas sur une solution.";
+      break;
+    case 'sadness':
+      base =
+        'Il a l’air triste. Accueille ce qu’il ressent avant tout, sois douce et présente, ne minimise pas.';
+      break;
+    case 'anxiety':
+      base = 'Il semble anxieux. Rassure-le, ralentis, prends une chose à la fois.';
+      break;
+    case 'tired':
+      base = 'Il est fatigué. Sois brève et douce, et propose-lui de souffler.';
+      break;
+    case 'affection':
+      base = 'Il est tendre avec toi. Réponds avec chaleur et sincérité, sans en faire trop.';
+      break;
+    case 'gratitude':
+      base = 'Il te remercie. Accueille-le simplement, avec chaleur.';
+      break;
+    case 'joy':
+      base = 'Il est de bonne humeur. Partage son enthousiasme avec entrain.';
+      break;
+    case 'joking':
+      base = 'Il plaisante. Tu peux être joueuse et légère.';
+      break;
+    case 'deep-talk':
+      base = 'Sujet qui compte pour lui. Sois présente, un peu plus posée et profonde.';
+      break;
+    default:
+      return '';
+  }
+  if (
+    strong &&
+    (emotion === 'frustration' ||
+      emotion === 'sadness' ||
+      emotion === 'anxiety' ||
+      emotion === 'tired')
+  ) {
+    base = `Il semble vraiment affecté. ${base} Priorité absolue à l’accueil, avant toute autre chose.`;
+  }
+  if (HUMOR_WELCOME.has(emotion)) {
+    base +=
+      ' Si le moment s’y prête, tu peux — avec délicatesse — proposer de lui changer les idées (une petite blague, un mot doux), sans jamais forcer.';
+  }
+  return base;
+}
+
+/** One-line tone instruction for a coarse RelationalSignal (legacy callers). */
 export function registerGuidanceForSignal(signal: RelationalSignal): string {
   switch (signal) {
     case 'frustration':
-      return "Patrice a l'air tendu ou bloqué. Accorde ton ton : douceur et présence d'abord, valide ce qu'il ressent, ne te précipite pas sur une solution.";
+      return "Il a l'air tendu ou bloqué. Accorde ton ton : douceur et présence d'abord, valide ce qu'il ressent, ne te précipite pas sur une solution.";
     case 'affection':
       return 'Il est tendre avec toi. Réponds avec chaleur et sincérité, sans en faire trop.';
     case 'gratitude':

--- a/src/sensory/hybrid-reply.ts
+++ b/src/sensory/hybrid-reply.ts
@@ -25,6 +25,16 @@ import type { ReplyFn, VoiceStepOptions } from './voice-loop.js';
 import type { PermissionMode } from '../security/permission-modes.js';
 import { matchPrefetched, loadPrefetchCache } from '../companion/prefetch-engine.js';
 import { loadPrefetchItems } from '../companion/prefetch-config.js';
+import { isJokeRequest, nextJoke } from '../companion/jokes.js';
+
+/** Instant joke when the user asks for one (no LLM, no agent). null otherwise. */
+function defaultJokeMatch(heard: string): string | null {
+  try {
+    return isJokeRequest(heard) ? nextJoke() : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Instant answer for a common question from the prefetch cache (weather, news,
@@ -71,6 +81,8 @@ export interface HybridReplyOptions {
   /** Injectable: instant precomputed answer for a common question (null ⇒ none).
    *  Default: the prefetch cache when CODEBUDDY_PREFETCH is on. */
   prefetch?: (heard: string) => string | null;
+  /** Injectable: instant joke when asked (null ⇒ not a joke request). Default: jokes.ts. */
+  jokes?: (heard: string) => string | null;
 }
 
 /** Lowercase + strip diacritics so STT accent loss ("ca va" ≈ "ça va") still matches. */
@@ -194,6 +206,13 @@ export function makeHybridReply(options: HybridReplyOptions = {}): ReplyFn {
         remember(heard, pre);
         logger.info(`[voice-hybrid] prefetch → ${pre.slice(0, 60)}`);
         return pre;
+      }
+      // Instant joke on request — no LLM, no slow agent turn.
+      const joke = (options.jokes ?? defaultJokeMatch)(heard);
+      if (joke) {
+        remember(heard, joke);
+        logger.info(`[voice-hybrid] joke → ${joke.slice(0, 60)}`);
+        return joke;
       }
       const substantive = classify(heard);
       const stepOpts = signal ? { signal } : undefined;

--- a/src/sensory/voice-loop.ts
+++ b/src/sensory/voice-loop.ts
@@ -618,10 +618,10 @@ export async function defaultReply(
         if (rel) systemPrompt = `${systemPrompt}\n\n${rel}`;
         // Emotion-aware tone (the caring.md playbook: soften on frustration, be present) + vary the
         // opening so replies don't all start the same way.
-        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } =
+        const { detectEmotion, emotionGuidance, avoidOpenersGuidance } =
           await import('../companion/reply-augment.js');
         const guidance = [
-          registerGuidanceForSignal(detectRelationalSignal(heard)),
+          emotionGuidance(detectEmotion(heard)),
           avoidOpenersGuidance(recentReplyOpeners),
         ]
           .filter(Boolean)
@@ -685,10 +685,10 @@ export async function* defaultStreamReply(
         const { buildRelationalContext } = await import('../companion/relational-context.js');
         const rel = await buildRelationalContext();
         if (rel) systemPrompt = `${systemPrompt}\n\n${rel}`;
-        const { detectRelationalSignal, registerGuidanceForSignal, avoidOpenersGuidance } =
+        const { detectEmotion, emotionGuidance, avoidOpenersGuidance } =
           await import('../companion/reply-augment.js');
         const guidance = [
-          registerGuidanceForSignal(detectRelationalSignal(heard)),
+          emotionGuidance(detectEmotion(heard)),
           avoidOpenersGuidance(recentReplyOpeners),
         ]
           .filter(Boolean)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1407,6 +1407,20 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
             void runPrefetch(); // warm the cache immediately, don't wait for the first beat
             logger.info(`Prefetch: Enabled (CODEBUDDY_PREFETCH) — precompute common answers every ${prefetchEvery} beats`);
           }
+          // Jokes top-up (opt-in) — generate a few fresh jokes in the background so Lisa's humour
+          // stays varied. The curated list already works instantly WITHOUT this.
+          if (process.env.CODEBUDDY_JOKES_TOPUP === 'true') {
+            const jokesEvery = Math.max(1, Number(process.env.CODEBUDDY_JOKES_TOPUP_EVERY ?? 200));
+            heart.register({
+              name: 'jokes-topup',
+              everyBeats: jokesEvery,
+              handler: async () => {
+                const { refreshJokePool } = await import('../companion/jokes.js');
+                await refreshJokePool();
+              },
+            });
+            logger.info(`Jokes top-up: Enabled (CODEBUDDY_JOKES_TOPUP) — fresh jokes every ${jokesEvery} beats`);
+          }
           heart.start();
           sensoryTeardown.push(() => heart.stop());
           logger.info(`Sensory bridge: Enabled (buddy-sense → event bus; heartbeat treatments every ${everyBeats} beats)`);

--- a/tests/companion/jokes.test.ts
+++ b/tests/companion/jokes.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Jokes — request detection + anti-repeat picker (pure; no LLM, no daemon).
+ */
+import {
+  CURATED_JOKES,
+  effectiveJokePool,
+  isJokeRequest,
+  pickJoke,
+} from '../../src/companion/jokes.js';
+
+describe('isJokeRequest', () => {
+  it('detects joke requests (STT-robust)', () => {
+    expect(isJokeRequest('raconte-moi une blague')).toBe(true);
+    expect(isJokeRequest('Lisa, tu connais une blague ?')).toBe(true);
+    expect(isJokeRequest('fais-moi rire')).toBe(true);
+    expect(isJokeRequest('raconte-moi un truc drôle')).toBe(true);
+    expect(isJokeRequest('une autre blague')).toBe(true);
+  });
+
+  it('ignores non-joke utterances', () => {
+    expect(isJokeRequest('quelle est la météo')).toBe(false);
+    expect(isJokeRequest('raconte-moi ta journée')).toBe(false);
+    expect(isJokeRequest('')).toBe(false);
+  });
+});
+
+describe('pickJoke', () => {
+  it('avoids recently told jokes', () => {
+    const pool = ['a', 'b', 'c'];
+    const picked = pickJoke(pool, ['a', 'b'], () => 0); // rng→0 would pick 'a', but it is recent
+    expect(picked).toBe('c');
+  });
+
+  it('falls back to the full pool when all are recent', () => {
+    const pool = ['a', 'b'];
+    expect(pickJoke(pool, ['a', 'b'], () => 0)).toBe('a');
+  });
+
+  it('returns null for an empty pool', () => {
+    expect(pickJoke([], [])).toBeNull();
+  });
+});
+
+describe('effectiveJokePool', () => {
+  it('always includes the curated jokes', () => {
+    const pool = effectiveJokePool({} as NodeJS.ProcessEnv);
+    expect(pool.length).toBeGreaterThanOrEqual(CURATED_JOKES.length);
+    expect(pool).toContain(CURATED_JOKES[0]);
+  });
+});

--- a/tests/companion/reply-augment.test.ts
+++ b/tests/companion/reply-augment.test.ts
@@ -11,12 +11,19 @@ import { join } from 'path';
 import {
   detectRelationalSignal,
   registerGuidanceForSignal,
+  detectEmotion,
+  emotionToSignal,
+  emotionGuidance,
   openerKey,
   pushOpener,
   avoidOpenersGuidance,
 } from '../../src/companion/reply-augment.js';
 import { makeHybridReply } from '../../src/sensory/hybrid-reply.js';
-import { loadRelationshipState, personalityOf, DEFAULT_TRAITS } from '../../src/companion/relationship-state.js';
+import {
+  loadRelationshipState,
+  personalityOf,
+  DEFAULT_TRAITS,
+} from '../../src/companion/relationship-state.js';
 
 describe('detectRelationalSignal', () => {
   it('classifies the dominant emotional colour', () => {
@@ -43,6 +50,61 @@ describe('registerGuidanceForSignal', () => {
   });
   it('neutral → no guidance', () => {
     expect(registerGuidanceForSignal('neutral')).toBe('');
+  });
+});
+
+describe('detectEmotion (enriched)', () => {
+  it('detects the new emotions', () => {
+    expect(detectEmotion('je suis vraiment triste ce soir').emotion).toBe('sadness');
+    expect(detectEmotion('je suis hyper stressé').emotion).toBe('anxiety');
+    expect(detectEmotion('je suis épuisé, crevé').emotion).toBe('tired');
+    expect(detectEmotion("c'est génial, j'ai réussi !").emotion).toBe('joy');
+    expect(detectEmotion('quelle heure est-il').emotion).toBe('neutral');
+  });
+
+  it('flags intensity from markers', () => {
+    expect(detectEmotion('je galère vraiment').intensity).toBe('high');
+    expect(detectEmotion('je galère un peu').intensity).toBe('normal');
+  });
+
+  it('negatives take priority (frustration first)', () => {
+    expect(detectEmotion('merci mais je suis à bout').emotion).toBe('frustration');
+  });
+});
+
+describe('emotionToSignal (backward-compatible mapping)', () => {
+  it('maps fine emotions to the coarse trait-drift signal', () => {
+    expect(emotionToSignal('sadness')).toBe('deep-talk');
+    expect(emotionToSignal('anxiety')).toBe('frustration');
+    expect(emotionToSignal('tired')).toBe('frustration');
+    expect(emotionToSignal('joy')).toBe('joking');
+    // detectRelationalSignal still returns the historical values via the mapping
+    expect(detectRelationalSignal('je suis triste')).toBe('deep-talk');
+    expect(detectRelationalSignal('je suis fatigué')).toBe('frustration');
+  });
+});
+
+describe('emotionGuidance (rich tone + proactive humour)', () => {
+  it('leads with acknowledgment on sadness and offers to lighten the mood', () => {
+    const g = emotionGuidance({ emotion: 'sadness', intensity: 'normal' });
+    expect(g).toMatch(/accueille|triste/i);
+    expect(g).toMatch(/changer les id[ée]es|blague/i); // proactive humour offer
+  });
+
+  it('strengthens the register at high intensity', () => {
+    expect(emotionGuidance({ emotion: 'frustration', intensity: 'high' })).toMatch(
+      /vraiment|priorit[ée]/i
+    );
+  });
+
+  it('joy shares enthusiasm and does not offer humour', () => {
+    const g = emotionGuidance({ emotion: 'joy', intensity: 'normal' });
+    expect(g).toMatch(/enthousiasme|bonne humeur/i);
+    expect(g).not.toMatch(/changer les id[ée]es/i);
+  });
+
+  it('neutral → empty', () => {
+    expect(emotionGuidance({ emotion: 'neutral', intensity: 'normal' })).toBe('');
   });
 });
 
@@ -97,10 +159,17 @@ describe('hybrid reply evolves Lisa’s traits per utterance (real state file, o
     const state2 = join(tmp2, 'relationship-state.json');
     process.env.CODEBUDDY_RELATIONSHIP_STATE_FILE = state2;
     try {
-      const reply2 = makeHybridReply({ fastReply: () => 'ok', chitchat: async () => 'ok', agentReply: async () => 'ok', classify: () => false });
+      const reply2 = makeHybridReply({
+        fastReply: () => 'ok',
+        chitchat: async () => 'ok',
+        agentReply: async () => 'ok',
+        classify: () => false,
+      });
       await reply2("je t'aime");
       // No file written → load returns the default baseline.
-      expect(personalityOf(loadRelationshipState(state2)).traits.warmth).toBe(DEFAULT_TRAITS.warmth);
+      expect(personalityOf(loadRelationshipState(state2)).traits.warmth).toBe(
+        DEFAULT_TRAITS.warmth
+      );
     } finally {
       rmSync(tmp2, { recursive: true, force: true });
     }


### PR DESCRIPTION
**Blagues** : liste FR soignée servie **instantanément** (0 LLM, anti-répétition) via un seam dans `makeHybridReply` (avant le chemin agent lent) + top-up LLM optionnel en fond. **Émotion** : détection enrichie (tristesse/anxiété/fatigue/joie + intensité), ton adapté (accueil d'abord), **humour proactif** quand tendu/triste, mapping rétro-compatible (drift inchangé). Prénom neutralisé. 23 tests, tsc/eslint 0.