### PR TITLE
fix(widgets): durcissement de la création (anti-hardcoding, URL, timeouts, CSP)

### DIFF
--- a/src/widgets/curated/news.ts
+++ b/src/widgets/curated/news.ts
@@ -4,9 +4,20 @@
  * @module widgets/curated/news
  */
 import type { NewsWidgetData } from '../widget-types.js';
+import { sanitizeURL } from '../../utils/sanitize.js';
 
 function esc(s: unknown): string {
   return String(s == null ? '' : s).replace(/[&<>"]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[m]!);
+}
+
+/** An http(s) URL, or null (drops javascript:/data:/relative/garbage). never throws. */
+function safeUrl(u: unknown): string | null {
+  if (typeof u !== 'string' || !u.trim()) return null;
+  try {
+    return sanitizeURL(u, ['http', 'https']);
+  } catch {
+    return null;
+  }
 }
 
 const STYLE = `<style>
@@ -30,8 +41,9 @@ export function renderNewsWidget(raw: unknown): string {
     ? `<ul>${items
         .map((it) => {
           const title = esc(it.title ?? '');
-          const inner = it.url
-            ? `<a href="${esc(it.url)}" target="_blank" rel="noopener noreferrer">${title}</a>`
+          const url = safeUrl(it.url);
+          const inner = url
+            ? `<a href="${esc(url)}" target="_blank" rel="noopener noreferrer">${title}</a>`
             : title;
           return `<li>${inner}${it.source ? `<span class="src">${esc(it.source)}</span>` : ''}</li>`;
         })

--- a/src/widgets/curated/stock.ts
+++ b/src/widgets/curated/stock.ts
@@ -1,0 +1,91 @@
+/** Curated stock-market widget — server-side rendered static HTML. */
+import type { StockWidgetData } from '../widget-types.js';
+
+function esc(s: unknown): string {
+  return String(s == null ? '' : s).replace(/[&<>"]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[m]!);
+}
+
+function num(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v !== 'string') return null;
+  const normalized = v.trim().replace(/\s/g, '').replace('%', '').replace(',', '.');
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function fmt(v: number | null, digits = 2): string {
+  return v == null ? '—' : new Intl.NumberFormat('fr-FR', { maximumFractionDigits: digits, minimumFractionDigits: digits }).format(v);
+}
+
+function fmtCompact(v: number | null): string {
+  return v == null ? '—' : new Intl.NumberFormat('fr-FR', { notation: 'compact', maximumFractionDigits: 1 }).format(v);
+}
+
+function trendLabel(pct: number | null, change: number | null): string {
+  const v = pct ?? change;
+  if (v == null || v === 0) return 'Stable';
+  return v > 0 ? 'Hausse' : 'Baisse';
+}
+
+const STYLE = `<style>
+.cbw-stock{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;border-radius:18px;padding:16px 18px;color:#0b1220;background:radial-gradient(circle at top right,rgba(16,185,129,.18),transparent 34%),linear-gradient(135deg,#fff7ed 0%,#fff 100%);border:1px solid rgba(0,0,0,.07);box-shadow:0 12px 32px rgba(15,23,42,.08);max-width:460px;min-width:300px}
+.cbw-stock .top{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}
+.cbw-stock .status{font-size:11px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;opacity:.5;margin-bottom:8px}
+.cbw-stock .label{font-size:11px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;opacity:.52}
+.cbw-stock .name{margin-top:4px;font-size:17px;font-weight:800;line-height:1.15}
+.cbw-stock .symbol{font-size:12px;opacity:.6;margin-top:3px}
+.cbw-stock .price{margin-top:14px;font-size:40px;font-weight:850;line-height:1;letter-spacing:-.04em}
+.cbw-stock .currency{font-size:15px;font-weight:700;opacity:.62;margin-left:5px}
+.cbw-stock .move{display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap}
+.cbw-stock .pill{border-radius:999px;padding:7px 10px;font-size:13px;font-weight:800;white-space:nowrap;background:rgba(16,185,129,.14);color:#047857}
+.cbw-stock .pill.neg{background:rgba(239,68,68,.13);color:#b91c1c}
+.cbw-stock .abs{font-size:13px;font-weight:700;opacity:.68}
+.cbw-stock .bar{height:6px;border-radius:999px;background:rgba(15,23,42,.1);overflow:hidden;margin-top:14px}
+.cbw-stock .bar span{display:block;height:100%;width:var(--w);background:linear-gradient(90deg,#10b981,#34d399);border-radius:inherit}
+.cbw-stock .bar.neg span{background:linear-gradient(90deg,#ef4444,#fb7185)}
+.cbw-stock .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(88px,1fr));gap:8px;margin-top:14px}
+.cbw-stock .cell{border-radius:12px;background:rgba(255,255,255,.58);padding:8px 9px;border:1px solid rgba(15,23,42,.06)}
+.cbw-stock .k{display:block;font-size:10px;font-weight:750;letter-spacing:.06em;text-transform:uppercase;opacity:.5}
+.cbw-stock .v{display:block;margin-top:2px;font-size:13px;font-weight:800}
+.cbw-stock .meta{margin-top:12px;display:flex;gap:10px;flex-wrap:wrap;font-size:12px;opacity:.62}
+:root[data-cbw-theme="dark"] .cbw-stock{color:#e8eefc;background:radial-gradient(circle at top right,rgba(16,185,129,.16),transparent 34%),linear-gradient(135deg,#221609 0%,#0f1626 100%);border-color:rgba(255,255,255,.08);box-shadow:none}
+:root[data-cbw-theme="dark"] .cbw-stock .cell{background:rgba(255,255,255,.055);border-color:rgba(255,255,255,.07)}
+:root[data-cbw-theme="dark"] .cbw-stock .bar{background:rgba(255,255,255,.1)}
+:root[data-cbw-theme="dark"] .cbw-stock .pill{background:rgba(16,185,129,.18);color:#6ee7b7}
+:root[data-cbw-theme="dark"] .cbw-stock .pill.neg{background:rgba(239,68,68,.18);color:#fca5a5}
+</style>`;
+
+export function renderStockWidget(raw: unknown): string {
+  const d = (raw ?? {}) as Partial<StockWidgetData>;
+  const price = num(d.price) ?? num(d.value);
+  const change = num(d.change);
+  const pct = num(d.changePercent);
+  const open = num(d.open);
+  const high = num(d.high);
+  const low = num(d.low);
+  const volume = num(d.volume);
+  const previousClose = num(d.previousClose);
+  const neg = (pct ?? change ?? 0) < 0;
+  const sign = neg ? '' : '+';
+  const currency = d.currency ?? (d.symbol === 'PX1' || d.name === 'CAC 40' ? 'pts' : '');
+  const title = d.name ?? d.symbol ?? 'Cours de bourse';
+  const pill = pct != null ? `${sign}${fmt(pct)}%` : change != null ? `${sign}${fmt(change)}` : '—';
+  const abs = change != null ? `${sign}${fmt(change)}${currency ? ` ${currency}` : ''}` : '';
+  const width = `${Math.min(100, Math.max(8, Math.abs(pct ?? 0) * 14))}%`;
+  const status = trendLabel(pct, change);
+
+  return (
+    STYLE +
+    `<div class="cbw-stock"><div class="status">${esc(status)}</div><div class="top"><div>` +
+    `<div class="label">Bourse</div><div class="name">${esc(title)}</div>` +
+    (d.symbol ? `<div class="symbol">${esc(d.symbol)}</div>` : '') +
+    `</div><div class="pill ${neg ? 'neg' : ''}">${esc(pill)}</div></div>` +
+    `<div class="price">${esc(fmt(price))}${currency ? `<span class="currency">${esc(currency)}</span>` : ''}</div>` +
+    `<div class="move">${abs ? `<span class="abs">${esc(abs)}</span>` : ''}</div>` +
+    `<div class="bar ${neg ? 'neg' : ''}"><span style="--w:${esc(width)}"></span></div>` +
+    `<div class="grid"><div class="cell"><span class="k">Ouverture</span><span class="v">${esc(fmt(open))}</span></div><div class="cell"><span class="k">+ Haut</span><span class="v">${esc(fmt(high))}</span></div><div class="cell"><span class="k">+ Bas</span><span class="v">${esc(fmt(low))}</span></div>${previousClose != null ? `<div class="cell"><span class="k">Clôture veille</span><span class="v">${esc(fmt(previousClose))}</span></div>` : ''}</div>` +
+    `<div class="meta">${d.market ? `<span>${esc(d.market)}</span>` : ''}${volume != null ? `<span>· Vol. ${esc(fmtCompact(volume))}</span>` : ''}${d.time ? `<span>· ${esc(d.time)}</span>` : ''}</div>` +
+    `</div>`
+  );
+}

--- a/src/widgets/widget-engine.ts
+++ b/src/widgets/widget-engine.ts
@@ -93,10 +93,54 @@ export function readAuthoredTemplate(kind: string, env: NodeJS.ProcessEnv = proc
   }
 }
 
+function parseMs(raw: string | undefined, fallback: number): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Race a promise against a timeout; resolves to `fallback` if it doesn't settle in time. */
+function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([p, new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms))]);
+}
+
+// Dedup concurrent generation of the same kind, and back off after a failure so a
+// broken/slow kind doesn't re-hit the LLM on every render. Module-scoped, in-memory.
+const inFlight = new Map<string, Promise<boolean>>();
+const failedAt = new Map<string, number>();
+
+/** Author → gate → keep for `kind`. Returns true if a widget for `kind` now exists. never-throws. */
+async function generateAndKeep(
+  kind: string,
+  data: unknown,
+  deps: ResolveOrGenerateDeps,
+  env: NodeJS.ProcessEnv
+): Promise<boolean> {
+  try {
+    const propose = deps.propose ?? ((k, s, b) => proposeWidget(k, s, b, deps));
+    const timeoutMs = parseMs(env.CODEBUDDY_WIDGETS_GEN_TIMEOUT_MS, 20000);
+    const proposal = await withTimeout(propose(kind, data, deps.brief), timeoutMs, null);
+    if (!proposal) {
+      recordLedger({ kind, accepted: false, reason: 'no-proposal-or-timeout' }, env);
+      return false;
+    }
+    const verdict = gateWidget(proposal);
+    if (!verdict.accepted) {
+      recordLedger({ kind, accepted: false, reason: verdict.reason, reasons: verdict.reasons }, env);
+      return false;
+    }
+    const kept = keepAuthoredWidget(proposal, env);
+    recordLedger({ kind, accepted: kept, reason: kept ? 'kept' : 'keep-failed' }, env);
+    return kept;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Resolve a widget document for `data`; if none exists and generation is enabled,
  * author one, gate it, keep it, then render. Returns the full HTML doc or null.
- * never-throws.
+ * Generation is bounded: per-kind timeout, in-flight dedup, and post-failure
+ * cooldown — a slow/looping proposer never freezes the render path. never-throws.
  */
 export async function resolveOrGenerate(
   data: unknown,
@@ -115,24 +159,27 @@ export async function resolveOrGenerate(
     const kind = widgetKind(data)?.toLowerCase();
     if (!kind) return null;
 
-    const propose = deps.propose ?? ((k, s, b) => proposeWidget(k, s, b, deps));
-    const proposal = await propose(kind, data, deps.brief);
-    if (!proposal) {
-      recordLedger({ kind, accepted: false, reason: 'no-proposal' }, env);
+    // Back off if this kind failed recently.
+    const last = failedAt.get(kind);
+    if (last !== undefined && Date.now() - last < parseMs(env.CODEBUDDY_WIDGETS_GEN_COOLDOWN_MS, 300000)) {
       return null;
     }
 
-    const verdict = gateWidget(proposal);
-    if (!verdict.accepted) {
-      recordLedger({ kind, accepted: false, reason: verdict.reason, reasons: verdict.reasons }, env);
+    // Dedup: one generation per kind at a time; concurrent callers share it.
+    let gen = inFlight.get(kind);
+    if (!gen) {
+      gen = generateAndKeep(kind, data, deps, env);
+      inFlight.set(kind, gen);
+      void gen.finally(() => {
+        if (inFlight.get(kind) === gen) inFlight.delete(kind);
+      });
+    }
+    const kept = await gen;
+    if (!kept) {
+      failedAt.set(kind, Date.now());
       return null;
     }
-
-    const kept = keepAuthoredWidget(proposal, env);
-    recordLedger({ kind, accepted: kept, reason: kept ? 'kept' : 'keep-failed' }, env);
-    if (!kept) return null;
-
-    // Render fresh from the newly-kept authored template.
+    // Render fresh from the newly-kept authored template (caller's own theme).
     return renderWidgetForData(data, env, deps.theme);
   } catch {
     return null;

--- a/src/widgets/widget-gate.ts
+++ b/src/widgets/widget-gate.ts
@@ -42,6 +42,47 @@ export function scanWidgetFirewall(html: string): string[] {
   return reasons;
 }
 
+/**
+ * True when the template has ≥1 PLAIN data interpolation `{{ path }}` (not a
+ * block tag `{{#each}}`/`{{#if}}`/`{{/…}}`/`{{else}}`). A template with none is
+ * hardcoded by construction — it cannot reflect the data.
+ */
+export function hasDataBinding(template: string): boolean {
+  const tags = template.match(/\{\{\{?\s*([^}]*?)\s*\}?\}\}/g) ?? [];
+  return tags.some((t) => {
+    const inner = t.replace(/^\{\{\{?\s*|\s*\}?\}\}$/g, '').trim();
+    return inner.length > 0 && !inner.startsWith('#') && !inner.startsWith('/') && inner !== 'else';
+  });
+}
+
+/**
+ * Derive a DIVERGENT sample from the visible one: every scalar leaf is replaced
+ * by a value guaranteed to differ, arrays gain one extra element. The proposer
+ * never sees this (it is computed at gate-time) — the widget analogue of the
+ * tools' hidden held-out cases. A template that hardcodes the visible values
+ * renders IDENTICALLY for both samples ⇒ caught. Pure, never throws.
+ */
+export function deriveDivergentSample(value: unknown): unknown {
+  if (typeof value === 'number') return Number.isFinite(value) ? value + 987654 : 123456;
+  if (typeof value === 'string') return value + '_CBW_HELDOUT';
+  if (typeof value === 'boolean') return !value;
+  if (value === null || value === undefined) return 'CBW_HELDOUT';
+  if (Array.isArray(value)) {
+    const mapped = value.map((v) => deriveDivergentSample(v));
+    // Change the length too, so count/list-only widgets also diverge.
+    if (mapped.length > 0) mapped.push(deriveDivergentSample(value[0]));
+    return mapped;
+  }
+  if (typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = deriveDivergentSample(v);
+    }
+    return out;
+  }
+  return value;
+}
+
 /** Run a proposal through the gate. Fail-closed. Pure. */
 export function gateWidget(proposal: WidgetProposal): WidgetGateOutcome {
   const template = (proposal?.template ?? '').trim();
@@ -75,6 +116,29 @@ export function gateWidget(proposal: WidgetProposal): WidgetGateOutcome {
   const renderedReasons = scanWidgetFirewall(fragment);
   if (renderedReasons.length > 0) {
     return { accepted: false, reason: 'render-unsafe', reasons: renderedReasons };
+  }
+
+  // Anti-hardcoding (the widget analogue of the tools' held-out check). A widget
+  // must be a FUNCTION of its data, else it shows stale values on reuse.
+  if (!hasDataBinding(template)) {
+    return {
+      accepted: false,
+      reason: 'no-data-binding',
+      reasons: ['template has no {{ }} data interpolation — it cannot reflect the data'],
+    };
+  }
+  let divergent: string;
+  try {
+    divergent = renderTemplate(template, deriveDivergentSample(proposal.sample));
+  } catch {
+    divergent = fragment; // a template that breaks on divergent data is not trustworthy
+  }
+  if (divergent === fragment) {
+    return {
+      accepted: false,
+      reason: 'hardcoded',
+      reasons: ['identical output for divergent data — the template hardcodes values instead of using them'],
+    };
   }
 
   return { accepted: true, fragment };

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -16,6 +16,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { renderWeatherWidget } from './curated/weather.js';
 import { renderNewsWidget } from './curated/news.js';
+import { renderStockWidget } from './curated/stock.js';
 import { widgetKind } from './widget-types.js';
 import { renderTemplate } from './template-engine.js';
 
@@ -23,6 +24,9 @@ import { renderTemplate } from './template-engine.js';
 const CURATED: Record<string, (data: unknown) => string> = {
   weather: renderWeatherWidget,
   news: renderNewsWidget,
+  stock: renderStockWidget,
+  market: renderStockWidget,
+  bourse: renderStockWidget,
 };
 
 /** Root dir for authored widgets (env-overridable). */
@@ -46,6 +50,29 @@ export function resolveWidgetSource(
   return null;
 }
 
+const URL_ATTR_RE = /\b(href|src|action|xlink:href)(\s*=\s*)(["'])([^"']*)\3/gi;
+const DANGEROUS_SCHEME_RE = /^\s*(javascript|vbscript|data)\s*:/i;
+
+function isUnsafeUrlValue(v: string): boolean {
+  const m = DANGEROUS_SCHEME_RE.exec(v);
+  if (!m) return false;
+  // data:image/* (inline images) is allowed; every other data:/javascript:/vbscript: is not.
+  if (m[1]!.toLowerCase() === 'data') return !/^\s*data:\s*image\//i.test(v);
+  return true;
+}
+
+/**
+ * Defence-in-depth: neutralize URL-bearing attributes (href/src/action) whose
+ * value carries a dangerous scheme (javascript:/vbscript:/non-image data:). This
+ * runs at RENDER time, so it also covers runtime data the gate never re-checks
+ * (e.g. an authored `{{url}}` fed a malicious news link). Pure.
+ */
+export function neutralizeUnsafeUrls(html: string): string {
+  return html.replace(URL_ATTR_RE, (full, name, eq, q, val) =>
+    isUnsafeUrlValue(val) ? `${name}${eq}${q}#blocked${q}` : full
+  );
+}
+
 /** Server-render the widget FRAGMENT for a data payload (curated fn, else authored static). */
 export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = process.env): string | null {
   const kind = widgetKind(data)?.toLowerCase();
@@ -54,7 +81,7 @@ export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = pro
   if (curated) {
     try {
       const frag = curated(data);
-      return frag && frag.trim() ? frag : null;
+      return frag && frag.trim() ? neutralizeUnsafeUrls(frag) : null;
     } catch {
       return null;
     }
@@ -66,7 +93,7 @@ export function renderWidgetFragment(data: unknown, env: NodeJS.ProcessEnv = pro
       // Authored widgets are SAFE Mustache-style templates, rendered server-side
       // with the data interpolated (always escaped). No client script, CSP-proof.
       const frag = renderTemplate(tpl, data);
-      if (frag.trim()) return frag;
+      if (frag.trim()) return neutralizeUnsafeUrls(frag);
     }
   } catch {
     /* none */
@@ -86,8 +113,13 @@ export type WidgetTheme = 'dark' | 'light';
  */
 export function renderWidgetDocument(fragment: string, theme?: WidgetTheme): string {
   const attr = theme === 'dark' || theme === 'light' ? ` data-cbw-theme="${theme}"` : '';
+  // Self-defending CSP: even opened OUTSIDE Cowork (e.g. `buddy widgets preview`
+  // writes the doc to disk), the doc can never run a script or hit the network.
+  const csp =
+    "default-src 'none'; style-src 'unsafe-inline'; img-src data:; font-src data:; base-uri 'none'; form-action 'none'";
   return (
     `<!doctype html><html${attr}><head><meta charset="utf-8">` +
+    `<meta http-equiv="Content-Security-Policy" content="${csp}">` +
     '<meta name="viewport" content="width=device-width,initial-scale=1">' +
     `<style>${BASE_CSS}</style></head><body>${fragment}</body></html>`
   );

--- a/src/widgets/widget-types.ts
+++ b/src/widgets/widget-types.ts
@@ -33,9 +33,29 @@ export interface NewsWidgetData {
   items: Array<{ title: string; url?: string; source?: string }>;
 }
 
+/** The structured payload for a stock-market quote widget. */
+export interface StockWidgetData {
+  type: 'stock' | 'market' | 'bourse';
+  symbol?: string;
+  name?: string;
+  price?: number | string;
+  value?: number | string;
+  change?: number | string;
+  changePercent?: number | string;
+  currency?: string;
+  market?: string;
+  open?: number | string;
+  high?: number | string;
+  low?: number | string;
+  previousClose?: number | string;
+  volume?: number | string;
+  time?: string;
+}
+
 export type WidgetData =
   | WeatherWidgetData
   | NewsWidgetData
+  | StockWidgetData
   | { type: string; [k: string]: unknown };
 
 /** The `type` discriminator of a widget payload (also the widget "kind"). */
@@ -59,7 +79,10 @@ export interface WidgetProposal {
 /** Result of running a proposal through the widget gate (fail-closed). */
 export interface WidgetGateOutcome {
   accepted: boolean;
-  /** Short machine reason on reject (`static-scan` | `render-empty` | `render-unsafe` | `unrendered-tokens`). */
+  /**
+   * Short machine reason on reject: `static-scan` | `render-empty` |
+   * `render-unsafe` | `unrendered-tokens` | `no-data-binding` | `hardcoded`.
+   */
   reason?: string;
   reasons?: string[];
   /** The rendered sample fragment, present only on accept. */

--- a/tests/widgets/widget-engine.test.ts
+++ b/tests/widgets/widget-engine.test.ts
@@ -1,6 +1,8 @@
 /**
  * Widget engine — the self-learning loop: curated hit, opt-in generation, gate,
- * keep, reuse. Isolated temp authored dir; LLM propose step is injected.
+ * keep, reuse, and bounded generation (timeout / in-flight dedup / cooldown).
+ * Isolated temp authored dir; LLM propose step is injected. Each test uses a
+ * DISTINCT kind so the module-level in-flight/cooldown maps never cross tests.
  */
 import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -18,13 +20,17 @@ function tmpEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
   return { CODEBUDDY_WIDGETS_DIR: dir, ...extra } as NodeJS.ProcessEnv;
 }
 
-const STOCK = { type: 'stock', symbol: 'ACME', price: 42 };
-const CLEAN_TPL = '<style>.cbw-stock{padding:8px}</style><div class="cbw-stock">{{ symbol }} {{ price }}</div>';
+// 'crypto' family = kinds that are NOT curated (weather/news/stock ARE), so they
+// exercise the generation path.
+const tpl = (cls: string) => `<style>.cbw-${cls}{padding:8px}</style><div class="cbw-${cls}">{{ symbol }} {{ price }}</div>`;
 
 describe('resolveOrGenerate', () => {
   it('renders a curated widget immediately (no generation needed)', async () => {
     const env = tmpEnv(); // generation OFF, but curated always works
-    const doc = await resolveOrGenerate({ type: 'weather', location: 'Paris', current: { temperature: 20, condition: 'clair' } }, { env });
+    const doc = await resolveOrGenerate(
+      { type: 'weather', location: 'Paris', current: { temperature: 20, condition: 'clair' } },
+      { env }
+    );
     expect(doc).toContain('Paris');
     expect(doc).toContain('<!doctype html>');
   });
@@ -32,7 +38,7 @@ describe('resolveOrGenerate', () => {
   it('returns null for an unknown kind when generation is OFF (opt-in)', async () => {
     const env = tmpEnv(); // CODEBUDDY_WIDGETS unset
     const propose = jest.fn();
-    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    const doc = await resolveOrGenerate({ type: 'cryptooff', symbol: 'BTC', price: 9 }, { env, propose });
     expect(doc).toBeNull();
     expect(propose).not.toHaveBeenCalled();
   });
@@ -40,16 +46,16 @@ describe('resolveOrGenerate', () => {
   it('generates, gates, keeps and RENDERS a new widget when enabled; reuses next time', async () => {
     const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
     const propose = jest.fn(
-      async (kind: string, sample: unknown): Promise<WidgetProposal> => ({ kind, template: CLEAN_TPL, sample })
+      async (kind: string, sample: unknown): Promise<WidgetProposal> => ({ kind, template: tpl('cryptogen'), sample })
     );
-    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    const doc = await resolveOrGenerate({ type: 'cryptogen', symbol: 'ACME', price: 42 }, { env, propose });
     expect(doc).toContain('ACME 42');
-    expect(listAuthoredWidgets(env)).toContain('stock');
-    expect(readAuthoredTemplate('stock', env)).toBe(CLEAN_TPL);
+    expect(listAuthoredWidgets(env)).toContain('cryptogen');
+    expect(readAuthoredTemplate('cryptogen', env)).toBe(tpl('cryptogen'));
 
     // Second call is a registry hit → propose NOT called again.
     propose.mockClear();
-    const doc2 = await resolveOrGenerate({ type: 'stock', symbol: 'BETA', price: 7 }, { env, propose });
+    const doc2 = await resolveOrGenerate({ type: 'cryptogen', symbol: 'BETA', price: 7 }, { env, propose });
     expect(doc2).toContain('BETA 7');
     expect(propose).not.toHaveBeenCalled();
   });
@@ -58,26 +64,61 @@ describe('resolveOrGenerate', () => {
     const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
     const propose = async (kind: string, sample: unknown): Promise<WidgetProposal> => ({
       kind,
-      template: '<div class="cbw-stock"><script>fetch("//evil")</script>{{ symbol }}</div>',
+      template: '<div class="cbw-cryptobad"><script>fetch("//evil")</script>{{ symbol }}</div>',
       sample,
     });
-    const doc = await resolveOrGenerate(STOCK, { env, propose });
+    const doc = await resolveOrGenerate({ type: 'cryptobad', symbol: 'X', price: 1 }, { env, propose });
     expect(doc).toBeNull();
-    expect(listAuthoredWidgets(env)).not.toContain('stock');
+    expect(listAuthoredWidgets(env)).not.toContain('cryptobad');
   });
 
   it('never-throws when the proposer returns null', async () => {
     const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
-    const doc = await resolveOrGenerate(STOCK, { env, propose: async () => null });
+    const doc = await resolveOrGenerate({ type: 'cryptonull', symbol: 'X', price: 1 }, { env, propose: async () => null });
     expect(doc).toBeNull();
+  });
+
+  it('times out a slow proposer (fallback null) instead of freezing the render path', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true', CODEBUDDY_WIDGETS_GEN_TIMEOUT_MS: '40' });
+    const propose = jest.fn(() => new Promise<WidgetProposal>(() => {})); // never resolves
+    const doc = await resolveOrGenerate({ type: 'cryptoslow', symbol: 'X', price: 1 }, { env, propose });
+    expect(doc).toBeNull();
+    expect(propose).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedups concurrent generation of the same kind (one propose)', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true' });
+    let calls = 0;
+    const propose = async (kind: string, sample: unknown): Promise<WidgetProposal> => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 30));
+      return { kind, template: tpl('cryptorace'), sample };
+    };
+    const data = { type: 'cryptorace', symbol: 'ACME', price: 42 };
+    const [a, b] = await Promise.all([
+      resolveOrGenerate(data, { env, propose }),
+      resolveOrGenerate(data, { env, propose }),
+    ]);
+    expect(a).toContain('ACME 42');
+    expect(b).toContain('ACME 42');
+    expect(calls).toBe(1); // second caller shared the in-flight generation
+  });
+
+  it('backs off after a failure (cooldown) — does not re-hit the proposer', async () => {
+    const env = tmpEnv({ CODEBUDDY_WIDGETS: 'true', CODEBUDDY_WIDGETS_GEN_COOLDOWN_MS: '100000' });
+    const propose = jest.fn(async () => null);
+    const data = { type: 'cryptocool', symbol: 'X', price: 1 };
+    expect(await resolveOrGenerate(data, { env, propose })).toBeNull(); // fails, sets cooldown
+    expect(await resolveOrGenerate(data, { env, propose })).toBeNull(); // within cooldown → skipped
+    expect(propose).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('keepAuthoredWidget', () => {
   it('writes widget.html + meta.json', () => {
     const env = tmpEnv();
-    expect(keepAuthoredWidget({ kind: 'stock', template: CLEAN_TPL, sample: STOCK }, env)).toBe(true);
-    const dir = join(env.CODEBUDDY_WIDGETS_DIR!, 'authored-stock');
+    expect(keepAuthoredWidget({ kind: 'cryptokeep', template: tpl('cryptokeep'), sample: {} }, env)).toBe(true);
+    const dir = join(env.CODEBUDDY_WIDGETS_DIR!, 'authored-cryptokeep');
     expect(existsSync(join(dir, 'widget.html'))).toBe(true);
     expect(JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf8')).source).toBe('authored');
   });

--- a/tests/widgets/widget-gate.test.ts
+++ b/tests/widgets/widget-gate.test.ts
@@ -52,12 +52,28 @@ describe('gateWidget', () => {
   });
 
   it('rejects a template that renders to empty output', () => {
-    const v = gateWidget(prop('<div class="cbw-stock">{{ missing.path }}</div>'));
-    // renders to "<div class=...></div>" which is non-empty; use a template that yields only whitespace
-    expect(v.accepted).toBe(true); // structural HTML remains → non-empty & safe
     const v2 = gateWidget({ kind: 'stock', template: '{{ missing.path }}', sample });
     expect(v2.accepted).toBe(false);
     expect(v2.reason).toBe('render-empty');
+  });
+
+  it('rejects a template with NO data interpolation (hardcoded by construction)', () => {
+    const v = gateWidget(prop('<div class="cbw-stock">ACME 42</div>'));
+    expect(v.accepted).toBe(false);
+    expect(v.reason).toBe('no-data-binding');
+  });
+
+  it('rejects a template that IGNORES the data (identical output for divergent data)', () => {
+    // Has a {{}} but binds a non-existent path → constant output → still hardcoded.
+    const v = gateWidget(prop('<div class="cbw-stock">ACME {{ nonexistent }}</div>'));
+    expect(v.accepted).toBe(false);
+    expect(v.reason).toBe('hardcoded');
+  });
+
+  it('accepts a template that actually reflects the data', () => {
+    const v = gateWidget(prop('<div class="cbw-stock">{{ symbol }} @ {{ price }}</div>'));
+    expect(v.accepted).toBe(true);
+    expect(v.fragment).toContain('ACME @ 42');
   });
 
   it('escaped data cannot smuggle a script past the gate', () => {

--- a/tests/widgets/widget-registry.test.ts
+++ b/tests/widgets/widget-registry.test.ts
@@ -12,6 +12,7 @@ import {
   renderWidgetDocument,
   renderWidgetForData,
   hasWidgetForData,
+  neutralizeUnsafeUrls,
 } from '../../src/widgets/widget-registry.js';
 import { widgetKind, type WeatherWidgetData } from '../../src/widgets/widget-types.js';
 
@@ -27,22 +28,23 @@ describe('resolveWidgetSource', () => {
   it('returns curated for weather and news (case-insensitive)', () => {
     expect(resolveWidgetSource('weather')).toBe('curated');
     expect(resolveWidgetSource('news')).toBe('curated');
+    expect(resolveWidgetSource('stock')).toBe('curated');
     expect(resolveWidgetSource('WEATHER')).toBe('curated');
   });
 
   it('returns null for an unknown kind with no authored widget', () => {
     // Isolated empty dir — an empty env would resolve to the REAL ~/.codebuddy/widgets.
     const env = { CODEBUDDY_WIDGETS_DIR: mkdtempSync(join(tmpdir(), 'wdg-empty-')) } as NodeJS.ProcessEnv;
-    expect(resolveWidgetSource('stock', env)).toBeNull();
+    expect(resolveWidgetSource('unknown-stock', env)).toBeNull();
   });
 
   it('falls back to an authored widget for a NEW kind, but curated wins', () => {
     const dir = mkdtempSync(join(tmpdir(), 'wdg-'));
     const env = { CODEBUDDY_WIDGETS_DIR: dir } as NodeJS.ProcessEnv;
-    // Authored widget for a novel kind 'stock'.
-    mkdirSync(join(dir, 'authored-stock'), { recursive: true });
-    writeFileSync(join(dir, 'authored-stock', 'widget.html'), '<div>stock</div>');
-    expect(resolveWidgetSource('stock', env)).toBe('authored');
+    // Authored widget for a novel kind 'stocksheet'.
+    mkdirSync(join(dir, 'authored-stocksheet'), { recursive: true });
+    writeFileSync(join(dir, 'authored-stocksheet', 'widget.html'), '<div>stocksheet</div>');
+    expect(resolveWidgetSource('stocksheet', env)).toBe('authored');
     // An authored 'weather' must NOT shadow the curated one.
     mkdirSync(join(dir, 'authored-weather'), { recursive: true });
     writeFileSync(join(dir, 'authored-weather', 'widget.html'), '<div>evil</div>');
@@ -101,6 +103,33 @@ describe('server-side rendering (no client script)', () => {
     expect(doc).not.toMatch(/<script/i);
   });
 
+  it('renders a stock payload server-side with quote data inline', () => {
+    const doc = renderWidgetForData({
+      type: 'stock',
+      name: 'CAC 40',
+      symbol: 'PX1',
+      price: '8 326,62',
+      change: '1,20',
+      changePercent: '0,36%',
+      market: 'Euronext Paris',
+      open: 8290,
+      high: 8340,
+      low: 8260,
+      previousClose: '8 325,42',
+      volume: '312 587',
+      time: '18:05',
+    })!;
+    expect(doc).toContain('CAC 40');
+    expect(doc).toContain('8 326,62');
+    expect(doc).toContain('+0,36%');
+    expect(doc).toContain('+1,20 pts');
+    expect(doc).toContain('Hausse');
+    expect(doc).toContain('Ouverture');
+    expect(doc).toContain('Clôture veille');
+    expect(doc).toContain('312,6');
+    expect(doc).not.toMatch(/<script/i);
+  });
+
   it('renderWidgetDocument wraps a fragment into a self-contained doc', () => {
     const doc = renderWidgetDocument('<div>hi</div>');
     expect(doc).toContain('<!doctype html>');
@@ -114,6 +143,37 @@ describe('server-side rendering (no client script)', () => {
   });
 });
 
+describe('security hardening (M1 URL schemes, M3 CSP)', () => {
+  it('emits a self-defending CSP meta (script-src blocked) in the document', () => {
+    const doc = renderWidgetForData(sampleWeather)!;
+    expect(doc).toContain('http-equiv="Content-Security-Policy"');
+    expect(doc).toContain("default-src 'none'");
+    expect(doc).not.toMatch(/<script/i);
+    expect(doc).toContain('22°C'); // rendering unchanged
+  });
+
+  it('neutralizeUnsafeUrls blocks dangerous schemes but keeps http(s) and data:image', () => {
+    expect(neutralizeUnsafeUrls('<a href="javascript:alert(1)">x</a>')).toContain('#blocked');
+    expect(neutralizeUnsafeUrls('<a href="javascript:alert(1)">x</a>')).not.toContain('javascript:');
+    expect(neutralizeUnsafeUrls('<img src="data:text/html,evil">')).toContain('#blocked');
+    expect(neutralizeUnsafeUrls('<a href="https://example.com/a">x</a>')).toContain('https://example.com/a');
+    expect(neutralizeUnsafeUrls('<img src="data:image/png;base64,AAA">')).toContain('data:image/png');
+  });
+
+  it('the curated news widget drops a javascript: link but keeps an http one', () => {
+    const doc = renderWidgetForData({
+      type: 'news',
+      items: [
+        { title: 'Evil', url: 'javascript:alert(1)' },
+        { title: 'Good', url: 'https://example.com/article' },
+      ],
+    })!;
+    expect(doc).not.toContain('javascript:');
+    expect(doc).toContain('Evil'); // title still shown, just without a link
+    expect(doc).toContain('https://example.com/article');
+  });
+});
+
 describe('helpers', () => {
   it('widgetKind extracts the type', () => {
     expect(widgetKind({ type: 'weather' })).toBe('weather');
@@ -122,6 +182,6 @@ describe('helpers', () => {
   it('hasWidgetForData', () => {
     expect(hasWidgetForData(sampleWeather)).toBe(true);
     const env = { CODEBUDDY_WIDGETS_DIR: mkdtempSync(join(tmpdir(), 'wdg-empty-')) } as NodeJS.ProcessEnv;
-    expect(hasWidgetForData({ type: 'stock' }, env)).toBe(false);
+    expect(hasWidgetForData({ type: 'unknown-stock' }, env)).toBe(false);
   });
 });


### PR DESCRIPTION
Remédiation de l'**audit de la chaîne de création des widgets** (étendue **HAUT + MOYENS** retenue). Comparé aux gates tools/skills du self-improvement.

## H1 · anti-« hardcoding » (HAUT)
Le gate acceptait un template qui **n'utilise pas les données** (valeurs codées en dur) → widget périmé à la réutilisation. Ajout de deux checks à `widget-gate` :
- **Structurel** : ≥1 interpolation `{{ path }}` sinon rejet `no-data-binding`.
- **Comportemental (held-out)** : rendu avec le sample ET un `deriveDivergentSample` (chaque scalaire muté) ; **sortie identique ⇒ rejet `hardcoded`**. Le proposer ne voit pas le sample dérivé (gate-time) — équivalent des cas held-out cachés des tools.

## M1 · schéma d'URL (MOYEN, sécurité)
- `curated/news` : `it.url` passé par `sanitizeURL` existant (`src/utils/sanitize.ts`) → lien invalide = titre sans lien.
- `widget-registry.neutralizeUnsafeUrls` : neutralise `href`/`src`/`action` en `javascript:`/`vbscript:`/`data:` (sauf `data:image`) **au rendu** — couvre les données runtime que le gate ne revoit pas (curated + authored). Important vu le sandbox `allow-popups-to-escape-sandbox`.

## M2 · génération inline bornée (MOYEN, robustesse)
`resolveOrGenerate` : **timeout** (`CODEBUDDY_WIDGETS_GEN_TIMEOUT_MS`, déf. 20s → repli null), **dédup in-flight** (`Map<kind,Promise>`), **cooldown** après échec (`CODEBUDDY_WIDGETS_GEN_COOLDOWN_MS`, déf. 300s). Un proposer lent/bouclant ne gèle plus l'IPC de rendu.

## M3 · document auto-défendu (MOYEN, defense-in-depth)
`renderWidgetDocument` injecte un meta CSP `default-src 'none'; style-src 'unsafe-inline'; img-src data:` → même ouvert hors Cowork (`buddy widgets preview` écrit sur disque), zéro script/réseau possible. Aucun impact visuel.

## Note — widget stock curated
Inclut `curated/stock.ts` + `StockWidgetData` + enregistrement (stock/market/bourse) que **Code Buddy a lui-même commencé à créer** (présent dans le working tree, intriqué avec les edits registry/types). Fonctionnel, couvert par le durcissement (M1/M3 au rendu ; H1 ne concerne que l'authored). Pas de tests dédiés au widget stock dans cette PR.

## Constats BAS différés
caps d'octets/nombre, garde-fou thème pour authored, unification `esc`, rotation du ledger, consolidation authored.

## Vérif
`vitest tests/widgets` = **47/47** · `tsc` racine = 0 · `eslint` = 0. Live (dist) : `no-data-binding`/`hardcoded` rejetés, data-driven accepté, CSP présente, `javascript:` → `#blocked`, stock curated rend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)