### PR TITLE
feat(widgets): complète le widget stock/market (samples, indice→pts, tests)

### DIFF
--- a/src/commands/widgets.ts
+++ b/src/commands/widgets.ts
@@ -18,7 +18,7 @@ import { listAuthoredWidgets, keepAuthoredWidget } from '../widgets/widget-engin
 import { proposeWidget } from '../widgets/widget-proposer.js';
 import { gateWidget } from '../widgets/widget-gate.js';
 
-const CURATED_KINDS = ['weather', 'news'] as const;
+const CURATED_KINDS = ['weather', 'news', 'stock', 'market', 'bourse'] as const;
 
 /** Built-in sample payloads so `preview` works for curated kinds with no --sample. */
 const SAMPLES: Record<string, unknown> = {
@@ -40,7 +40,37 @@ const SAMPLES: Record<string, unknown> = {
       { title: 'Un autre titre', source: 'AFP' },
     ],
   },
+  stock: {
+    type: 'stock',
+    name: 'Apple Inc.',
+    symbol: 'AAPL',
+    price: 226.34,
+    change: 3.12,
+    changePercent: 1.4,
+    currency: 'USD',
+    open: 223.5,
+    high: 227.1,
+    low: 222.8,
+    previousClose: 223.22,
+    volume: 48200000,
+    market: 'NASDAQ',
+    time: 'Clôture',
+  },
+  market: {
+    type: 'market',
+    name: 'CAC 40',
+    symbol: 'PX1',
+    value: 7654.2,
+    change: -42.8,
+    changePercent: -0.56,
+    high: 7712.0,
+    low: 7640.1,
+    previousClose: 7697.0,
+    market: 'Euronext Paris',
+    time: '17:35',
+  },
 };
+SAMPLES.bourse = { ...(SAMPLES.market as object), type: 'bourse' };
 
 function parseSample(raw: string | undefined, kind: string): unknown {
   if (raw && raw.trim()) {

--- a/src/widgets/curated/stock.ts
+++ b/src/widgets/curated/stock.ts
@@ -68,7 +68,10 @@ export function renderStockWidget(raw: unknown): string {
   const previousClose = num(d.previousClose);
   const neg = (pct ?? change ?? 0) < 0;
   const sign = neg ? '' : '+';
-  const currency = d.currency ?? (d.symbol === 'PX1' || d.name === 'CAC 40' ? 'pts' : '');
+  // An index (market/bourse kind, or a recognized index) is quoted in points
+  // unless an explicit currency is given.
+  const isIndex = d.type === 'market' || d.type === 'bourse' || d.symbol === 'PX1' || d.name === 'CAC 40';
+  const currency = d.currency ?? (isIndex ? 'pts' : '');
   const title = d.name ?? d.symbol ?? 'Cours de bourse';
   const pill = pct != null ? `${sign}${fmt(pct)}%` : change != null ? `${sign}${fmt(change)}` : '—';
   const abs = change != null ? `${sign}${fmt(change)}${currency ? ` ${currency}` : ''}` : '';

--- a/tests/widgets/stock-widget.test.ts
+++ b/tests/widgets/stock-widget.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Curated stock/market widget — server-side rendered, theme-aware, tolerant of
+ * string inputs, green/red on sign, missing fields → em-dash. Pure.
+ */
+import { renderStockWidget } from '../../src/widgets/curated/stock.js';
+import { renderWidgetForData } from '../../src/widgets/widget-registry.js';
+
+describe('renderStockWidget', () => {
+  const up = {
+    type: 'stock',
+    name: 'Apple Inc.',
+    symbol: 'AAPL',
+    price: 226.34,
+    change: 3.12,
+    changePercent: 1.4,
+    currency: 'USD',
+    open: 223.5,
+    high: 227.1,
+    low: 222.8,
+    previousClose: 223.22,
+    volume: 48200000,
+    market: 'NASDAQ',
+  };
+
+  it('renders name, symbol and a formatted price with the currency', () => {
+    const h = renderStockWidget(up);
+    expect(h).toContain('Apple Inc.');
+    expect(h).toContain('AAPL');
+    expect(h).toContain('226,34'); // fr-FR formatting
+    expect(h).toContain('USD');
+    expect(h).not.toMatch(/<script/i);
+  });
+
+  it('is GREEN (no neg class, + sign) on a positive move', () => {
+    const h = renderStockWidget(up);
+    expect(h).toContain('class="pill "'); // no "neg"
+    expect(h).toContain('+1,40%');
+  });
+
+  it('is RED (neg class, no + sign) on a negative move', () => {
+    const h = renderStockWidget({ ...up, change: -2.5, changePercent: -1.1 });
+    expect(h).toContain('pill neg');
+    expect(h).toContain('bar neg');
+    expect(h).toContain('-1,10%');
+    expect(h).not.toContain('+-'); // sign not doubled
+  });
+
+  it('parses string inputs (price "226,34", percent "1,4%")', () => {
+    const h = renderStockWidget({ type: 'stock', symbol: 'X', price: '226,34', changePercent: '1,4%' });
+    expect(h).toContain('226,34');
+    expect(h).toContain('1,40%');
+  });
+
+  it('shows em-dash for missing OHLC fields (never "undefined"/"NaN")', () => {
+    const h = renderStockWidget({ type: 'stock', symbol: 'X', price: 10 });
+    expect(h).toContain('—');
+    expect(h).not.toMatch(/undefined|NaN/);
+  });
+
+  it('quotes an index (type market/bourse) in points when no currency given', () => {
+    const h = renderStockWidget({ type: 'market', name: 'CAC 40', value: 7654.2, changePercent: -0.5 });
+    expect(h).toContain('pts');
+    expect(h).toContain('654,20'); // value used when price absent (fr-FR thousands sep is U+202F)
+  });
+
+  it('carries a data-cbw-theme dark variant (host-driven theme)', () => {
+    expect(renderStockWidget(up)).toContain(':root[data-cbw-theme="dark"] .cbw-stock');
+  });
+
+  it('is reachable through the registry with a self-contained doc + CSP', () => {
+    const doc = renderWidgetForData(up)!;
+    expect(doc).toContain('<!doctype html>');
+    expect(doc).toContain('Apple Inc.');
+    expect(doc).toContain("default-src 'none'"); // hardening CSP applies
+    expect(doc).not.toMatch(/<script/i);
+  });
+});


### PR DESCRIPTION
Finalise le widget curated **stock/market/bourse** que Code Buddy avait commencé à créer.

- `buddy widgets preview stock|market|bourse` fonctionne : **samples intégrés** (Apple/NASDAQ hausse, CAC 40/Euronext baisse) + ajout aux `CURATED_KINDS` (visibles dans `buddy widgets list`).
- **Indice → pts** plus robuste : points quand `type=market/bourse` OU indice reconnu (superset non-breaking de l'ancien heuristique nom/symbole → l'ancien test reste vert).
- **Tests dédiés** (`tests/widgets/stock-widget.test.ts`) : prix formaté fr-FR + devise, pastille/barre **verte** en hausse & **rouge** en baisse (signe non doublé), parsing string ("226,34"/"1,4%"), champs manquants → « — » (jamais undefined/NaN), indice→pts, variante `data-cbw-theme`, chemin registry (doc auto-contenu + CSP).

Rendu vérifié live (capture headless : Apple +1,40% vert / CAC 40 −0,56% rouge, tuile « — » pour un champ absent).

`vitest tests/widgets` = **55/55** · tsc racine = 0 · eslint = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)