### PR TITLE
fix(tools): expose stock_quote au LLM (définition manquante) + parité executor

### DIFF
--- a/src/agent/tool-executor.ts
+++ b/src/agent/tool-executor.ts
@@ -21,6 +21,7 @@ import {
   ImageTool,
   WebSearchTool,
   WeatherTool,
+  StockQuoteTool,
   MorphEditorTool,
 } from "../tools/index.js";
 import { ToolResult, getErrorMessage } from "../types/index.js";
@@ -57,6 +58,8 @@ export interface ToolExecutorDependencies {
   webSearch: WebSearchTool;
   /** Optional — defaults to a fresh WeatherTool (no config/key needed). */
   weather?: WeatherTool;
+  /** Optional — defaults to a fresh StockQuoteTool (no config/key needed). */
+  stockQuote?: StockQuoteTool;
   checkpointManager: CheckpointManager;
   morphEditor?: MorphEditorTool | null;
 }
@@ -203,6 +206,7 @@ const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
   web_search: 'web',
   web_fetch: 'web',
   weather: 'web',
+  stock_quote: 'web',
   browser: 'web',
   // Planning
   create_todo_list: 'planning',
@@ -241,6 +245,7 @@ export class ToolExecutor {
   private imageTool: ImageTool;
   private webSearch: WebSearchTool;
   private weather: WeatherTool;
+  private stockQuote: StockQuoteTool;
   private checkpointManager: CheckpointManager;
   private morphEditor?: MorphEditorTool | null;
 
@@ -270,6 +275,7 @@ export class ToolExecutor {
     this.imageTool = deps.imageTool;
     this.webSearch = deps.webSearch;
     this.weather = deps.weather ?? new WeatherTool();
+    this.stockQuote = deps.stockQuote ?? new StockQuoteTool();
     this.checkpointManager = deps.checkpointManager;
     this.morphEditor = deps.morphEditor;
 
@@ -463,6 +469,11 @@ export class ToolExecutor {
           args.days as number | undefined,
           args.units as 'metric' | 'imperial' | undefined,
         );
+
+      case "stock_quote":
+        // Live dispatch also goes through ToolHandler→FormalToolRegistry
+        // (StockQuoteExecuteTool); this keeps the legacy executor in parity.
+        return await this.stockQuote.getQuote(args.symbol as string);
 
       case "web_fetch":
         return await this.webSearch.fetchPage(args.url as string);

--- a/src/codebuddy/tool-definitions/web-tools.ts
+++ b/src/codebuddy/tool-definitions/web-tools.ts
@@ -159,6 +159,30 @@ export const WEATHER_TOOL: CodeBuddyTool = {
   },
 };
 
+// Stock quote tool — real market data via Yahoo Finance → Nasdaq → Stooq (free,
+// no API key), optional Finnhub. Emits a structured payload that renders the
+// curated stock widget inline.
+export const STOCK_QUOTE_TOOL: CodeBuddyTool = {
+  type: "function",
+  function: {
+    name: "stock_quote",
+    description:
+      "Get a real stock or index market quote (price, change, day range, volume) via Yahoo Finance / Nasdaq (free, no API key). " +
+      "ALWAYS use this tool (never web_search) for stock price / cours de bourse / market index questions.",
+    parameters: {
+      type: "object",
+      properties: {
+        symbol: {
+          type: "string",
+          description:
+            "Ticker symbol. US stocks plain (e.g. 'AAPL', 'TSLA', 'NVDA'); other exchanges suffixed (e.g. 'MC.PA' for LVMH, 'BMW.DE'); indices prefixed with ^ (e.g. '^FCHI' for CAC 40, '^GSPC' for S&P 500). Map the company/index name the user says to its ticker.",
+        },
+      },
+      required: ["symbol"],
+    },
+  },
+};
+
 /**
  * All web tools as an array
  */
@@ -167,5 +191,6 @@ export const WEB_TOOLS: CodeBuddyTool[] = [
   WEB_FETCH_TOOL,
   WEB_EXTRACT_TOOL,
   WEATHER_TOOL,
+  STOCK_QUOTE_TOOL,
   // BROWSER_TOOL omitted — superseded by the richer browser-tools.ts (40+ actions)
 ];

--- a/tests/agent/tool-executor.test.ts
+++ b/tests/agent/tool-executor.test.ts
@@ -30,6 +30,7 @@ jest.mock("../../src/tools/index.js", () => ({
     processImage: jest.fn().mockResolvedValue({ success: true }),
   }; }),
   WeatherTool: jest.fn().mockImplementation(function() { return { getWeather: jest.fn().mockResolvedValue({ success: true, output: 'weather report' }) }; }),
+  StockQuoteTool: jest.fn().mockImplementation(function() { return { getQuote: jest.fn().mockResolvedValue({ success: true, output: 'stock quote', data: { type: 'stock' } }) }; }),
   WebSearchTool: jest.fn().mockImplementation(function() { return {
     search: jest.fn().mockResolvedValue({ success: true, output: "web results" }),
     fetchPage: jest.fn().mockResolvedValue({ success: true, output: "page content" }),


### PR DESCRIPTION
## Le bug
`stock_quote` était bien enregistré côté exécution (FormalToolRegistry / ITool), mais **sa définition OpenAI manquait dans `WEB_TOOLS`** → il n'entrait pas dans la liste d'outils envoyée au LLM (`registerGroup(WEB_TOOLS)`), donc l'agent Cowork répondait « le tool n'est pas dispo ». C'était l'étape 2 manquante du guide *Adding a Tool* (définition dans `tool-definitions/`).

## Fix
- `STOCK_QUOTE_TOOL` ajouté à `src/codebuddy/tool-definitions/web-tools.ts` + tableau `WEB_TOOLS` (comme `WEATHER_TOOL`) → **visible par le LLM**.
- Parité de l'executor legacy (`src/agent/tool-executor.ts`) : import, dep optionnelle + champ + init, catégorie `'web'`, `case "stock_quote"`.
- Mock `StockQuoteTool` ajouté au test (sinon le constructeur explosait).

## Preuve LIVE dans Cowork
« Donne-moi le cours d'Apple (AAPL) » → l'agent appelle `stock_quote` → **widget rendu inline** : Apple Inc. AAPL **316,22 USD +0,90 %**, Ouverture 310,45 / +Haut 316,53 / +Bas 308,16 / Clôture veille 313,39, NMS · Vol. 44,9 M — vraies données $0.

`tsc` 0 · `eslint` 0 · tool-executor **23/23**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)