### PR TITLE
feat(widgets): moteur génératif auto-apprenant (authored, façon skills)

### DIFF
--- a/cowork/src/main/ipc/widgets-ipc.ts
+++ b/cowork/src/main/ipc/widgets-ipc.ts
@@ -7,6 +7,10 @@ interface WidgetRegistryModule {
   renderWidgetForData?: (data: unknown) => string | null;
 }
 
+interface WidgetEngineModule {
+  resolveOrGenerate?: (data: unknown) => Promise<string | null>;
+}
+
 function hasStructuredType(data: unknown): data is { type: string } {
   return (
     typeof data === 'object' &&
@@ -20,6 +24,20 @@ export function registerWidgetsIpcHandlers(): void {
     if (!hasStructuredType(data)) return null;
 
     try {
+      // Prefer the engine: it renders known kinds instantly AND, when opted in
+      // (CODEBUDDY_WIDGETS=true), authors+gates+keeps a widget for a NEW kind.
+      // Default off ⇒ behaves exactly like renderWidgetForData. never-throws.
+      try {
+        const engine = await loadCoreModule<WidgetEngineModule>('widgets/widget-engine.js');
+        if (engine?.resolveOrGenerate) {
+          const html = await engine.resolveOrGenerate(data);
+          if (typeof html === 'string' && html.trim().length > 0) return html;
+          // engine returned null (miss + generation off/failed) → fall through to registry
+        }
+      } catch (engineError) {
+        logError('[widgets-ipc] engine unavailable, falling back to registry:', engineError);
+      }
+
       const mod = await loadCoreModule<WidgetRegistryModule>('widgets/widget-registry.js');
       if (!mod?.renderWidgetForData) return null;
       if (mod.hasWidgetForData && !mod.hasWidgetForData(data)) return null;

--- a/src/commands/widgets.ts
+++ b/src/commands/widgets.ts
@@ -1,0 +1,138 @@
+/**
+ * `buddy widgets` — inspect, preview and generate inline conversation widgets.
+ * Mirrors `buddy improve skills`. Curated widgets are always available; authored
+ * ones are generated on the fly and reused (see src/widgets/widget-engine).
+ *
+ * @module commands/widgets
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Command } from 'commander';
+import { logger } from '../utils/logger.js';
+import {
+  authoredWidgetsDir,
+  renderWidgetForData,
+  resolveWidgetSource,
+} from '../widgets/widget-registry.js';
+import { listAuthoredWidgets, keepAuthoredWidget } from '../widgets/widget-engine.js';
+import { proposeWidget } from '../widgets/widget-proposer.js';
+import { gateWidget } from '../widgets/widget-gate.js';
+
+const CURATED_KINDS = ['weather', 'news'] as const;
+
+/** Built-in sample payloads so `preview` works for curated kinds with no --sample. */
+const SAMPLES: Record<string, unknown> = {
+  weather: {
+    type: 'weather',
+    location: 'Paris',
+    current: { temperature: 22, feelsLike: 24, condition: 'ensoleillé', humidity: 66, windSpeed: 6 },
+    forecast: [
+      { day: 'jeu', min: 15, max: 24, condition: 'ensoleillé' },
+      { day: 'ven', min: 14, max: 21, condition: 'nuageux' },
+    ],
+    units: 'metric',
+  },
+  news: {
+    type: 'news',
+    title: 'À la une',
+    items: [
+      { title: 'Un titre d\'actualité', source: 'Le Monde' },
+      { title: 'Un autre titre', source: 'AFP' },
+    ],
+  },
+};
+
+function parseSample(raw: string | undefined, kind: string): unknown {
+  if (raw && raw.trim()) {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !(parsed as { type?: unknown }).type) {
+      (parsed as Record<string, unknown>).type = kind;
+    }
+    return parsed;
+  }
+  const s = SAMPLES[kind];
+  if (!s) throw new Error(`no built-in sample for "${kind}" — pass --sample '<json>'`);
+  return s;
+}
+
+export function registerWidgetsCommand(program: Command): void {
+  const widgets = program
+    .command('widgets')
+    .description('Inline conversation widgets: list, preview, and generate (authored) widgets');
+
+  widgets
+    .command('list')
+    .description('List curated and authored widgets')
+    .action(() => {
+      logger.info('Curated widgets:');
+      for (const k of CURATED_KINDS) logger.info(`  • ${k}`);
+      const authored = listAuthoredWidgets();
+      logger.info(`\nAuthored widgets (${authored.length}):`);
+      if (authored.length === 0) logger.info('  (none yet — generated on demand with CODEBUDDY_WIDGETS=true)');
+      for (const k of authored) logger.info(`  • ${k}  (authored-${k}/widget.html)`);
+    });
+
+  widgets
+    .command('preview <kind>')
+    .description('Render a widget to an HTML file and print its path')
+    .option('--sample <json>', 'sample data payload (JSON); defaults to a built-in sample for curated kinds')
+    .action((kind: string, opts: { sample?: string }) => {
+      try {
+        const data = parseSample(opts.sample, kind);
+        const doc = renderWidgetForData(data);
+        if (!doc) {
+          logger.error(`No widget renders "${kind}". Curated: ${CURATED_KINDS.join(', ')}; authored: ${listAuthoredWidgets().join(', ') || '(none)'}.`);
+          process.exitCode = 1;
+          return;
+        }
+        const dir = authoredWidgetsDir();
+        mkdirSync(dir, { recursive: true });
+        const out = join(dir, `preview-${kind}.html`);
+        writeFileSync(out, doc);
+        logger.info(`Preview written: ${out}`);
+        logger.info(`Source: ${resolveWidgetSource(kind) ?? 'unknown'}`);
+      } catch (e) {
+        logger.error(`preview failed: ${e instanceof Error ? e.message : String(e)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  widgets
+    .command('gen <kind>')
+    .description('Generate (LLM) an authored widget for a kind, gate it, and keep it if safe')
+    .option('--sample <json>', 'sample data payload (JSON) to design against')
+    .option('--brief <text>', 'design intention for the proposer')
+    .action(async (kind: string, opts: { sample?: string; brief?: string }) => {
+      try {
+        if (resolveWidgetSource(kind) === 'curated') {
+          logger.error(`"${kind}" is a curated widget — authored widgets can never shadow it.`);
+          process.exitCode = 1;
+          return;
+        }
+        const data = parseSample(opts.sample, kind);
+        logger.info(`Proposing a widget for "${kind}"…`);
+        const proposal = await proposeWidget(kind, data, opts.brief);
+        if (!proposal) {
+          logger.error('No proposal (LLM unavailable or empty). Ensure a provider is configured (buddy login).');
+          process.exitCode = 1;
+          return;
+        }
+        const verdict = gateWidget(proposal);
+        if (!verdict.accepted) {
+          logger.error(`Rejected by gate (${verdict.reason}): ${(verdict.reasons ?? []).join('; ')}`);
+          process.exitCode = 1;
+          return;
+        }
+        const kept = keepAuthoredWidget(proposal);
+        if (!kept) {
+          logger.error('Passed the gate but could not be persisted.');
+          process.exitCode = 1;
+          return;
+        }
+        logger.info(`✓ Kept authored-${kind}/widget.html. Preview: buddy widgets preview ${kind}`);
+      } catch (e) {
+        logger.error(`gen failed: ${e instanceof Error ? e.message : String(e)}`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3127,6 +3127,11 @@ addLazyCommandGroup(program, 'assistant', 'Manage the voice assistant (Lisa): im
   registerAssistantCommand(program);
 });
 
+addLazyCommandGroup(program, 'widgets', 'Inline conversation widgets: list, preview, generate (authored)', async () => {
+  const { registerWidgetsCommand } = await import('./commands/widgets.js');
+  registerWidgetsCommand(program);
+});
+
 // Utility commands (doctor, security-audit, onboard, webhook) are all registered
 // by a single registerUtilityCommands() call, so we must remove all stubs before
 // re-registering to avoid Commander duplicate command errors.

--- a/src/widgets/template-engine.ts
+++ b/src/widgets/template-engine.ts
@@ -1,0 +1,148 @@
+/**
+ * Tiny, SAFE Mustache-style template engine for AUTHORED widgets. Authored
+ * widgets are data-driven yet inert: `{{path}}` interpolation is ALWAYS
+ * HTML-escaped, `{{#each}}`/`{{#if}}` are the only control structures, and there
+ * is NO expression evaluation, NO function calls, NO `eval`. A template is a
+ * pure string transform — CSP-proof (no client script) and injection-safe (every
+ * interpolated value is escaped, so authored data can never inject markup).
+ *
+ * Grammar:
+ *   {{ a.b.c }}            → HTML-escaped value at dot-path (empty if missing)
+ *   {{#each items}} … {{/each}}   → iterate an array; inside, {{this}} / {{field}}
+ *   {{#if flag}} … {{else}} … {{/if}}  → truthy conditional
+ * Paths resolve against the current item, walking up to parent contexts.
+ *
+ * @module widgets/template-engine
+ */
+
+export function escapeHtml(s: unknown): string {
+  return String(s == null ? '' : s).replace(
+    /[&<>"']/g,
+    (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[m]!
+  );
+}
+
+interface Ctx {
+  data: unknown;
+  parent?: Ctx;
+}
+
+/** Resolve a dot-path against the context chain (item → parents). undefined if unresolved. */
+function resolvePath(path: string, ctx: Ctx): unknown {
+  const p = path.trim();
+  if (p === 'this' || p === '.') return ctx.data;
+  const parts = p.replace(/^this\./, '').split('.').map((s) => s.trim()).filter(Boolean);
+  if (parts.length === 0) return ctx.data;
+  for (let cur: Ctx | undefined = ctx; cur; cur = cur.parent) {
+    let val: unknown = cur.data;
+    let ok = true;
+    for (const key of parts) {
+      if (val != null && typeof val === 'object' && key in (val as object)) {
+        val = (val as Record<string, unknown>)[key];
+      } else {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return val;
+  }
+  return undefined;
+}
+
+function isTruthy(v: unknown): boolean {
+  if (Array.isArray(v)) return v.length > 0;
+  return !!v;
+}
+
+type Token = { text: string } | { tag: string };
+
+function tokenize(tpl: string): Token[] {
+  const tokens: Token[] = [];
+  const re = /\{\{\{?\s*([^}]*?)\s*\}?\}\}/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(tpl)) !== null) {
+    if (m.index > last) tokens.push({ text: tpl.slice(last, m.index) });
+    tokens.push({ tag: m[1]!.trim() });
+    last = re.lastIndex;
+  }
+  if (last < tpl.length) tokens.push({ text: tpl.slice(last) });
+  return tokens;
+}
+
+/**
+ * Render a chunk of tokens from index `start` until an optional stop tag.
+ * Returns the produced string and the index of the token AFTER the stop tag.
+ */
+function renderTokens(
+  tokens: Token[],
+  start: number,
+  ctx: Ctx,
+  stop: (tag: string) => boolean
+): { out: string; next: number } {
+  let out = '';
+  let i = start;
+  while (i < tokens.length) {
+    const tok = tokens[i]!;
+    if ('text' in tok) {
+      out += tok.text;
+      i++;
+      continue;
+    }
+    const tag = tok.tag;
+    if (stop(tag)) return { out, next: i };
+
+    if (tag.startsWith('#each ')) {
+      const path = tag.slice(6).trim();
+      const bodyStart = i + 1;
+      // Find the matching {{/each}} to know where the block ends (skip nested each).
+      const arr = resolvePath(path, ctx);
+      const items = Array.isArray(arr) ? arr : [];
+      let rendered = '';
+      let endIdx = bodyStart;
+      if (items.length === 0) {
+        // Render once into a sink to advance past the block.
+        const sink = renderTokens(tokens, bodyStart, ctx, (t) => t === '/each');
+        endIdx = sink.next;
+      } else {
+        for (let k = 0; k < items.length; k++) {
+          const r = renderTokens(tokens, bodyStart, { data: items[k], parent: ctx }, (t) => t === '/each');
+          rendered += r.out;
+          endIdx = r.next;
+        }
+      }
+      out += rendered;
+      i = endIdx + 1; // skip the {{/each}}
+      continue;
+    }
+
+    if (tag.startsWith('#if ')) {
+      const path = tag.slice(4).trim();
+      const truthy = isTruthy(resolvePath(path, ctx));
+      // Render the "then" branch up to {{else}} or {{/if}}.
+      const thenR = renderTokens(tokens, i + 1, ctx, (t) => t === 'else' || t === '/if');
+      let afterThen = thenR.next;
+      let elseOut = '';
+      let endIf = afterThen;
+      if (tokens[afterThen] && 'tag' in tokens[afterThen]! && (tokens[afterThen] as { tag: string }).tag === 'else') {
+        const elseR = renderTokens(tokens, afterThen + 1, ctx, (t) => t === '/if');
+        elseOut = elseR.out;
+        endIf = elseR.next;
+      }
+      out += truthy ? thenR.out : elseOut;
+      i = endIf + 1; // skip {{/if}}
+      continue;
+    }
+
+    // Plain interpolation — ALWAYS escaped.
+    out += escapeHtml(resolvePath(tag, ctx));
+    i++;
+  }
+  return { out, next: i };
+}
+
+/** Render a safe Mustache-style template with `data`. Pure, never executes code. */
+export function renderTemplate(tpl: string, data: unknown): string {
+  const tokens = tokenize(tpl);
+  return renderTokens(tokens, 0, { data }, () => false).out;
+}

--- a/src/widgets/widget-engine.ts
+++ b/src/widgets/widget-engine.ts
@@ -1,0 +1,137 @@
+/**
+ * Widget engine — the self-learning loop (mirrors the authored-skills/tools
+ * engine): resolve a widget for a data payload, and when none exists, GENERATE
+ * one on the fly, GATE it (fail-closed), KEEP it under `authored-<kind>/`, and
+ * render — so the next time the same `kind` appears it is an instant registry
+ * hit. Authored templates are inert Mustache (see template-engine + widget-gate).
+ *
+ * Opt-in via `CODEBUDDY_WIDGETS=true` (default off ⇒ generation never runs, only
+ * curated widgets render). never-throws — any failure falls back to null (the UI
+ * shows plain text). Every proposal (kept or rejected) is appended to an audit
+ * ledger.
+ *
+ * @module widgets/widget-engine
+ */
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { widgetKind, type WidgetProposal } from './widget-types.js';
+import {
+  authoredWidgetsDir,
+  hasWidgetForData,
+  renderWidgetForData,
+  resolveWidgetSource,
+} from './widget-registry.js';
+import { gateWidget } from './widget-gate.js';
+import { proposeWidget, type ProposeWidgetDeps } from './widget-proposer.js';
+
+export interface ResolveOrGenerateDeps extends ProposeWidgetDeps {
+  /** Human-readable brief passed to the proposer. */
+  brief?: string;
+  /** Override the propose step (tests). */
+  propose?: (kind: string, sample: unknown, brief?: string) => Promise<WidgetProposal | null>;
+}
+
+function authoredDir(kind: string, env: NodeJS.ProcessEnv): string {
+  return join(authoredWidgetsDir(env), `authored-${kind}`);
+}
+
+function ledgerPath(env: NodeJS.ProcessEnv): string {
+  return join(authoredWidgetsDir(env), 'archive.jsonl');
+}
+
+/** Append a proposal outcome to the audit ledger (append-only). never-throws. */
+function recordLedger(entry: Record<string, unknown>, env: NodeJS.ProcessEnv): void {
+  try {
+    mkdirSync(authoredWidgetsDir(env), { recursive: true });
+    appendFileSync(ledgerPath(env), JSON.stringify({ ts: Date.now(), ...entry }) + '\n');
+  } catch {
+    /* audit is best-effort */
+  }
+}
+
+/** Persist an accepted authored widget template. never-throws (returns false on failure). */
+export function keepAuthoredWidget(proposal: WidgetProposal, env: NodeJS.ProcessEnv = process.env): boolean {
+  const kind = proposal.kind.trim().toLowerCase();
+  // authored-* can NEVER shadow a curated widget.
+  if (resolveWidgetSource(kind, env) === 'curated') return false;
+  try {
+    const dir = authoredDir(kind, env);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'widget.html'), proposal.template);
+    writeFileSync(
+      join(dir, 'meta.json'),
+      JSON.stringify({ kind, source: 'authored', createdAt: Date.now(), brief: proposal.brief ?? null }, null, 2)
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** List authored widget kinds present on disk. */
+export function listAuthoredWidgets(env: NodeJS.ProcessEnv = process.env): string[] {
+  try {
+    return readdirSync(authoredWidgetsDir(env), { withFileTypes: true })
+      .filter((d) => d.isDirectory() && d.name.startsWith('authored-'))
+      .map((d) => d.name.slice('authored-'.length))
+      .filter((k) => existsSync(join(authoredWidgetsDir(env), `authored-${k}`, 'widget.html')));
+  } catch {
+    return [];
+  }
+}
+
+/** Read an authored widget's raw template (or null). */
+export function readAuthoredTemplate(kind: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  try {
+    const p = join(authoredDir(kind.trim().toLowerCase(), env), 'widget.html');
+    return existsSync(p) ? readFileSync(p, 'utf8') : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a widget document for `data`; if none exists and generation is enabled,
+ * author one, gate it, keep it, then render. Returns the full HTML doc or null.
+ * never-throws.
+ */
+export async function resolveOrGenerate(
+  data: unknown,
+  deps: ResolveOrGenerateDeps = {}
+): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  try {
+    // Registry hit (curated or an already-authored kind) → render immediately.
+    if (hasWidgetForData(data, env)) {
+      return renderWidgetForData(data, env);
+    }
+
+    // Miss. Generation is strictly opt-in.
+    if (env.CODEBUDDY_WIDGETS !== 'true') return null;
+
+    const kind = widgetKind(data)?.toLowerCase();
+    if (!kind) return null;
+
+    const propose = deps.propose ?? ((k, s, b) => proposeWidget(k, s, b, deps));
+    const proposal = await propose(kind, data, deps.brief);
+    if (!proposal) {
+      recordLedger({ kind, accepted: false, reason: 'no-proposal' }, env);
+      return null;
+    }
+
+    const verdict = gateWidget(proposal);
+    if (!verdict.accepted) {
+      recordLedger({ kind, accepted: false, reason: verdict.reason, reasons: verdict.reasons }, env);
+      return null;
+    }
+
+    const kept = keepAuthoredWidget(proposal, env);
+    recordLedger({ kind, accepted: kept, reason: kept ? 'kept' : 'keep-failed' }, env);
+    if (!kept) return null;
+
+    // Render fresh from the newly-kept authored template.
+    return renderWidgetForData(data, env);
+  } catch {
+    return null;
+  }
+}

--- a/src/widgets/widget-gate.ts
+++ b/src/widgets/widget-gate.ts
@@ -1,0 +1,81 @@
+/**
+ * Widget gate — validates an LLM-proposed authored widget template. Ordered,
+ * blocking, FAIL-CLOSED (anything unproven is rejected; nothing is kept on a
+ * miss). Mirrors the self-improvement skill/tool gates.
+ *
+ *   G1 STATIC FIREWALL — the authored template must be inert & self-contained:
+ *      no <script>, no inline event handlers, no `javascript:`, no external
+ *      resource loads (src=, external stylesheet, @import, url(http…)), no
+ *      <iframe>/<object>/<embed>. (Outbound <a href> links ARE allowed.)
+ *   G2 RENDER — `renderTemplate(template, sample)` must produce non-empty output,
+ *      leave NO unresolved `{{…}}` tokens, and the rendered HTML must ALSO pass
+ *      the firewall (defence in depth; data is escaped so this is belt & braces).
+ *
+ * Pure & synchronous — no I/O, no network, no code execution.
+ *
+ * @module widgets/widget-gate
+ */
+import { renderTemplate } from './template-engine.js';
+import type { WidgetProposal, WidgetGateOutcome } from './widget-types.js';
+
+/** Patterns that make a widget unsafe (loads/executes code or phones home). */
+const FIREWALL_PATTERNS: Array<{ re: RegExp; why: string }> = [
+  { re: /<\s*script\b/i, why: 'inline <script> (CSP-blocked and unsafe)' },
+  { re: /<\s*(iframe|object|embed|frame|frameset)\b/i, why: 'nested framing/embedding element' },
+  { re: /\son[a-z]+\s*=/i, why: 'inline event handler (onload/onclick/…)' },
+  { re: /javascript\s*:/i, why: 'javascript: URL' },
+  { re: /\bdata\s*:\s*text\/html/i, why: 'data:text/html payload' },
+  { re: /<\s*link\b[^>]*\bhref\s*=\s*["']?\s*https?:/i, why: 'external stylesheet <link>' },
+  { re: /@import\b/i, why: '@import (external stylesheet load)' },
+  { re: /\burl\s*\(\s*["']?\s*(https?:)?\/\//i, why: 'url() loading an external resource' },
+  // A resource-loading `src=` to an external/absolute URL. Escaped `{{ }}` is fine.
+  { re: /\bsrc\s*=\s*["']?\s*(https?:)?\/\//i, why: 'external resource via src=' },
+  { re: /<\s*(base|meta)\b/i, why: '<base>/<meta> (can redirect resource resolution)' },
+];
+
+/** Scan a chunk of HTML for firewall violations. Returns the list of reasons (empty = safe). */
+export function scanWidgetFirewall(html: string): string[] {
+  const reasons: string[] = [];
+  for (const { re, why } of FIREWALL_PATTERNS) {
+    if (re.test(html)) reasons.push(why);
+  }
+  return reasons;
+}
+
+/** Run a proposal through the gate. Fail-closed. Pure. */
+export function gateWidget(proposal: WidgetProposal): WidgetGateOutcome {
+  const template = (proposal?.template ?? '').trim();
+  if (!template) {
+    return { accepted: false, reason: 'render-empty', reasons: ['empty template'] };
+  }
+
+  // G1 — firewall on the raw template.
+  const staticReasons = scanWidgetFirewall(template);
+  if (staticReasons.length > 0) {
+    return { accepted: false, reason: 'static-scan', reasons: staticReasons };
+  }
+
+  // G2 — render with the sample and re-check.
+  let fragment: string;
+  try {
+    fragment = renderTemplate(template, proposal.sample);
+  } catch (e) {
+    return { accepted: false, reason: 'render-empty', reasons: [`render threw: ${String(e)}`] };
+  }
+  if (!fragment.trim()) {
+    return { accepted: false, reason: 'render-empty', reasons: ['template rendered to empty output'] };
+  }
+  if (/\{\{.*?\}\}/.test(fragment)) {
+    return {
+      accepted: false,
+      reason: 'unrendered-tokens',
+      reasons: ['rendered output still contains unresolved {{…}} tokens'],
+    };
+  }
+  const renderedReasons = scanWidgetFirewall(fragment);
+  if (renderedReasons.length > 0) {
+    return { accepted: false, reason: 'render-unsafe', reasons: renderedReasons };
+  }
+
+  return { accepted: true, fragment };
+}

--- a/src/widgets/widget-proposer.ts
+++ b/src/widgets/widget-proposer.ts
@@ -1,0 +1,96 @@
+/**
+ * Widget proposer — asks the LLM (one-shot, $0 via the resolved command provider)
+ * to author a NEW widget for a data `kind` it doesn't have yet. The model returns
+ * a SAFE Mustache-style HTML+CSS template (no script, self-contained) which the
+ * gate then validates before anything is kept. The `chat` fn is injectable for
+ * deterministic tests. never-throws (returns null on any failure).
+ *
+ * @module widgets/widget-proposer
+ */
+import type { WidgetProposal } from './widget-types.js';
+
+export type WidgetChat = (system: string, user: string) => Promise<string>;
+
+export interface ProposeWidgetDeps {
+  chat?: WidgetChat;
+  env?: NodeJS.ProcessEnv;
+}
+
+const SYSTEM = [
+  'Tu es un designer UI. On te donne un type de données structurées et un exemple JSON.',
+  "Tu produis UN composant HTML AUTO-CONTENU qui affiche ces données joliment, INLINE dans une conversation.",
+  '',
+  'RÈGLES STRICTES (sinon rejeté) :',
+  '- Format Mustache SÛR uniquement : {{ chemin.valeur }} pour interpoler (toujours échappé),',
+  "  {{#each liste}} … {{/each}} pour itérer (à l'intérieur : {{ this }} ou {{ champ }}),",
+  '  {{#if champ}} … {{else}} … {{/if}} pour un conditionnel. AUCUNE autre syntaxe.',
+  "- ZÉRO <script>, zéro gestionnaire d'événement (onclick…), zéro javascript:.",
+  '- ZÉRO ressource externe : pas de src=http, pas de <link> feuille de style externe, pas de @import,',
+  '  pas de url(http…), pas de police/CDN distant, pas de <iframe>/<object>/<embed>.',
+  "- Tout le style dans un <style> scopé sous une classe racine .cbw-<type> (police système).",
+  '- Thème clair ET sombre (via @media (prefers-color-scheme: dark)).',
+  '- Largeur max ~520px, coins arrondis, soigné. Les liens <a href> externes sont autorisés.',
+  '',
+  'Réponds UNIQUEMENT en JSON : {"template": "<style>…</style><div class=\\"cbw-<type>\\">…</div>"}',
+].join('\n');
+
+function buildUser(kind: string, sample: unknown, brief?: string): string {
+  const json = JSON.stringify(sample, null, 2).slice(0, 2000);
+  return [
+    `Type de données : "${kind}".`,
+    brief ? `Intention : ${brief}` : '',
+    'Exemple de données (window de rendu) :',
+    '```json',
+    json,
+    '```',
+    `Crée le template Mustache du widget "${kind}". Référence les vrais chemins de l'exemple.`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function defaultChat(env: NodeJS.ProcessEnv): Promise<WidgetChat | null> {
+  try {
+    const { resolveCommandProvider } = await import('../commands/llm-provider-resolution.js');
+    const resolved = resolveCommandProvider({});
+    if (!resolved) return null;
+    const { CodeBuddyClient } = await import('../codebuddy/client.js');
+    const client = new CodeBuddyClient(resolved.apiKey, resolved.model, resolved.baseURL);
+    return async (system: string, user: string) => {
+      const resp = await client.chat(
+        [
+          { role: 'system', content: system },
+          { role: 'user', content: user },
+        ],
+        undefined,
+        { responseFormat: 'json' }
+      );
+      return resp?.choices?.[0]?.message?.content ?? '';
+    };
+  } catch {
+    void env;
+    return null;
+  }
+}
+
+/** Propose an authored widget template for `kind` given a sample payload. null on failure. */
+export async function proposeWidget(
+  kind: string,
+  sample: unknown,
+  brief?: string,
+  deps: ProposeWidgetDeps = {}
+): Promise<WidgetProposal | null> {
+  const env = deps.env ?? process.env;
+  try {
+    const chat = deps.chat ?? (await defaultChat(env));
+    if (!chat) return null;
+    const { generateJsonWithRetry } = await import('../utils/llm-retry.js');
+    const gen = (u: string): Promise<string> => chat(SYSTEM, u);
+    const parsed = await generateJsonWithRetry<{ template?: unknown }>(gen, buildUser(kind, sample, brief));
+    const template = typeof parsed?.template === 'string' ? parsed.template.trim() : '';
+    if (!template) return null;
+    return { kind, template, sample, ...(brief ? { brief } : {}) };
+  } catch {
+    return null;
+  }
+}

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import { renderWeatherWidget } from './curated/weather.js';
 import { renderNewsWidget } from './curated/news.js';
 import { widgetKind } from './widget-types.js';
+import { renderTemplate } from './template-engine.js';
 
 /** Curated server-side renderers: data → self-contained HTML fragment (no script). */
 const CURATED: Record<string, (data: unknown) => string> = {
@@ -61,8 +62,11 @@ export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = pro
   try {
     const p = join(authoredWidgetsDir(env), `authored-${kind}`, 'widget.html');
     if (existsSync(p)) {
-      const html = readFileSync(p, 'utf8');
-      if (html.trim()) return html;
+      const tpl = readFileSync(p, 'utf8');
+      // Authored widgets are SAFE Mustache-style templates, rendered server-side
+      // with the data interpolated (always escaped). No client script, CSP-proof.
+      const frag = renderTemplate(tpl, data);
+      if (frag.trim()) return frag;
     }
   } catch {
     /* none */

--- a/src/widgets/widget-types.ts
+++ b/src/widgets/widget-types.ts
@@ -43,3 +43,25 @@ export function widgetKind(data: unknown): string | null {
   const t = (data as { type?: unknown })?.type;
   return typeof t === 'string' && t.trim() ? t.trim() : null;
 }
+
+/** A candidate authored widget (LLM-proposed), before it clears the gate. */
+export interface WidgetProposal {
+  /** The data `type` this widget renders. */
+  kind: string;
+  /** SAFE Mustache-style HTML+CSS template (no script), read by the template engine. */
+  template: string;
+  /** Sample data the gate renders the template against. */
+  sample: unknown;
+  /** Optional human-readable brief the proposer was given. */
+  brief?: string;
+}
+
+/** Result of running a proposal through the widget gate (fail-closed). */
+export interface WidgetGateOutcome {
+  accepted: boolean;
+  /** Short machine reason on reject (`static-scan` | `render-empty` | `render-unsafe` | `unrendered-tokens`). */
+  reason?: string;
+  reasons?: string[];
+  /** The rendered sample fragment, present only on accept. */
+  fragment?: string;
+}

--- a/tests/widgets/template-engine.test.ts
+++ b/tests/widgets/template-engine.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Safe Mustache-style template engine — interpolation is always escaped, control
+ * blocks work, no code is executed. Pure.
+ */
+import { renderTemplate, escapeHtml } from '../../src/widgets/template-engine.js';
+
+describe('escapeHtml', () => {
+  it('escapes the dangerous HTML characters', () => {
+    expect(escapeHtml('<b>"x"&\'y\'')).toBe('&lt;b&gt;&quot;x&quot;&amp;&#39;y&#39;');
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(42)).toBe('42');
+  });
+});
+
+describe('renderTemplate', () => {
+  it('interpolates dot-paths and escapes the value', () => {
+    const out = renderTemplate('Hi {{ user.name }}!', { user: { name: '<b>x</b>' } });
+    expect(out).toBe('Hi &lt;b&gt;x&lt;/b&gt;!');
+  });
+
+  it('renders empty for missing paths (never "undefined")', () => {
+    expect(renderTemplate('[{{ nope.deep }}]', {})).toBe('[]');
+  });
+
+  it('iterates arrays with {{#each}} and {{this}} / fields', () => {
+    const out = renderTemplate('{{#each items}}<li>{{this.t}}</li>{{/each}}', {
+      items: [{ t: 'a' }, { t: 'b' }],
+    });
+    expect(out).toBe('<li>a</li><li>b</li>');
+  });
+
+  it('supports {{#each}} over scalars via {{this}}', () => {
+    expect(renderTemplate('{{#each xs}}[{{this}}]{{/each}}', { xs: ['a', 'b'] })).toBe('[a][b]');
+  });
+
+  it('handles {{#if}} / {{else}} truthiness (empty array is falsy)', () => {
+    const tpl = '{{#if items}}has{{else}}none{{/if}}';
+    expect(renderTemplate(tpl, { items: [1] })).toBe('has');
+    expect(renderTemplate(tpl, { items: [] })).toBe('none');
+    expect(renderTemplate(tpl, {})).toBe('none');
+  });
+
+  it('resolves parent context from inside an each block', () => {
+    const out = renderTemplate('{{#each items}}{{ this }}@{{ city }} {{/each}}', {
+      city: 'Paris',
+      items: ['a', 'b'],
+    });
+    expect(out).toBe('a@Paris b@Paris ');
+  });
+
+  it('handles nested each', () => {
+    const out = renderTemplate('{{#each rows}}<r>{{#each cells}}{{this}}{{/each}}</r>{{/each}}', {
+      rows: [{ cells: ['1', '2'] }, { cells: ['3'] }],
+    });
+    expect(out).toBe('<r>12</r><r>3</r>');
+  });
+
+  it('never executes interpolated markup (XSS-safe)', () => {
+    const out = renderTemplate('<div>{{ x }}</div>', { x: '<img src=x onerror=alert(1)>' });
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+});

--- a/tests/widgets/widget-engine.test.ts
+++ b/tests/widgets/widget-engine.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Widget engine — the self-learning loop: curated hit, opt-in generation, gate,
+ * keep, reuse. Isolated temp authored dir; LLM propose step is injected.
+ */
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resolveOrGenerate,
+  keepAuthoredWidget,
+  listAuthoredWidgets,
+  readAuthoredTemplate,
+} from '../../src/widgets/widget-engine.js';
+import type { WidgetProposal } from '../../src/widgets/widget-types.js';
+
+function tmpEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+  const dir = mkdtempSync(join(tmpdir(), 'wdg-eng-'));
+  return { CODEBUDDY_WIDGETS_DIR: dir, ...extra } as NodeJS.ProcessEnv;
+}
+
+const STOCK = { type: 'stock', symbol: 'ACME', price: 42 };
+const CLEAN_TPL = '<style>.cbw-stock{padding:8px}</style><div class="cbw-stock">{{ symbol }} {{ price }}</div>';
+
+describe('resolveOrGenerate', () => {
+  it('renders a curated widget immediately (no generation needed)', async () => {
+    const env = tmpEnv(); // generation OFF, but curated always works
+    const doc = await resolveOrGenerate({ type: 'weather', location: 'Paris', current: { temperature: 20, condition: 'clair' } }, { env });
+    expect(doc).toContain('Paris');
+    expect(doc).toContain('<!doctype html>');
+  });
+
+  it('returns null for an unknown kind when generation is OFF (opt-in)', async () => {
+    const env = tmpEnv(); // CODEBUDDY_WIDGETS unset
+    const propose = jest.fn();
+    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    expect(doc).toBeNull();
+    expect(propose).not.toHaveBeenCalled();
+  });
+
+  it('generates, gates, keeps and RENDERS a new widget when enabled; reuses next time', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
+    const propose = jest.fn(
+      async (kind: string, sample: unknown): Promise<WidgetProposal> => ({ kind, template: CLEAN_TPL, sample })
+    );
+    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    expect(doc).toContain('ACME 42');
+    expect(listAuthoredWidgets(env)).toContain('stock');
+    expect(readAuthoredTemplate('stock', env)).toBe(CLEAN_TPL);
+
+    // Second call is a registry hit → propose NOT called again.
+    propose.mockClear();
+    const doc2 = await resolveOrGenerate({ type: 'stock', symbol: 'BETA', price: 7 }, { env, propose });
+    expect(doc2).toContain('BETA 7');
+    expect(propose).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsafe proposal and keeps NOTHING', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
+    const propose = async (kind: string, sample: unknown): Promise<WidgetProposal> => ({
+      kind,
+      template: '<div class="cbw-stock"><script>fetch("//evil")</script>{{ symbol }}</div>',
+      sample,
+    });
+    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    expect(doc).toBeNull();
+    expect(listAuthoredWidgets(env)).not.toContain('stock');
+  });
+
+  it('never-throws when the proposer returns null', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
+    const doc = await resolveOrGenerate(STOCK, { env, propose: async () => null });
+    expect(doc).toBeNull();
+  });
+});
+
+describe('keepAuthoredWidget', () => {
+  it('writes widget.html + meta.json', () => {
+    const env = tmpEnv();
+    expect(keepAuthoredWidget({ kind: 'stock', template: CLEAN_TPL, sample: STOCK }, env)).toBe(true);
+    const dir = join(env.CODEBUDDY_WIDGETS_DIR!, 'authored-stock');
+    expect(existsSync(join(dir, 'widget.html'))).toBe(true);
+    expect(JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf8')).source).toBe('authored');
+  });
+
+  it('refuses to shadow a curated widget', () => {
+    const env = tmpEnv();
+    expect(keepAuthoredWidget({ kind: 'weather', template: '<div>evil</div>', sample: {} }, env)).toBe(false);
+    expect(listAuthoredWidgets(env)).not.toContain('weather');
+  });
+});

--- a/tests/widgets/widget-gate.test.ts
+++ b/tests/widgets/widget-gate.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Widget gate — fail-closed validation of an authored widget template.
+ */
+import { gateWidget, scanWidgetFirewall } from '../../src/widgets/widget-gate.js';
+import type { WidgetProposal } from '../../src/widgets/widget-types.js';
+
+const sample = { type: 'stock', symbol: 'ACME', price: 42, items: [{ t: 'a' }] };
+function prop(template: string): WidgetProposal {
+  return { kind: 'stock', template, sample };
+}
+
+const CLEAN = `<style>.cbw-stock{padding:8px}</style><div class="cbw-stock">{{ symbol }}: {{ price }}</div>`;
+
+describe('scanWidgetFirewall', () => {
+  it('flags scripts, external loads, handlers, javascript: and @import', () => {
+    expect(scanWidgetFirewall('<script>x</script>')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<img src="https://evil/x.png">')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<div onclick="x">')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<a href="javascript:alert(1)">')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<style>@import "http://evil";</style>')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<style>.x{background:url(http://evil/a.png)}</style>')).not.toHaveLength(0);
+    expect(scanWidgetFirewall('<iframe src="x">')).not.toHaveLength(0);
+  });
+
+  it('allows a clean self-contained template and outbound <a href>', () => {
+    expect(scanWidgetFirewall(CLEAN)).toHaveLength(0);
+    expect(scanWidgetFirewall('<a href="https://example.com/article">read</a>')).toHaveLength(0);
+  });
+});
+
+describe('gateWidget', () => {
+  it('accepts a clean template and returns the rendered fragment', () => {
+    const v = gateWidget(prop(CLEAN));
+    expect(v.accepted).toBe(true);
+    expect(v.fragment).toContain('ACME: 42');
+  });
+
+  it('rejects an empty template', () => {
+    expect(gateWidget(prop('   ')).reason).toBe('render-empty');
+  });
+
+  it('rejects a template with a <script> (static scan)', () => {
+    const v = gateWidget(prop(`${CLEAN}<script>fetch("//evil")</script>`));
+    expect(v.accepted).toBe(false);
+    expect(v.reason).toBe('static-scan');
+  });
+
+  it('rejects a template that loads an external resource', () => {
+    const v = gateWidget(prop(`<div class="cbw-stock"><img src="https://evil/pixel.png">{{ symbol }}</div>`));
+    expect(v.accepted).toBe(false);
+    expect(v.reason).toBe('static-scan');
+  });
+
+  it('rejects a template that renders to empty output', () => {
+    const v = gateWidget(prop('<div class="cbw-stock">{{ missing.path }}</div>'));
+    // renders to "<div class=...></div>" which is non-empty; use a template that yields only whitespace
+    expect(v.accepted).toBe(true); // structural HTML remains → non-empty & safe
+    const v2 = gateWidget({ kind: 'stock', template: '{{ missing.path }}', sample });
+    expect(v2.accepted).toBe(false);
+    expect(v2.reason).toBe('render-empty');
+  });
+
+  it('escaped data cannot smuggle a script past the gate', () => {
+    const evil = { type: 'stock', symbol: '<script>alert(1)</script>', price: 1 };
+    const v = gateWidget({ kind: 'stock', template: CLEAN, sample: evil });
+    expect(v.accepted).toBe(true); // the script is escaped in the rendered fragment
+    expect(v.fragment).not.toContain('<script>');
+    expect(v.fragment).toContain('&lt;script&gt;');
+  });
+});

--- a/tests/widgets/widget-registry.test.ts
+++ b/tests/widgets/widget-registry.test.ts
@@ -31,7 +31,9 @@ describe('resolveWidgetSource', () => {
   });
 
   it('returns null for an unknown kind with no authored widget', () => {
-    expect(resolveWidgetSource('stock', {} as NodeJS.ProcessEnv)).toBeNull();
+    // Isolated empty dir — an empty env would resolve to the REAL ~/.codebuddy/widgets.
+    const env = { CODEBUDDY_WIDGETS_DIR: mkdtempSync(join(tmpdir(), 'wdg-empty-')) } as NodeJS.ProcessEnv;
+    expect(resolveWidgetSource('stock', env)).toBeNull();
   });
 
   it('falls back to an authored widget for a NEW kind, but curated wins', () => {
@@ -98,6 +100,7 @@ describe('helpers', () => {
   });
   it('hasWidgetForData', () => {
     expect(hasWidgetForData(sampleWeather)).toBe(true);
-    expect(hasWidgetForData({ type: 'stock' }, {} as NodeJS.ProcessEnv)).toBe(false);
+    const env = { CODEBUDDY_WIDGETS_DIR: mkdtempSync(join(tmpdir(), 'wdg-empty-')) } as NodeJS.ProcessEnv;
+    expect(hasWidgetForData({ type: 'stock' }, env)).toBe(false);
   });
 });


### PR DESCRIPTION
## Widgets qui se génèrent tout seuls, puis se réutilisent (« comme les skills »)

Phase 2 de la bibliothèque de widgets. Quand un résultat d'outil porte un `data.type` qu'aucun widget ne couvre, le moteur **authore** un widget à la volée, le **gate** (fail-closed), le **garde**, puis le rend. La fois suivante = hit registre instantané. Même patron que les skills/tools authored : `proposer → gate → keep → réutilise`, namespace `authored-*`.

### La bonne conception : template inerte, pas de code
Un widget authored ne peut pas être du HTML statique (pas data-driven) ni du JS (bloqué par la CSP + pas d'`eval`). C'est donc un **template Mustache inerte**, rendu **côté serveur**, données interpolées et **toujours échappées**.

- **`template-engine.ts`** — Mustache sûr : `{{path}}` (échappé), `{{#each}}`, `{{#if/else}}`. Zéro expression, zéro `eval`, zéro exécution. XSS-safe.
- **`widget-gate.ts`** — **G1 firewall statique** (zéro `<script>`/`on*=`/`javascript:`/ressource externe/`@import`/`url(http)`/`<iframe>`) + **G2 rendu** (non vide, pas de `{{ }}` résiduel, re-scan). Fail-closed.
- **`widget-proposer.ts`** — LLM one-shot **$0** (`resolveCommandProvider`, injectable) → `{template}`.
- **`widget-engine.ts`** — `resolveOrGenerate(data)` : hit registre sinon propose→gate→keep→rend. **Opt-in `CODEBUDDY_WIDGETS=true`** (défaut off ⇒ seuls les curated), never-throws, ledger d'audit append-only, un authored **ne masque jamais** un curated.
- **CLI** `buddy widgets list|preview <kind>|gen <kind>`.
- **Cowork** `widgets-ipc` : préfère `resolveOrGenerate` (auto-génère quand opté), repli registre ; **comportement par défaut inchangé**.

### Preuve live ($0)
`buddy widgets gen stock --sample '{"symbol":"ACME","price":42.5,…}'` a produit un **vrai widget boursier** (pastille verte/rouge en **CSS pur** via `data-change`, boîtes haut/bas, thème clair/sombre), passé le firewall, gardé, et re-rendu instantanément : `source=authored`, `len=3169`, **zéro `<script>`**, aucun `{{ }}` résiduel.

### Vérif
- `tsc` racine + `cowork` = 0 · `eslint` = 0 · `vitest tests/widgets` = **35/35**

Basé sur #59 (fix CSP + rendu serveur). Phase 3 (exposition MCP Apps-SDK) différée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)