### PR TITLE
fix(widgets): rendu côté serveur CSP-proof + câblage inline Cowork

### DIFF
--- a/cowork/src/main/claude/agent-runner.ts
+++ b/cowork/src/main/claude/agent-runner.ts
@@ -2383,6 +2383,10 @@ Tool routing:
                 typeof event.result === 'string'
                   ? event.result
                   : JSON.stringify(event.result || '');
+              const resultData =
+                typeof event.result === 'object' && event.result !== null && 'data' in event.result
+                  ? (event.result as { data?: unknown }).data
+                  : undefined;
               this.sendTraceUpdate(session.id, toolCallId, {
                 status: isError ? 'error' : 'completed',
                 toolName: event.toolName,
@@ -2400,6 +2404,7 @@ Tool routing:
                     toolUseId: toolCallId,
                     content: sanitizeOutputPaths(outputText),
                     isError,
+                    ...(resultData !== undefined ? { data: resultData } : {}),
                   },
                 ],
                 timestamp: Date.now(),

--- a/cowork/src/main/engine/codebuddy-engine-runner.ts
+++ b/cowork/src/main/engine/codebuddy-engine-runner.ts
@@ -274,6 +274,7 @@ export class CodeBuddyEngineRunner {
                   toolUseId: event.tool.id,
                   content: event.tool.output || '',
                   isError: event.tool.isError,
+                  ...(event.tool.data !== undefined ? { data: event.tool.data } : {}),
                 } as ToolResultContent);
 
                 // Phase 2 step 13: emit gui.action events for Computer Use overlay.

--- a/cowork/src/main/index.ts
+++ b/cowork/src/main/index.ts
@@ -157,6 +157,7 @@ import { registerSessionInsightsIpcHandlers } from './ipc/session-insights-ipc';
 import { registerPluginsIpcHandlers } from './ipc/plugins-ipc';
 import { registerTestRunnerIpcHandlers } from './ipc/test-runner-ipc';
 import { registerMemoryIpcHandlers } from './ipc/memory-ipc';
+import { registerWidgetsIpcHandlers } from './ipc/widgets-ipc';
 import { ConfigExportService } from './config/config-export-service';
 import { KnowledgeService } from './knowledge/knowledge-service';
 import { NotificationBridge } from './notification/notification-bridge';
@@ -2550,6 +2551,9 @@ registerFilmIpc(ipcMain, new FilmService(undefined, join(app.getPath('userData')
 
 // Assistant: voice assistant config + daemon lifecycle (core companion/assistant-config).
 registerAssistantIpc(ipcMain, new AssistantService());
+
+// Tool result widgets: render core-provided self-contained HTML in the main process.
+registerWidgetsIpcHandlers();
 
 // ── .codebuddy/ backups (same core handler as `buddy backup`) ────────────
 registerBackupIpcHandlers();

--- a/cowork/src/main/ipc/widgets-ipc.ts
+++ b/cowork/src/main/ipc/widgets-ipc.ts
@@ -1,0 +1,34 @@
+import { ipcMain } from 'electron';
+import { loadCoreModule } from '../utils/core-loader';
+import { logError } from '../utils/logger';
+
+interface WidgetRegistryModule {
+  hasWidgetForData?: (data: unknown) => boolean;
+  renderWidgetForData?: (data: unknown) => string | null;
+}
+
+function hasStructuredType(data: unknown): data is { type: string } {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as { type?: unknown }).type === 'string'
+  );
+}
+
+export function registerWidgetsIpcHandlers(): void {
+  ipcMain.handle('widgets.render', async (_event, data: unknown): Promise<string | null> => {
+    if (!hasStructuredType(data)) return null;
+
+    try {
+      const mod = await loadCoreModule<WidgetRegistryModule>('widgets/widget-registry.js');
+      if (!mod?.renderWidgetForData) return null;
+      if (mod.hasWidgetForData && !mod.hasWidgetForData(data)) return null;
+
+      const html = mod.renderWidgetForData(data);
+      return typeof html === 'string' && html.trim().length > 0 ? html : null;
+    } catch (error) {
+      logError('[widgets-ipc] failed to render widget:', error);
+      return null;
+    }
+  });
+}

--- a/cowork/src/preload/index.ts
+++ b/cowork/src/preload/index.ts
@@ -839,6 +839,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('assistant.setVolume', percent),
   },
 
+  widgets: {
+    render: (data: unknown): Promise<string | null> => ipcRenderer.invoke('widgets.render', data),
+  },
+
   // App Studio (bolt.diy-style file tree + editor + terminal + live preview).
   // Channels mirror the main-process register*Ipc handlers under
   // src/main/studio/*. Note: the file listing handler is `studio.files.tree`.
@@ -4927,6 +4931,9 @@ declare global {
         restart: () => Promise<AssistantRestartResponse>;
         getVolume: () => Promise<AssistantVolumeResponse>;
         setVolume: (percent: number) => Promise<AssistantSetVolumeResponse>;
+      };
+      widgets: {
+        render: (data: unknown) => Promise<string | null>;
       };
       selectFiles: () => Promise<string[]>;
       artifacts: {

--- a/cowork/src/renderer/components/message/ActivityGroupBlock.tsx
+++ b/cowork/src/renderer/components/message/ActivityGroupBlock.tsx
@@ -3,6 +3,7 @@ import { Activity, ChevronDown, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ContentBlock, Message, ToolResultContent } from '../../types';
 import { ContentBlockView } from './ContentBlockView';
+import { WidgetBlock } from '../widgets/WidgetBlock';
 
 interface ActivityGroupBlockProps {
   blocks: ContentBlock[];
@@ -18,6 +19,32 @@ export const ActivityGroupBlock = memo(function ActivityGroupBlock({
   isStreaming,
 }: ActivityGroupBlockProps) {
   const { t } = useTranslation();
+  const widgetCandidates = useMemo(() => {
+    const candidates: Array<{ id: string; data: unknown }> = [];
+    const seen = new Set<string>();
+    const pushResult = (result: ToolResultContent) => {
+      if (result.isError || result.data === undefined || seen.has(result.toolUseId)) return;
+      seen.add(result.toolUseId);
+      candidates.push({ id: result.toolUseId, data: result.data });
+    };
+
+    for (const block of blocks) {
+      if (block.type === 'tool_result') {
+        pushResult(block as ToolResultContent);
+      }
+      if (block.type === 'tool_use') {
+        const toolUseId = (block as { id?: unknown }).id;
+        if (typeof toolUseId !== 'string') continue;
+        const result = allBlocks.find(
+          (candidate) =>
+            candidate.type === 'tool_result' &&
+            (candidate as ToolResultContent).toolUseId === toolUseId
+        ) as ToolResultContent | undefined;
+        if (result) pushResult(result);
+      }
+    }
+    return candidates;
+  }, [allBlocks, blocks]);
   const [expanded, setExpanded] = useState(isStreaming === true);
   const { toolCount, thinkingCount, errorCount } = useMemo(() => {
     let tools = 0;
@@ -59,6 +86,15 @@ export const ActivityGroupBlock = memo(function ActivityGroupBlock({
           <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
         )}
       </button>
+      {!expanded
+        ? widgetCandidates.map((candidate) => (
+            <WidgetBlock
+              key={candidate.id}
+              data={candidate.data}
+              className="mb-2 mt-2"
+            />
+          ))
+        : null}
       {expanded ? (
         <div className="space-y-1.5 border-t border-border/50 px-2.5 py-2">
           {blocks.map((block, index) => (

--- a/cowork/src/renderer/components/message/ToolResultBlock.tsx
+++ b/cowork/src/renderer/components/message/ToolResultBlock.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight, XCircle, CheckCircle2 } from 'lucide-react';
 import { useAppStore } from '../../store';
 import { shouldUseScreenshotSummary } from '../../utils/tool-result-summary';
 import type { ToolResultContent, ContentBlock, ToolUseContent, Message } from '../../types';
+import { WidgetBlock } from '../widgets/WidgetBlock';
 
 // Only allow safe image MIME types for data: URI rendering
 const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
@@ -73,6 +74,7 @@ export const ToolResultBlock = memo(function ToolResultBlock({
   };
 
   const hasImages = block.images && block.images.length > 0;
+  const widgetData = !block.isError ? block.data : undefined;
 
   return (
     <div
@@ -106,6 +108,8 @@ export const ToolResultBlock = memo(function ToolResultBlock({
           <ChevronRight className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
         )}
       </button>
+
+      {widgetData !== undefined && <WidgetBlock data={widgetData} className="mb-2 mt-2" />}
 
       {expanded && (
         <div className="border-t border-border/50 px-3 py-2 animate-fade-in">

--- a/cowork/src/renderer/components/message/ToolUseBlock.tsx
+++ b/cowork/src/renderer/components/message/ToolUseBlock.tsx
@@ -9,6 +9,7 @@ import { TodoWriteBlock } from './TodoWriteBlock';
 import { getToolIcon, getToolLabel } from './toolHelpers';
 import { TerminalOutput } from './TerminalOutput';
 import { DiffViewer } from '../DiffViewer';
+import { WidgetBlock } from '../widgets/WidgetBlock';
 
 const EDIT_TOOLS = new Set(['write', 'edit', 'str_replace_editor', 'create_file', 'write_file', 'edit_file', 'apply_patch']);
 const BASH_TOOLS = new Set(['bash', 'execute_command', 'shell_exec', 'run_command']);
@@ -69,7 +70,8 @@ export const ToolUseBlock = memo(function ToolUseBlock({
   const hasActiveTurn = Boolean(activeTurn);
   const isRunning = !toolResult && hasActiveTurn;
   const isError = toolResult?.isError === true;
-  const isSuccess = toolResult && !isError;
+  const isSuccess = Boolean(toolResult && !isError);
+  const widgetData = toolResult && !isError ? toolResult.data : undefined;
 
   // Live output while running — tool_stream deltas accumulated on the trace
   // step by the store. The card streams instead of hiding behind the spinner.
@@ -177,6 +179,8 @@ export const ToolUseBlock = memo(function ToolUseBlock({
           <ChevronRight className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
         )}
       </button>
+
+      {widgetData !== undefined && <WidgetBlock data={widgetData} className="mb-2 mt-2" />}
 
       {/* Expanded content */}
       {expanded && (

--- a/cowork/src/renderer/components/widgets/WidgetBlock.tsx
+++ b/cowork/src/renderer/components/widgets/WidgetBlock.tsx
@@ -1,0 +1,58 @@
+import { memo, useEffect, useState } from 'react';
+
+interface WidgetBlockProps {
+  data: unknown;
+  className?: string;
+}
+
+function isWidgetCandidate(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as { type?: unknown }).type === 'string'
+  );
+}
+
+export const WidgetBlock = memo(function WidgetBlock({ data, className = '' }: WidgetBlockProps) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHtml(null);
+
+    if (!isWidgetCandidate(data) || typeof window === 'undefined') return;
+    const render = window.electronAPI?.widgets?.render;
+    if (!render) return;
+
+    void render(data)
+      .then((nextHtml) => {
+        if (!cancelled) setHtml(nextHtml);
+      })
+      .catch(() => {
+        if (!cancelled) setHtml(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  if (!html) return null;
+
+  return (
+    <div
+      className={`w-full max-w-[560px] overflow-hidden rounded-lg border border-border-subtle bg-white ${className}`}
+    >
+      {/* Widgets are rendered SERVER-SIDE (static HTML+CSS, no client script), so
+          the iframe needs no `allow-scripts` — full sandbox + popups for outbound
+          links only. No `allow-same-origin`. */}
+      <iframe
+        title="tool-result-widget"
+        sandbox="allow-popups allow-popups-to-escape-sandbox"
+        srcDoc={html}
+        className="block w-full border-0 bg-white"
+        style={{ minHeight: 120, height: 'clamp(120px, 38vw, 320px)' }}
+      />
+    </div>
+  );
+});

--- a/cowork/src/renderer/types/index.ts
+++ b/cowork/src/renderer/types/index.ts
@@ -1168,6 +1168,7 @@ export interface ToolResultContent {
   toolUseId: string;
   content: string;
   isError?: boolean;
+  data?: unknown;
   images?: Array<{
     data: string;          // base64 encoded image data
     mimeType: string;      // e.g., 'image/png'

--- a/src/widgets/curated/news.ts
+++ b/src/widgets/curated/news.ts
@@ -1,42 +1,40 @@
 /**
- * Curated news widget — a self-contained body fragment (no external network)
- * that renders a `NewsWidgetData` payload from `window.__WIDGET_DATA__`.
+ * Curated news widget — SERVER-SIDE rendered (static HTML, no client script;
+ * CSP-proof for inline srcdoc iframes). Pure.
  * @module widgets/curated/news
  */
-export const NEWS_WIDGET_HTML = String.raw`
-<style>
-  .cbw-news { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    border-radius: 16px; padding: 16px 18px; color: #0b1220;
-    background: #ffffff; border: 1px solid rgba(0,0,0,.08); max-width: 520px; }
-  .cbw-news .cbw-h { font-size: 14px; font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
-  .cbw-news ul { list-style: none; margin: 0; padding: 0; }
-  .cbw-news li { padding: 9px 0; border-top: 1px solid rgba(0,0,0,.06); font-size: 14px; line-height: 1.35; }
-  .cbw-news li:first-child { border-top: none; }
-  .cbw-news .cbw-src { display: block; font-size: 11px; opacity: .55; margin-top: 2px; }
-  .cbw-news a { color: inherit; text-decoration: none; }
-  .cbw-news a:hover { text-decoration: underline; }
-  @media (prefers-color-scheme: dark) {
-    .cbw-news { color: #e8eefc; background: #0f1626; border-color: rgba(255,255,255,.08); }
-    .cbw-news li { border-color: rgba(255,255,255,.08); }
-  }
-</style>
-<div class="cbw-news" id="cbw-news"></div>
-<script>
-(function(){
-  var d = (window.__WIDGET_DATA__) || {};
-  var root = document.getElementById('cbw-news');
-  if (!root) return;
-  var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g, function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m];}); };
-  var items = Array.isArray(d.items) ? d.items.slice(0, 8) : [];
-  root.innerHTML =
-    '<div class="cbw-h">📰 ' + esc(d.title || "Actualités du jour") + '</div>'
-    + (items.length
-        ? '<ul>' + items.map(function(it){
-            var title = esc(it.title || '');
-            var inner = it.url ? '<a href="' + esc(it.url) + '" target="_blank" rel="noopener">' + title + '</a>' : title;
-            return '<li>' + inner + (it.source ? '<span class="cbw-src">' + esc(it.source) + '</span>' : '') + '</li>';
-          }).join('') + '</ul>'
-        : '<div style="opacity:.6;font-size:13px">Pas d\'actualité disponible.</div>');
-})();
-</script>
-`;
+import type { NewsWidgetData } from '../widget-types.js';
+
+function esc(s: unknown): string {
+  return String(s == null ? '' : s).replace(/[&<>"]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[m]!);
+}
+
+const STYLE = `<style>
+.cbw-news{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;border-radius:16px;padding:16px 18px;color:#0b1220;background:#fff;border:1px solid rgba(0,0,0,.08);max-width:520px}
+.cbw-news .h{font-size:14px;font-weight:700;margin-bottom:10px}
+.cbw-news ul{list-style:none;margin:0;padding:0}
+.cbw-news li{padding:9px 0;border-top:1px solid rgba(0,0,0,.06);font-size:14px;line-height:1.35}
+.cbw-news li:first-child{border-top:none}
+.cbw-news .src{display:block;font-size:11px;opacity:.55;margin-top:2px}
+.cbw-news a{color:inherit;text-decoration:none}
+.cbw-news a:hover{text-decoration:underline}
+@media (prefers-color-scheme:dark){.cbw-news{color:#e8eefc;background:#0f1626;border-color:rgba(255,255,255,.08)}.cbw-news li{border-color:rgba(255,255,255,.08)}}
+</style>`;
+
+/** Render a news payload to a self-contained HTML fragment (no script). */
+export function renderNewsWidget(raw: unknown): string {
+  const d = (raw ?? {}) as Partial<NewsWidgetData>;
+  const items = Array.isArray(d.items) ? d.items.slice(0, 8) : [];
+  const body = items.length
+    ? `<ul>${items
+        .map((it) => {
+          const title = esc(it.title ?? '');
+          const inner = it.url
+            ? `<a href="${esc(it.url)}" target="_blank" rel="noopener noreferrer">${title}</a>`
+            : title;
+          return `<li>${inner}${it.source ? `<span class="src">${esc(it.source)}</span>` : ''}</li>`;
+        })
+        .join('')}</ul>`
+    : `<div style="opacity:.6;font-size:13px">Pas d'actualité disponible.</div>`;
+  return `${STYLE}<div class="cbw-news"><div class="h">📰 ${esc(d.title ?? 'Actualités du jour')}</div>${body}</div>`;
+}

--- a/src/widgets/curated/weather.ts
+++ b/src/widgets/curated/weather.ts
@@ -1,69 +1,72 @@
 /**
- * Curated weather widget — a self-contained body fragment (no external network)
- * that renders a `WeatherWidgetData` payload from `window.__WIDGET_DATA__`.
+ * Curated weather widget — SERVER-SIDE rendered (data interpolated into static
+ * HTML + scoped CSS, NO client <script>). This is CSP-proof: an inline-script
+ * approach fails because srcdoc iframes inherit the host CSP. `renderWeatherWidget`
+ * returns a self-contained body fragment. Pure.
  * @module widgets/curated/weather
  */
-export const WEATHER_WIDGET_HTML = String.raw`
-<style>
-  .cbw-weather { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    border-radius: 16px; padding: 18px 20px; color: #0b1220;
-    background: linear-gradient(135deg, #eaf3ff 0%, #f7fbff 100%);
-    border: 1px solid rgba(0,0,0,.06); max-width: 460px; }
-  .cbw-weather .cbw-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-  .cbw-weather .cbw-loc { font-size: 14px; font-weight: 600; opacity: .8; }
-  .cbw-weather .cbw-temp { font-size: 44px; font-weight: 700; line-height: 1; }
-  .cbw-weather .cbw-emoji { font-size: 44px; }
-  .cbw-weather .cbw-cond { margin-top: 2px; font-size: 14px; opacity: .85; text-transform: capitalize; }
-  .cbw-weather .cbw-meta { margin-top: 8px; font-size: 12px; opacity: .7; display: flex; gap: 14px; flex-wrap: wrap; }
-  .cbw-weather .cbw-fc { margin-top: 14px; display: flex; gap: 10px; overflow-x: auto; }
-  .cbw-weather .cbw-day { flex: 0 0 auto; text-align: center; padding: 8px 10px; border-radius: 12px;
-    background: rgba(255,255,255,.6); min-width: 62px; }
-  .cbw-weather .cbw-day .d { font-size: 11px; opacity: .7; text-transform: capitalize; }
-  .cbw-weather .cbw-day .e { font-size: 20px; margin: 2px 0; }
-  .cbw-weather .cbw-day .t { font-size: 12px; font-weight: 600; }
-  @media (prefers-color-scheme: dark) {
-    .cbw-weather { color: #e8eefc; background: linear-gradient(135deg, #101a2e 0%, #0b1220 100%);
-      border-color: rgba(255,255,255,.08); }
-    .cbw-weather .cbw-day { background: rgba(255,255,255,.06); }
-  }
-</style>
-<div class="cbw-weather" id="cbw-weather"></div>
-<script>
-(function(){
-  var d = (window.__WIDGET_DATA__) || {};
-  function emoji(cond){
-    var c = String(cond||'').toLowerCase();
-    if (/orage|thunder|storm/.test(c)) return '⛈️';
-    if (/neige|snow/.test(c)) return '🌨️';
-    if (/pluie|rain|averse|drizzle|bruine/.test(c)) return '🌧️';
-    if (/brou|fog|mist|brume/.test(c)) return '🌫️';
-    if (/nuag|cloud|couvert|overcast/.test(c)) return '☁️';
-    if (/éclair|partiel|partly/.test(c)) return '⛅';
-    if (/soleil|clear|ensole|sunny|dégagé|degage/.test(c)) return '☀️';
-    return '🌡️';
-  }
-  var unit = d.units === 'imperial' ? '°F' : '°C';
-  var cur = d.current || {};
-  var root = document.getElementById('cbw-weather');
-  if (!root) return;
-  var meta = [];
-  if (cur.feelsLike != null) meta.push('Ressenti ' + Math.round(cur.feelsLike) + unit);
-  if (cur.humidity != null) meta.push('💧 ' + cur.humidity + '%');
-  if (cur.windSpeed != null) meta.push('💨 ' + cur.windSpeed + ' km/h');
-  var fc = Array.isArray(d.forecast) ? d.forecast.slice(0,5) : [];
-  var esc = function(s){ return String(s==null?'':s).replace(/[&<>]/g, function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;'}[m];}); };
-  root.innerHTML =
-    '<div class="cbw-top"><div>'
-      + '<div class="cbw-loc">' + esc(d.location || 'Météo') + '</div>'
-      + '<div class="cbw-temp">' + (cur.temperature!=null?Math.round(cur.temperature):'—') + unit + '</div>'
-      + '<div class="cbw-cond">' + esc(cur.condition || '') + '</div>'
-      + '</div><div class="cbw-emoji">' + emoji(cur.condition) + '</div></div>'
-    + (meta.length ? '<div class="cbw-meta">' + meta.map(esc).join('<span>·</span>') + '</div>' : '')
-    + (fc.length ? '<div class="cbw-fc">' + fc.map(function(f){
-        return '<div class="cbw-day"><div class="d">' + esc(f.day) + '</div>'
-          + '<div class="e">' + emoji(f.condition) + '</div>'
-          + '<div class="t">' + (f.max!=null?Math.round(f.max):'—') + '° / ' + (f.min!=null?Math.round(f.min):'—') + '°</div></div>';
-      }).join('') + '</div>' : '');
-})();
-</script>
-`;
+import type { WeatherWidgetData } from '../widget-types.js';
+
+function esc(s: unknown): string {
+  return String(s == null ? '' : s).replace(/[&<>"]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[m]!);
+}
+
+function emoji(cond: unknown): string {
+  const c = String(cond ?? '').toLowerCase();
+  if (/orage|thunder|storm/.test(c)) return '⛈️';
+  if (/neige|snow/.test(c)) return '🌨️';
+  if (/pluie|rain|averse|drizzle|bruine/.test(c)) return '🌧️';
+  if (/brou|fog|mist|brume/.test(c)) return '🌫️';
+  if (/nuag|cloud|couvert|overcast/.test(c)) return '☁️';
+  if (/eclair|éclair|partiel|partly/.test(c)) return '⛅';
+  if (/soleil|clear|ensole|sunny|degage|dégagé/.test(c)) return '☀️';
+  return '🌡️';
+}
+
+const STYLE = `<style>
+.cbw-weather{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;border-radius:16px;padding:18px 20px;color:#0b1220;background:linear-gradient(135deg,#eaf3ff 0%,#f7fbff 100%);border:1px solid rgba(0,0,0,.06);max-width:460px}
+.cbw-weather .top{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.cbw-weather .loc{font-size:14px;font-weight:600;opacity:.8}
+.cbw-weather .temp{font-size:44px;font-weight:700;line-height:1}
+.cbw-weather .emoji{font-size:44px}
+.cbw-weather .cond{margin-top:2px;font-size:14px;opacity:.85;text-transform:capitalize}
+.cbw-weather .meta{margin-top:8px;font-size:12px;opacity:.7;display:flex;gap:14px;flex-wrap:wrap}
+.cbw-weather .fc{margin-top:14px;display:flex;gap:10px;overflow-x:auto}
+.cbw-weather .day{flex:0 0 auto;text-align:center;padding:8px 10px;border-radius:12px;background:rgba(255,255,255,.6);min-width:62px}
+.cbw-weather .day .d{font-size:11px;opacity:.7;text-transform:capitalize}
+.cbw-weather .day .e{font-size:20px;margin:2px 0}
+.cbw-weather .day .t{font-size:12px;font-weight:600}
+@media (prefers-color-scheme:dark){.cbw-weather{color:#e8eefc;background:linear-gradient(135deg,#101a2e 0%,#0b1220 100%);border-color:rgba(255,255,255,.08)}.cbw-weather .day{background:rgba(255,255,255,.06)}}
+</style>`;
+
+/** Render a weather payload to a self-contained HTML fragment (no script). */
+export function renderWeatherWidget(raw: unknown): string {
+  const d = (raw ?? {}) as Partial<WeatherWidgetData>;
+  const cur = d.current ?? ({} as NonNullable<WeatherWidgetData['current']>);
+  const unit = d.units === 'imperial' ? '°F' : '°C';
+  const meta: string[] = [];
+  if (cur.feelsLike != null) meta.push(`Ressenti ${Math.round(cur.feelsLike)}${unit}`);
+  if (cur.humidity != null) meta.push(`💧 ${cur.humidity}%`);
+  if (cur.windSpeed != null) meta.push(`💨 ${cur.windSpeed} km/h`);
+  const fc = Array.isArray(d.forecast) ? d.forecast.slice(0, 5) : [];
+  const temp = cur.temperature != null ? Math.round(cur.temperature) : '—';
+  return (
+    STYLE +
+    `<div class="cbw-weather"><div class="top"><div>` +
+    `<div class="loc">${esc(d.location ?? 'Météo')}</div>` +
+    `<div class="temp">${temp}${unit}</div>` +
+    `<div class="cond">${esc(cur.condition ?? '')}</div>` +
+    `</div><div class="emoji">${emoji(cur.condition)}</div></div>` +
+    (meta.length ? `<div class="meta">${meta.map((m) => esc(m)).join('<span>·</span>')}</div>` : '') +
+    (fc.length
+      ? `<div class="fc">${fc
+          .map(
+            (f) =>
+              `<div class="day"><div class="d">${esc(f.day)}</div><div class="e">${emoji(f.condition)}</div>` +
+              `<div class="t">${f.max != null ? Math.round(f.max) : '—'}° / ${f.min != null ? Math.round(f.min) : '—'}°</div></div>`
+          )
+          .join('')}</div>`
+      : '') +
+    `</div>`
+  );
+}

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -1,24 +1,27 @@
 /**
- * Widget registry — resolves the widget for a given data `kind` and renders it
- * into a self-contained sandboxed HTML document with the data injected.
+ * Widget registry — resolves the renderer for a data `kind` and produces a
+ * self-contained HTML document, SERVER-SIDE (data interpolated into static
+ * HTML+CSS, no client script). This is CSP-proof: srcdoc iframes inherit the
+ * host CSP, so an inline-`<script>` widget renders blank in Cowork/Electron.
  *
- * Curated widgets ship in-repo (weather, news). Authored widgets (generated on
- * the fly, Phase 2) live under ~/.codebuddy/widgets/<name>/widget.html and are
- * loaded lazily — but curated ALWAYS wins for a kind it covers (authored only
- * fills gaps, and can't shadow a curated one). never-throws.
+ * Curated widgets are pure render functions in-repo (weather, news). Authored
+ * widgets (generated on the fly, Phase 2) live under
+ * ~/.codebuddy/widgets/<name>/widget.html as a static fragment — but curated
+ * ALWAYS wins for a kind it covers. never-throws.
  *
  * @module widgets/widget-registry
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { WEATHER_WIDGET_HTML } from './curated/weather.js';
-import { NEWS_WIDGET_HTML } from './curated/news.js';
-import { widgetKind, type WidgetSpec } from './widget-types.js';
+import { renderWeatherWidget } from './curated/weather.js';
+import { renderNewsWidget } from './curated/news.js';
+import { widgetKind } from './widget-types.js';
 
-const CURATED: Record<string, string> = {
-  weather: WEATHER_WIDGET_HTML,
-  news: NEWS_WIDGET_HTML,
+/** Curated server-side renderers: data → self-contained HTML fragment (no script). */
+const CURATED: Record<string, (data: unknown) => string> = {
+  weather: renderWeatherWidget,
+  news: renderNewsWidget,
 };
 
 /** Root dir for authored widgets (env-overridable). */
@@ -26,63 +29,66 @@ export function authoredWidgetsDir(env: NodeJS.ProcessEnv = process.env): string
   return env.CODEBUDDY_WIDGETS_DIR?.trim() || join(homedir(), '.codebuddy', 'widgets');
 }
 
-/** Resolve the widget for a kind: curated first, else an authored one if present. never-throws. */
-export function resolveWidget(
+/** Which source (if any) can render this kind: curated wins over authored. */
+export function resolveWidgetSource(
   kind: string,
   env: NodeJS.ProcessEnv = process.env
-): WidgetSpec | null {
+): 'curated' | 'authored' | null {
   const k = (kind ?? '').trim().toLowerCase();
   if (!k) return null;
-  if (CURATED[k]) return { name: `curated-${k}`, kind: k, html: CURATED[k]!, source: 'curated' };
+  if (CURATED[k]) return 'curated';
   try {
-    const p = join(authoredWidgetsDir(env), `authored-${k}`, 'widget.html');
-    if (existsSync(p)) {
-      const html = readFileSync(p, 'utf8');
-      if (html.trim()) return { name: `authored-${k}`, kind: k, html, source: 'authored' };
-    }
+    if (existsSync(join(authoredWidgetsDir(env), `authored-${k}`, 'widget.html'))) return 'authored';
   } catch {
-    /* no authored widget — fine */
+    /* none */
   }
   return null;
 }
 
-/** JSON safe to inline inside a <script> tag (prevents a </script> breakout). */
-function safeJson(value: unknown): string {
-  return JSON.stringify(value ?? {})
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e');
+/** Server-render the widget FRAGMENT for a data payload (curated fn, else authored static). */
+export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = process.env): string | null {
+  const kind = widgetKind(data)?.toLowerCase();
+  if (!kind) return null;
+  const curated = CURATED[kind];
+  if (curated) {
+    try {
+      const frag = curated(data);
+      return frag && frag.trim() ? frag : null;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const p = join(authoredWidgetsDir(env), `authored-${kind}`, 'widget.html');
+    if (existsSync(p)) {
+      const html = readFileSync(p, 'utf8');
+      if (html.trim()) return html;
+    }
+  } catch {
+    /* none */
+  }
+  return null;
 }
 
 const BASE_CSS = `*{box-sizing:border-box}html,body{margin:0;padding:0;background:transparent}body{padding:2px}`;
 
-/**
- * Wrap a widget fragment + its data into a complete, self-contained HTML document
- * (the data script runs BEFORE the widget's own script). Pure.
- */
-export function renderWidgetDocument(spec: WidgetSpec, data: unknown): string {
+/** Wrap a rendered fragment into a complete, self-contained HTML document (no script). Pure. */
+export function renderWidgetDocument(fragment: string): string {
   return (
     '<!doctype html><html><head><meta charset="utf-8">' +
     '<meta name="viewport" content="width=device-width,initial-scale=1">' +
-    `<style>${BASE_CSS}</style></head><body>` +
-    `<script>window.__WIDGET_DATA__=${safeJson(data)};</script>` +
-    spec.html +
-    '</body></html>'
+    `<style>${BASE_CSS}</style></head><body>${fragment}</body></html>`
   );
 }
 
-/** Convenience: resolve + render for a tool's `data` payload. null when no widget fits. */
-export function renderWidgetForData(
-  data: unknown,
-  env: NodeJS.ProcessEnv = process.env
-): string | null {
-  const kind = widgetKind(data);
-  if (!kind) return null;
-  const spec = resolveWidget(kind, env);
-  return spec ? renderWidgetDocument(spec, data) : null;
+/** Resolve + server-render for a tool's `data` payload → a full HTML doc, or null. */
+export function renderWidgetForData(data: unknown, env: NodeJS.ProcessEnv = process.env): string | null {
+  const fragment = renderWidgetFragment(data, env);
+  return fragment ? renderWidgetDocument(fragment) : null;
 }
 
 /** True when SOME widget (curated or authored) can render this data. */
 export function hasWidgetForData(data: unknown, env: NodeJS.ProcessEnv = process.env): boolean {
   const kind = widgetKind(data);
-  return !!kind && resolveWidget(kind, env) !== null;
+  return !!kind && resolveWidgetSource(kind, env) !== null;
 }

--- a/src/widgets/widget-types.ts
+++ b/src/widgets/widget-types.ts
@@ -43,13 +43,3 @@ export function widgetKind(data: unknown): string | null {
   const t = (data as { type?: unknown })?.type;
   return typeof t === 'string' && t.trim() ? t.trim() : null;
 }
-
-export interface WidgetSpec {
-  /** Unique name: `curated-<kind>` or `authored-<kind>`. */
-  name: string;
-  /** The data `type` this widget renders (weather, news, …). */
-  kind: string;
-  /** Self-contained body fragment (HTML + scoped <style> + <script> reading __WIDGET_DATA__). */
-  html: string;
-  source: 'curated' | 'authored';
-}

--- a/tests/widgets/widget-registry.test.ts
+++ b/tests/widgets/widget-registry.test.ts
@@ -1,12 +1,14 @@
 /**
  * Widget registry — curated resolution, authored fallback (curated wins), and
- * safe data injection. Pure/isolated (temp authored dir).
+ * SERVER-SIDE rendering (data interpolated into static HTML, no client script —
+ * CSP-proof for inline srcdoc iframes). Pure/isolated (temp authored dir).
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  resolveWidget,
+  resolveWidgetSource,
+  renderWidgetFragment,
   renderWidgetDocument,
   renderWidgetForData,
   hasWidgetForData,
@@ -21,15 +23,15 @@ const sampleWeather: WeatherWidgetData = {
   units: 'metric',
 };
 
-describe('resolveWidget', () => {
-  it('returns curated widgets for weather and news', () => {
-    expect(resolveWidget('weather')?.source).toBe('curated');
-    expect(resolveWidget('news')?.name).toBe('curated-news');
-    expect(resolveWidget('WEATHER')?.kind).toBe('weather'); // case-insensitive
+describe('resolveWidgetSource', () => {
+  it('returns curated for weather and news (case-insensitive)', () => {
+    expect(resolveWidgetSource('weather')).toBe('curated');
+    expect(resolveWidgetSource('news')).toBe('curated');
+    expect(resolveWidgetSource('WEATHER')).toBe('curated');
   });
 
   it('returns null for an unknown kind with no authored widget', () => {
-    expect(resolveWidget('stock', {} as NodeJS.ProcessEnv)).toBeNull();
+    expect(resolveWidgetSource('stock', {} as NodeJS.ProcessEnv)).toBeNull();
   });
 
   it('falls back to an authored widget for a NEW kind, but curated wins', () => {
@@ -38,31 +40,54 @@ describe('resolveWidget', () => {
     // Authored widget for a novel kind 'stock'.
     mkdirSync(join(dir, 'authored-stock'), { recursive: true });
     writeFileSync(join(dir, 'authored-stock', 'widget.html'), '<div>stock</div>');
-    expect(resolveWidget('stock', env)?.source).toBe('authored');
+    expect(resolveWidgetSource('stock', env)).toBe('authored');
     // An authored 'weather' must NOT shadow the curated one.
     mkdirSync(join(dir, 'authored-weather'), { recursive: true });
     writeFileSync(join(dir, 'authored-weather', 'widget.html'), '<div>evil</div>');
-    expect(resolveWidget('weather', env)?.source).toBe('curated');
+    expect(resolveWidgetSource('weather', env)).toBe('curated');
   });
 });
 
-describe('renderWidgetDocument + data injection', () => {
-  it('produces a self-contained doc with the data injected and no </script> breakout', () => {
-    const spec = resolveWidget('weather')!;
-    const doc = renderWidgetDocument(spec, { type: 'weather', location: '</script><b>x' });
+describe('server-side rendering (no client script)', () => {
+  it('renderWidgetForData interpolates the real data, wraps a full doc, and injects NO script', () => {
+    const doc = renderWidgetForData(sampleWeather)!;
     expect(doc).toContain('<!doctype html>');
-    expect(doc).toContain('window.__WIDGET_DATA__=');
-    // The injected JSON must not contain a raw closing script tag.
-    expect(doc).not.toContain('</script><b>x'); // escaped to <
-    expect(doc).toContain('\\u003c/script');
+    expect(doc).toContain('Paris'); // location interpolated directly into the HTML
+    expect(doc).toContain('22°C'); // temperature rendered server-side
+    expect(doc).not.toContain('window.__WIDGET_DATA__'); // no client-side data script
+    expect(doc).not.toMatch(/<script/i); // CSP-proof: zero <script>
   });
 
-  it('renderWidgetForData resolves + renders, null for an unrecognized payload', () => {
-    const doc = renderWidgetForData(sampleWeather);
-    expect(doc).toContain('Paris'); // location travels in the injected JSON payload
-    expect(doc).toContain('window.__WIDGET_DATA__');
+  it('escapes injected values so they cannot break out of the markup', () => {
+    const doc = renderWidgetForData({ type: 'weather', location: '</div><b>x', current: {} })!;
+    expect(doc).not.toContain('</div><b>x'); // '<' and '>' are HTML-escaped
+    expect(doc).toContain('&lt;'); // proof of escaping
+  });
+
+  it('renderWidgetFragment returns null for an unrecognized payload', () => {
+    expect(renderWidgetFragment({ nope: true })).toBeNull();
+    expect(renderWidgetFragment('not an object')).toBeNull();
+  });
+
+  it('renderWidgetForData returns null for an unrecognized payload', () => {
     expect(renderWidgetForData({ nope: true })).toBeNull();
-    expect(renderWidgetForData('not an object')).toBeNull();
+  });
+
+  it('renders a news payload server-side with the item titles inline', () => {
+    const doc = renderWidgetForData({
+      type: 'news',
+      title: 'À la une',
+      items: [{ title: 'Titre A', source: 'Le Monde' }],
+    })!;
+    expect(doc).toContain('À la une');
+    expect(doc).toContain('Titre A');
+    expect(doc).not.toMatch(/<script/i);
+  });
+
+  it('renderWidgetDocument wraps a fragment into a self-contained doc', () => {
+    const doc = renderWidgetDocument('<div>hi</div>');
+    expect(doc).toContain('<!doctype html>');
+    expect(doc).toContain('<div>hi</div>');
   });
 });
 


### PR DESCRIPTION
## Problème

Les widgets météo/actus s'affichaient **blancs** inline dans Cowork. Diagnostic CDP : les iframes `srcDoc` **héritent de la CSP du document hôte** Electron (`script-src 'self'`, sans `unsafe-inline`), donc le `<script>` inline qui posait `window.__WIDGET_DATA__` était bloqué → `.cbw-weather` vide.

## Fix — rendu 100% côté serveur

Les curated widgets deviennent des **fonctions de rendu pures** : les données sont interpolées dans du HTML+CSS statique (échappé, thème clair/sombre), **zéro `<script>` client**. Rendu identique sous n'importe quelle CSP.

- `src/widgets/curated/{weather,news}.ts` → `renderWeatherWidget` / `renderNewsWidget` (fragment auto-contenu).
- `src/widgets/widget-registry.ts` → `CURATED` = map de renderers ; `renderWidgetFragment` / `renderWidgetDocument` (wrap sans data-script) / `renderWidgetForData` / `hasWidgetForData` / `resolveWidgetSource` (curated gagne sur authored).
- `widget-types.ts` → retrait de `WidgetSpec` (obsolète). Tests réécrits (11 verts).

## Câblage inline Cowork (Phase 1b)

- `cowork/src/main/ipc/widgets-ipc.ts` → IPC `widgets.render(data)` → `renderWidgetForData` via `loadCoreModule`, fail-closed.
- `cowork/src/renderer/components/widgets/WidgetBlock.tsx` → iframe **sandbox durcie** : plus de `allow-scripts` (inutile), `allow-popups` pour les liens d'actu, **jamais `allow-same-origin`**.
- Propagation de `tool_result.data` jusqu'au bloc (types, engine-runner, agent-runner, ToolResult/ToolUse/ActivityGroup, preload).

## Preuve live (CDP, renderer Electron réel)

`bodyLen: 1768`, `.cbw-weather` peuplée (« Paris 22°C Ensoleillé ☀️ Ressenti 24°C · 💧66% · 💨6 km/h » + prévisions jeu/ven), `hasScriptTag: false`, sous CSP `script-src 'self'`. Capture d'écran : carte météo rendue inline.

## Vérif
- `npx tsc --noEmit` racine + `cowork` = 0
- `vitest run tests/widgets/` = 11/11

Phase 1 (registre + widgets curated) livrée en #58 ; ceci est le **fix CSP + câblage Cowork**. Phase 2 (moteur génératif auto-apprenant `authored-*`) suit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)