### PR TITLE
fix(widgets): tuiles météo réelles + iframe qui épouse la carte (zéro blanc)

### DIFF
--- a/cowork/src/renderer/components/widgets/WidgetBlock.tsx
+++ b/cowork/src/renderer/components/widgets/WidgetBlock.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 
 interface WidgetBlockProps {
   data: unknown;
@@ -15,6 +15,8 @@ function isWidgetCandidate(data: unknown): boolean {
 
 export const WidgetBlock = memo(function WidgetBlock({ data, className = '' }: WidgetBlockProps) {
   const [html, setHtml] = useState<string | null>(null);
+  const [size, setSize] = useState<{ w: number | '100%'; h: number }>({ w: '100%', h: 132 });
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -37,21 +39,32 @@ export const WidgetBlock = memo(function WidgetBlock({ data, className = '' }: W
     };
   }, [data]);
 
+  // Auto-size the iframe to HUG the widget card exactly — no fixed height/width,
+  // so there's no empty gap around it. The iframe is `allow-same-origin` WITHOUT
+  // `allow-scripts`, so we can measure the (script-free, server-rendered) content
+  // while no script can ever execute inside it.
+  const measure = () => {
+    const doc = iframeRef.current?.contentDocument;
+    if (!doc) return;
+    const root = doc.querySelector('body > *:not(style):not(script)') as HTMLElement | null;
+    const rect = root?.getBoundingClientRect();
+    const h = Math.ceil(rect?.height || doc.documentElement?.scrollHeight || 0);
+    const w = Math.ceil(rect?.width || 0);
+    if (h > 0) setSize({ h, w: w > 0 ? w : '100%' });
+  };
+
   if (!html) return null;
 
   return (
-    <div
-      className={`w-full max-w-[560px] overflow-hidden rounded-lg border border-border-subtle bg-white ${className}`}
-    >
-      {/* Widgets are rendered SERVER-SIDE (static HTML+CSS, no client script), so
-          the iframe needs no `allow-scripts` — full sandbox + popups for outbound
-          links only. No `allow-same-origin`. */}
+    <div className={`max-w-full overflow-hidden rounded-xl ${className}`}>
       <iframe
+        ref={iframeRef}
         title="tool-result-widget"
-        sandbox="allow-popups allow-popups-to-escape-sandbox"
+        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         srcDoc={html}
-        className="block w-full border-0 bg-white"
-        style={{ minHeight: 120, height: 'clamp(120px, 38vw, 320px)' }}
+        onLoad={measure}
+        className="block border-0 bg-transparent"
+        style={{ height: size.h, width: size.w, maxWidth: '100%' }}
       />
     </div>
   );

--- a/src/widgets/curated/weather.ts
+++ b/src/widgets/curated/weather.ts
@@ -11,6 +11,26 @@ function esc(s: unknown): string {
   return String(s == null ? '' : s).replace(/[&<>"]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[m]!);
 }
 
+const WEEKDAYS = ['dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam'];
+
+/** Short weekday label from a `day` string or an ISO `date` (YYYY-MM-DD). */
+function dayLabel(raw: { day?: unknown; date?: unknown }): string {
+  if (typeof raw.day === 'string' && raw.day.trim()) return raw.day.trim();
+  const d = raw.date;
+  if (typeof d === 'string' && /^\d{4}-\d{2}-\d{2}/.test(d)) {
+    const parsed = new Date(d + (d.length === 10 ? 'T00:00:00' : ''));
+    const wd = parsed.getDay();
+    if (!Number.isNaN(wd)) return WEEKDAYS[wd]!;
+  }
+  return typeof d === 'string' ? d.slice(5) : '';
+}
+
+/** First finite number among the given candidates (tolerates min/max vs low/high). */
+function num(...candidates: unknown[]): number | null {
+  for (const c of candidates) if (typeof c === 'number' && Number.isFinite(c)) return c;
+  return null;
+}
+
 function emoji(cond: unknown): string {
   const c = String(cond ?? '').toLowerCase();
   if (/orage|thunder|storm/.test(c)) return '⛈️';
@@ -60,11 +80,15 @@ export function renderWeatherWidget(raw: unknown): string {
     (meta.length ? `<div class="meta">${meta.map((m) => esc(m)).join('<span>·</span>')}</div>` : '') +
     (fc.length
       ? `<div class="fc">${fc
-          .map(
-            (f) =>
-              `<div class="day"><div class="d">${esc(f.day)}</div><div class="e">${emoji(f.condition)}</div>` +
-              `<div class="t">${f.max != null ? Math.round(f.max) : '—'}° / ${f.min != null ? Math.round(f.min) : '—'}°</div></div>`
-          )
+          .map((f) => {
+            const g = f as Record<string, unknown>;
+            const hi = num(g.max, g.high);
+            const lo = num(g.min, g.low);
+            return (
+              `<div class="day"><div class="d">${esc(dayLabel(g))}</div><div class="e">${emoji(g.condition)}</div>` +
+              `<div class="t">${hi != null ? Math.round(hi) : '—'}° / ${lo != null ? Math.round(lo) : '—'}°</div></div>`
+            );
+          })
           .join('')}</div>`
       : '') +
     `</div>`

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -74,7 +74,7 @@ export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = pro
   return null;
 }
 
-const BASE_CSS = `*{box-sizing:border-box}html,body{margin:0;padding:0;background:transparent}body{padding:2px}`;
+const BASE_CSS = `*{box-sizing:border-box}html,body{margin:0;padding:0;background:transparent}`;
 
 /** Wrap a rendered fragment into a complete, self-contained HTML document (no script). Pure. */
 export function renderWidgetDocument(fragment: string): string {

--- a/tests/widgets/widget-registry.test.ts
+++ b/tests/widgets/widget-registry.test.ts
@@ -75,6 +75,21 @@ describe('server-side rendering (no client script)', () => {
     expect(renderWidgetForData({ nope: true })).toBeNull();
   });
 
+  it('renders the REAL WeatherTool forecast shape (high/low/date), not just min/max/day', () => {
+    // WeatherTool.data.forecast items are { date, high, low, condition } — the
+    // widget must map those, not render "—°".
+    const doc = renderWidgetForData({
+      type: 'weather',
+      location: 'Lyon',
+      current: { temperature: 33, condition: 'Sunny' },
+      forecast: [{ date: '2026-07-09', high: 35, low: 24, condition: 'partly cloudy' }],
+      units: 'metric',
+    })!;
+    expect(doc).toContain('35° / 24°'); // high/low rendered
+    expect(doc).not.toContain('—°'); // no missing-value placeholder
+    expect(doc).toContain('jeu'); // weekday derived from the ISO date (2026-07-09 = Thursday)
+  });
+
   it('renders a news payload server-side with the item titles inline', () => {
     const doc = renderWidgetForData({
       type: 'news',


### PR DESCRIPTION
Correctifs issus du test inline live dans Cowork (retour Patrice : « trop de blanc autour de la tuile »).

**1. Tuiles de prévision « —° »** → `WeatherTool.data.forecast` émet `{date,high,low}` alors que le widget lisait `{day,min,max}`. `renderWeatherWidget` tolère les deux shapes + dérive le jour court depuis la date ISO.

**2. Trop de blanc** → l'iframe avait une hauteur fixe + fond blanc. `WidgetBlock` **mesure la carte et épouse ses dimensions exactes** (largeur+hauteur), fond transparent. Technique : `allow-same-origin` **sans** `allow-scripts` → mesurable, mais aucun script ne s'exécute jamais.

Prouvé live : météo Lyon → carte 460×221 collée au contenu, tuiles Jeu 35°/24° · Ven 36°/23° · Sam 36°/25°, zéro blanc. `vitest tests/widgets` = 36/36 (test de non-régression ajouté), tsc racine+cowork = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)