### PR TITLE
feat(widgets): moteur de widgets inline (registre + curated météo/actus)

### DIFF
--- a/src/widgets/curated/news.ts
+++ b/src/widgets/curated/news.ts
@@ -1,0 +1,42 @@
+/**
+ * Curated news widget — a self-contained body fragment (no external network)
+ * that renders a `NewsWidgetData` payload from `window.__WIDGET_DATA__`.
+ * @module widgets/curated/news
+ */
+export const NEWS_WIDGET_HTML = String.raw`
+<style>
+  .cbw-news { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    border-radius: 16px; padding: 16px 18px; color: #0b1220;
+    background: #ffffff; border: 1px solid rgba(0,0,0,.08); max-width: 520px; }
+  .cbw-news .cbw-h { font-size: 14px; font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .cbw-news ul { list-style: none; margin: 0; padding: 0; }
+  .cbw-news li { padding: 9px 0; border-top: 1px solid rgba(0,0,0,.06); font-size: 14px; line-height: 1.35; }
+  .cbw-news li:first-child { border-top: none; }
+  .cbw-news .cbw-src { display: block; font-size: 11px; opacity: .55; margin-top: 2px; }
+  .cbw-news a { color: inherit; text-decoration: none; }
+  .cbw-news a:hover { text-decoration: underline; }
+  @media (prefers-color-scheme: dark) {
+    .cbw-news { color: #e8eefc; background: #0f1626; border-color: rgba(255,255,255,.08); }
+    .cbw-news li { border-color: rgba(255,255,255,.08); }
+  }
+</style>
+<div class="cbw-news" id="cbw-news"></div>
+<script>
+(function(){
+  var d = (window.__WIDGET_DATA__) || {};
+  var root = document.getElementById('cbw-news');
+  if (!root) return;
+  var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g, function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m];}); };
+  var items = Array.isArray(d.items) ? d.items.slice(0, 8) : [];
+  root.innerHTML =
+    '<div class="cbw-h">📰 ' + esc(d.title || "Actualités du jour") + '</div>'
+    + (items.length
+        ? '<ul>' + items.map(function(it){
+            var title = esc(it.title || '');
+            var inner = it.url ? '<a href="' + esc(it.url) + '" target="_blank" rel="noopener">' + title + '</a>' : title;
+            return '<li>' + inner + (it.source ? '<span class="cbw-src">' + esc(it.source) + '</span>' : '') + '</li>';
+          }).join('') + '</ul>'
+        : '<div style="opacity:.6;font-size:13px">Pas d\'actualité disponible.</div>');
+})();
+</script>
+`;

--- a/src/widgets/curated/weather.ts
+++ b/src/widgets/curated/weather.ts
@@ -1,0 +1,69 @@
+/**
+ * Curated weather widget — a self-contained body fragment (no external network)
+ * that renders a `WeatherWidgetData` payload from `window.__WIDGET_DATA__`.
+ * @module widgets/curated/weather
+ */
+export const WEATHER_WIDGET_HTML = String.raw`
+<style>
+  .cbw-weather { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    border-radius: 16px; padding: 18px 20px; color: #0b1220;
+    background: linear-gradient(135deg, #eaf3ff 0%, #f7fbff 100%);
+    border: 1px solid rgba(0,0,0,.06); max-width: 460px; }
+  .cbw-weather .cbw-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .cbw-weather .cbw-loc { font-size: 14px; font-weight: 600; opacity: .8; }
+  .cbw-weather .cbw-temp { font-size: 44px; font-weight: 700; line-height: 1; }
+  .cbw-weather .cbw-emoji { font-size: 44px; }
+  .cbw-weather .cbw-cond { margin-top: 2px; font-size: 14px; opacity: .85; text-transform: capitalize; }
+  .cbw-weather .cbw-meta { margin-top: 8px; font-size: 12px; opacity: .7; display: flex; gap: 14px; flex-wrap: wrap; }
+  .cbw-weather .cbw-fc { margin-top: 14px; display: flex; gap: 10px; overflow-x: auto; }
+  .cbw-weather .cbw-day { flex: 0 0 auto; text-align: center; padding: 8px 10px; border-radius: 12px;
+    background: rgba(255,255,255,.6); min-width: 62px; }
+  .cbw-weather .cbw-day .d { font-size: 11px; opacity: .7; text-transform: capitalize; }
+  .cbw-weather .cbw-day .e { font-size: 20px; margin: 2px 0; }
+  .cbw-weather .cbw-day .t { font-size: 12px; font-weight: 600; }
+  @media (prefers-color-scheme: dark) {
+    .cbw-weather { color: #e8eefc; background: linear-gradient(135deg, #101a2e 0%, #0b1220 100%);
+      border-color: rgba(255,255,255,.08); }
+    .cbw-weather .cbw-day { background: rgba(255,255,255,.06); }
+  }
+</style>
+<div class="cbw-weather" id="cbw-weather"></div>
+<script>
+(function(){
+  var d = (window.__WIDGET_DATA__) || {};
+  function emoji(cond){
+    var c = String(cond||'').toLowerCase();
+    if (/orage|thunder|storm/.test(c)) return '⛈️';
+    if (/neige|snow/.test(c)) return '🌨️';
+    if (/pluie|rain|averse|drizzle|bruine/.test(c)) return '🌧️';
+    if (/brou|fog|mist|brume/.test(c)) return '🌫️';
+    if (/nuag|cloud|couvert|overcast/.test(c)) return '☁️';
+    if (/éclair|partiel|partly/.test(c)) return '⛅';
+    if (/soleil|clear|ensole|sunny|dégagé|degage/.test(c)) return '☀️';
+    return '🌡️';
+  }
+  var unit = d.units === 'imperial' ? '°F' : '°C';
+  var cur = d.current || {};
+  var root = document.getElementById('cbw-weather');
+  if (!root) return;
+  var meta = [];
+  if (cur.feelsLike != null) meta.push('Ressenti ' + Math.round(cur.feelsLike) + unit);
+  if (cur.humidity != null) meta.push('💧 ' + cur.humidity + '%');
+  if (cur.windSpeed != null) meta.push('💨 ' + cur.windSpeed + ' km/h');
+  var fc = Array.isArray(d.forecast) ? d.forecast.slice(0,5) : [];
+  var esc = function(s){ return String(s==null?'':s).replace(/[&<>]/g, function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;'}[m];}); };
+  root.innerHTML =
+    '<div class="cbw-top"><div>'
+      + '<div class="cbw-loc">' + esc(d.location || 'Météo') + '</div>'
+      + '<div class="cbw-temp">' + (cur.temperature!=null?Math.round(cur.temperature):'—') + unit + '</div>'
+      + '<div class="cbw-cond">' + esc(cur.condition || '') + '</div>'
+      + '</div><div class="cbw-emoji">' + emoji(cur.condition) + '</div></div>'
+    + (meta.length ? '<div class="cbw-meta">' + meta.map(esc).join('<span>·</span>') + '</div>' : '')
+    + (fc.length ? '<div class="cbw-fc">' + fc.map(function(f){
+        return '<div class="cbw-day"><div class="d">' + esc(f.day) + '</div>'
+          + '<div class="e">' + emoji(f.condition) + '</div>'
+          + '<div class="t">' + (f.max!=null?Math.round(f.max):'—') + '° / ' + (f.min!=null?Math.round(f.min):'—') + '°</div></div>';
+      }).join('') + '</div>' : '');
+})();
+</script>
+`;

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -1,0 +1,88 @@
+/**
+ * Widget registry — resolves the widget for a given data `kind` and renders it
+ * into a self-contained sandboxed HTML document with the data injected.
+ *
+ * Curated widgets ship in-repo (weather, news). Authored widgets (generated on
+ * the fly, Phase 2) live under ~/.codebuddy/widgets/<name>/widget.html and are
+ * loaded lazily — but curated ALWAYS wins for a kind it covers (authored only
+ * fills gaps, and can't shadow a curated one). never-throws.
+ *
+ * @module widgets/widget-registry
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { WEATHER_WIDGET_HTML } from './curated/weather.js';
+import { NEWS_WIDGET_HTML } from './curated/news.js';
+import { widgetKind, type WidgetSpec } from './widget-types.js';
+
+const CURATED: Record<string, string> = {
+  weather: WEATHER_WIDGET_HTML,
+  news: NEWS_WIDGET_HTML,
+};
+
+/** Root dir for authored widgets (env-overridable). */
+export function authoredWidgetsDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEBUDDY_WIDGETS_DIR?.trim() || join(homedir(), '.codebuddy', 'widgets');
+}
+
+/** Resolve the widget for a kind: curated first, else an authored one if present. never-throws. */
+export function resolveWidget(
+  kind: string,
+  env: NodeJS.ProcessEnv = process.env
+): WidgetSpec | null {
+  const k = (kind ?? '').trim().toLowerCase();
+  if (!k) return null;
+  if (CURATED[k]) return { name: `curated-${k}`, kind: k, html: CURATED[k]!, source: 'curated' };
+  try {
+    const p = join(authoredWidgetsDir(env), `authored-${k}`, 'widget.html');
+    if (existsSync(p)) {
+      const html = readFileSync(p, 'utf8');
+      if (html.trim()) return { name: `authored-${k}`, kind: k, html, source: 'authored' };
+    }
+  } catch {
+    /* no authored widget — fine */
+  }
+  return null;
+}
+
+/** JSON safe to inline inside a <script> tag (prevents a </script> breakout). */
+function safeJson(value: unknown): string {
+  return JSON.stringify(value ?? {})
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+}
+
+const BASE_CSS = `*{box-sizing:border-box}html,body{margin:0;padding:0;background:transparent}body{padding:2px}`;
+
+/**
+ * Wrap a widget fragment + its data into a complete, self-contained HTML document
+ * (the data script runs BEFORE the widget's own script). Pure.
+ */
+export function renderWidgetDocument(spec: WidgetSpec, data: unknown): string {
+  return (
+    '<!doctype html><html><head><meta charset="utf-8">' +
+    '<meta name="viewport" content="width=device-width,initial-scale=1">' +
+    `<style>${BASE_CSS}</style></head><body>` +
+    `<script>window.__WIDGET_DATA__=${safeJson(data)};</script>` +
+    spec.html +
+    '</body></html>'
+  );
+}
+
+/** Convenience: resolve + render for a tool's `data` payload. null when no widget fits. */
+export function renderWidgetForData(
+  data: unknown,
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  const kind = widgetKind(data);
+  if (!kind) return null;
+  const spec = resolveWidget(kind, env);
+  return spec ? renderWidgetDocument(spec, data) : null;
+}
+
+/** True when SOME widget (curated or authored) can render this data. */
+export function hasWidgetForData(data: unknown, env: NodeJS.ProcessEnv = process.env): boolean {
+  const kind = widgetKind(data);
+  return !!kind && resolveWidget(kind, env) !== null;
+}

--- a/src/widgets/widget-types.ts
+++ b/src/widgets/widget-types.ts
@@ -1,0 +1,55 @@
+/**
+ * Widgets — rich, self-contained UI components rendered INLINE in a conversation
+ * (ChatGPT-Apps-SDK style), driven by a tool's structured `data` payload.
+ *
+ * A widget is a body fragment (HTML + scoped CSS + JS) that reads its data from
+ * `window.__WIDGET_DATA__` and renders into the page. `renderWidgetDocument`
+ * wraps it in a sandboxed HTML document with the data injected. Curated widgets
+ * ship in-repo; authored ones are generated on the fly and reused (see the
+ * self-learning engine, Phase 2) — mirroring the authored-skills pattern.
+ *
+ * @module widgets/widget-types
+ */
+
+/** The structured payload a tool emits for a weather widget (aligns with WeatherTool.data). */
+export interface WeatherWidgetData {
+  type: 'weather';
+  location: string;
+  current: {
+    temperature: number;
+    feelsLike?: number;
+    condition: string;
+    humidity?: number;
+    windSpeed?: number;
+  };
+  forecast?: Array<{ day: string; min: number; max: number; condition: string }>;
+  units?: 'metric' | 'imperial';
+}
+
+/** The structured payload for a news/headlines widget. */
+export interface NewsWidgetData {
+  type: 'news';
+  title?: string;
+  items: Array<{ title: string; url?: string; source?: string }>;
+}
+
+export type WidgetData =
+  | WeatherWidgetData
+  | NewsWidgetData
+  | { type: string; [k: string]: unknown };
+
+/** The `type` discriminator of a widget payload (also the widget "kind"). */
+export function widgetKind(data: unknown): string | null {
+  const t = (data as { type?: unknown })?.type;
+  return typeof t === 'string' && t.trim() ? t.trim() : null;
+}
+
+export interface WidgetSpec {
+  /** Unique name: `curated-<kind>` or `authored-<kind>`. */
+  name: string;
+  /** The data `type` this widget renders (weather, news, …). */
+  kind: string;
+  /** Self-contained body fragment (HTML + scoped <style> + <script> reading __WIDGET_DATA__). */
+  html: string;
+  source: 'curated' | 'authored';
+}

--- a/tests/widgets/widget-registry.test.ts
+++ b/tests/widgets/widget-registry.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Widget registry — curated resolution, authored fallback (curated wins), and
+ * safe data injection. Pure/isolated (temp authored dir).
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resolveWidget,
+  renderWidgetDocument,
+  renderWidgetForData,
+  hasWidgetForData,
+} from '../../src/widgets/widget-registry.js';
+import { widgetKind, type WeatherWidgetData } from '../../src/widgets/widget-types.js';
+
+const sampleWeather: WeatherWidgetData = {
+  type: 'weather',
+  location: 'Paris',
+  current: { temperature: 22, feelsLike: 24, condition: 'ensoleillé', humidity: 66, windSpeed: 6 },
+  forecast: [{ day: 'jeu', min: 15, max: 24, condition: 'ensoleillé' }],
+  units: 'metric',
+};
+
+describe('resolveWidget', () => {
+  it('returns curated widgets for weather and news', () => {
+    expect(resolveWidget('weather')?.source).toBe('curated');
+    expect(resolveWidget('news')?.name).toBe('curated-news');
+    expect(resolveWidget('WEATHER')?.kind).toBe('weather'); // case-insensitive
+  });
+
+  it('returns null for an unknown kind with no authored widget', () => {
+    expect(resolveWidget('stock', {} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it('falls back to an authored widget for a NEW kind, but curated wins', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wdg-'));
+    const env = { CODEBUDDY_WIDGETS_DIR: dir } as NodeJS.ProcessEnv;
+    // Authored widget for a novel kind 'stock'.
+    mkdirSync(join(dir, 'authored-stock'), { recursive: true });
+    writeFileSync(join(dir, 'authored-stock', 'widget.html'), '<div>stock</div>');
+    expect(resolveWidget('stock', env)?.source).toBe('authored');
+    // An authored 'weather' must NOT shadow the curated one.
+    mkdirSync(join(dir, 'authored-weather'), { recursive: true });
+    writeFileSync(join(dir, 'authored-weather', 'widget.html'), '<div>evil</div>');
+    expect(resolveWidget('weather', env)?.source).toBe('curated');
+  });
+});
+
+describe('renderWidgetDocument + data injection', () => {
+  it('produces a self-contained doc with the data injected and no </script> breakout', () => {
+    const spec = resolveWidget('weather')!;
+    const doc = renderWidgetDocument(spec, { type: 'weather', location: '</script><b>x' });
+    expect(doc).toContain('<!doctype html>');
+    expect(doc).toContain('window.__WIDGET_DATA__=');
+    // The injected JSON must not contain a raw closing script tag.
+    expect(doc).not.toContain('</script><b>x'); // escaped to <
+    expect(doc).toContain('\\u003c/script');
+  });
+
+  it('renderWidgetForData resolves + renders, null for an unrecognized payload', () => {
+    const doc = renderWidgetForData(sampleWeather);
+    expect(doc).toContain('Paris'); // location travels in the injected JSON payload
+    expect(doc).toContain('window.__WIDGET_DATA__');
+    expect(renderWidgetForData({ nope: true })).toBeNull();
+    expect(renderWidgetForData('not an object')).toBeNull();
+  });
+});
+
+describe('helpers', () => {
+  it('widgetKind extracts the type', () => {
+    expect(widgetKind({ type: 'weather' })).toBe('weather');
+    expect(widgetKind({})).toBeNull();
+  });
+  it('hasWidgetForData', () => {
+    expect(hasWidgetForData(sampleWeather)).toBe(true);
+    expect(hasWidgetForData({ type: 'stock' }, {} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fondation d'une **bibliothèque de widgets** (façon ChatGPT Apps SDK) : `src/widgets/` — registre (curated puis authored, curated gagne), `renderWidgetDocument` injecte les données dans un doc HTML **auto-contenu** (zéro réseau, thème clair/sombre), + 2 widgets curated **météo/actus**. Rendu HTML réel prouvé. 7 tests, tsc/eslint 0. Phase 1a ; suite = câblage inline Cowork + moteur auto-apprenant façon skills.