### PR TITLE
fix(providers): make the $0 local Ollama path actually work (no more 404 grok-code-fast-1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -581,18 +581,30 @@ async function saveCommandLineSettings(
   }
 }
 
+/** Providers served by a local OpenAI-compatible runtime (no cloud model catalog). */
+const LOCAL_RUNTIME_PROVIDERS = new Set(['ollama', 'lmstudio', 'vllm']);
+
+/** A model id that only makes sense on a hosted cloud backend (never a local Ollama tag). */
+function looksLikeCloudModel(model: string): boolean {
+  return /grok|^gpt-|^o[1-9]|codex|claude|gemini/i.test(model);
+}
+
 /**
  * A saved/default model is only usable if it matches the detected provider's
  * backend: a `grok-*` slug 404s on the ChatGPT/Codex backend, and a `gpt-5.*`
- * slug 404s on xAI. We only enforce this for the two providers with a known
- * hard incompatibility (grok ↔ chatgpt); other providers are left untouched so
- * local/OpenAI/Anthropic model names pass through as before.
+ * slug 404s on xAI. We enforce this for the two cloud providers with a known
+ * hard incompatibility (grok ↔ chatgpt), AND for local runtimes (Ollama / LM
+ * Studio / vLLM) — a stale cloud slug like `grok-code-fast-1` left in
+ * settings.json must never be sent to a local server (it 404s with a cryptic
+ * "model not found"). Other providers are left untouched so OpenAI/Anthropic
+ * model names pass through as before.
  */
-function isModelCompatibleWithProvider(model: string, provider?: string): boolean {
+export function isModelCompatibleWithProvider(model: string, provider?: string): boolean {
   if (!provider) return true;
   const looksGrok = /grok/i.test(model);
   if (provider === 'grok') return looksGrok;
   if (provider === 'chatgpt') return /^(gpt-|o[1-9]|codex)/i.test(model) && !looksGrok;
+  if (LOCAL_RUNTIME_PROVIDERS.has(provider)) return !looksLikeCloudModel(model);
   return true;
 }
 
@@ -605,23 +617,57 @@ async function loadModel(): Promise<string | undefined> {
 
   const detected = await getDetectedProvider();
 
-  // 2. Project/user settings override auto-detection — UNLESS the saved model is
+  // Read the saved model once (reused by both the settings path and the
+  // local-runtime path below).
+  let settingsModel: string | undefined;
+  try {
+    const getSettingsManager = await lazyImport.settingsManager();
+    settingsModel = getSettingsManager().getCurrentModel() || undefined;
+  } catch (_err) {
+    logger.debug('Failed to load model from settings manager', { error: _err });
+  }
+
+  // 2. Local runtime (Ollama): resolve to a model that is ACTUALLY installed,
+  //    never a stale cloud slug. Detection sets `defaultModel` to the advertised
+  //    onboarding tag (e.g. `qwen2.5-coder:7b`), but a fresh box rarely has that
+  //    exact tag pulled — sending it (or a leftover `grok-code-fast-1` from
+  //    settings) yields a cryptic `404 model not found`. Probe the server's tags
+  //    and pick a real one; if none is installed / the server is down, fail with
+  //    a clear `ollama pull …` hint. This is the "$0 local" onboarding path, so
+  //    it must never dead-end on a Grok 404. Only triggers for local runtimes,
+  //    so cloud/no-provider behavior stays byte-identical.
+  if (detected && detected.provider === 'ollama') {
+    const { resolveInstalledOllamaModel, buildOllamaPullHint } = await import(
+      './providers/local-model-resolver.js'
+    );
+    const requested =
+      process.env.OLLAMA_MODEL ||
+      (settingsModel && isModelCompatibleWithProvider(settingsModel, 'ollama')
+        ? settingsModel
+        : undefined) ||
+      detected.defaultModel;
+    const resolution = await resolveInstalledOllamaModel({
+      baseURL: detected.baseURL,
+      requested,
+    });
+    if (resolution.model) return resolution.model;
+    cli.error(
+      buildOllamaPullHint({ baseURL: detected.baseURL, reachable: resolution.reachable, requested }),
+    );
+    process.exit(1);
+  }
+
+  // 3. Project/user settings override auto-detection — UNLESS the saved model is
   //    incompatible with the detected provider. A `gpt-5.5` left in settings.json
   //    would 404 against xAI after `buddy login xai`; symmetrically, a stale
   //    `grok-code-fast-1` default 404s against the ChatGPT/Codex backend (which
   //    then falls back to another unsupported slug and crashes). In either
   //    mismatch, prefer the detected provider's own default model.
-  try {
-    const getSettingsManager = await lazyImport.settingsManager();
-    const settingsModel = getSettingsManager().getCurrentModel();
-    if (settingsModel && isModelCompatibleWithProvider(settingsModel, detected?.provider)) {
-      return settingsModel;
-    }
-  } catch (_err) {
-    logger.debug('Failed to load model from settings manager', { error: _err });
+  if (settingsModel && isModelCompatibleWithProvider(settingsModel, detected?.provider)) {
+    return settingsModel;
   }
 
-  // 3. Fallback to auto-detected provider's default model
+  // 4. Fallback to auto-detected provider's default model
   if (detected) return detected.defaultModel;
 
   return undefined;

--- a/src/providers/local-model-resolver.ts
+++ b/src/providers/local-model-resolver.ts
@@ -1,0 +1,155 @@
+/**
+ * Local-model resolution for Ollama.
+ *
+ * Fixes the "$0 local" onboarding trap: `CODEBUDDY_PROVIDER=ollama buddy`
+ * used to detect Ollama correctly but then send a stale cloud model id
+ * (`grok-code-fast-1`) as the request model, producing a cryptic
+ * `404 model 'grok-code-fast-1' not found`.
+ *
+ * The resolver probes the tags actually installed on the local Ollama
+ * server and picks a real one (preferring a coding model). If the server
+ * is reachable but empty, or unreachable, callers get a clear, actionable
+ * signal (`ollama pull <model>`) instead of a 404.
+ *
+ * Pure functions (probe is injectable) so the whole thing is unit-testable
+ * without a live Ollama.
+ */
+
+const OLLAMA_TAGS_TIMEOUT_MS = 2_000;
+
+/** Default coding model advertised during onboarding — the pull hint target. */
+export const DEFAULT_OLLAMA_MODEL = 'qwen2.5-coder:7b';
+
+interface OllamaTagsResponse {
+  models?: Array<{ name?: unknown; model?: unknown }>;
+}
+
+/**
+ * Choose an installed Ollama model without assuming an exact tag.
+ *
+ * Order: an exact match for `requested` → a coding-oriented model
+ * (qwen coder, devstral, codestral, anything "coder"/"code") → the first
+ * installed model. Returns `null` when nothing is installed.
+ */
+export function chooseInstalledOllamaModel(
+  models: readonly string[],
+  requested?: string,
+): string | null {
+  const usable = models.map((model) => model.trim()).filter(Boolean);
+  const requestedModel = requested?.trim();
+  if (requestedModel) {
+    const exact = usable.find((model) => model.toLowerCase() === requestedModel.toLowerCase());
+    if (exact) return exact;
+  }
+
+  for (const pattern of [/qwen.*coder/i, /devstral/i, /codestral/i, /coder/i, /code/i]) {
+    const match = usable.find((model) => pattern.test(model));
+    if (match) return match;
+  }
+  return usable[0] ?? null;
+}
+
+/** Turn an Ollama base URL (with or without a trailing `/v1`) into its `/api/tags` endpoint. */
+export function ollamaTagsUrl(baseURL: string): string {
+  let host = (baseURL || 'http://localhost:11434').trim();
+  if (!/^https?:\/\//i.test(host)) host = `http://${host}`;
+  host = host.replace(/\/+$/, '').replace(/\/v1$/i, '');
+  return `${host}/api/tags`;
+}
+
+function parseOllamaModels(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  const models = (value as OllamaTagsResponse).models;
+  if (!Array.isArray(models)) return [];
+  return models
+    .map((entry) => {
+      const candidate = entry.name ?? entry.model;
+      return typeof candidate === 'string' ? candidate : null;
+    })
+    .filter((model): model is string => Boolean(model));
+}
+
+/**
+ * Fetch the installed model tags from a local Ollama server.
+ *
+ * Returns `null` when the server can't be reached or returns junk (so the
+ * caller can distinguish "Ollama is down" from "no models installed"), or a
+ * (possibly empty) list of tag names when it responds.
+ */
+export async function fetchOllamaTags(
+  baseURL: string,
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<string[] | null> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? OLLAMA_TAGS_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(ollamaTagsUrl(baseURL), { signal: controller.signal });
+    if (!response.ok) return null;
+    const body = (await response.json()) as unknown;
+    return parseOllamaModels(body);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface OllamaModelResolution {
+  /** The chosen installed model, or `null` when none is usable. */
+  model: string | null;
+  /** Whether the server was reachable (null tags ⇒ unreachable). */
+  reachable: boolean;
+  /** Number of installed models seen (0 when unreachable). */
+  installedCount: number;
+}
+
+/**
+ * Resolve the model to send to a local Ollama provider: probe the server,
+ * then pick an installed tag (preferring `requested`, then a coder model).
+ */
+export async function resolveInstalledOllamaModel(options: {
+  baseURL: string;
+  requested?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<OllamaModelResolution> {
+  const tags = await fetchOllamaTags(options.baseURL, {
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+  });
+  if (tags === null) {
+    return { model: null, reachable: false, installedCount: 0 };
+  }
+  return {
+    model: chooseInstalledOllamaModel(tags, options.requested),
+    reachable: true,
+    installedCount: tags.length,
+  };
+}
+
+/**
+ * Build the clear, actionable message shown when no local model can be
+ * resolved — the honest replacement for the cryptic Grok 404.
+ */
+export function buildOllamaPullHint(options: {
+  baseURL: string;
+  reachable: boolean;
+  requested?: string;
+}): string {
+  const model = options.requested?.trim() || DEFAULT_OLLAMA_MODEL;
+  if (!options.reachable) {
+    return [
+      `Ollama not reachable at ${options.baseURL}.`,
+      'Start it, then install a model:',
+      '  ollama serve            # if it is not already running',
+      `  ollama pull ${model}`,
+    ].join('\n');
+  }
+  return [
+    'No Ollama model is installed for the local ($0) path.',
+    'Install one, then re-run:',
+    `  ollama pull ${model}`,
+  ].join('\n');
+}

--- a/tests/providers/local-model-resolver.test.ts
+++ b/tests/providers/local-model-resolver.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for src/providers/local-model-resolver.ts.
+ *
+ * The regression guarded here: `CODEBUDDY_PROVIDER=ollama buddy` used to send
+ * a stale cloud model id (`grok-code-fast-1`) to the local Ollama server,
+ * yielding a cryptic `404 model 'grok-code-fast-1' not found`. The resolver
+ * must instead pick a model that is ACTUALLY installed, and — when none is —
+ * surface a clear `ollama pull …` hint rather than a 404.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  chooseInstalledOllamaModel,
+  ollamaTagsUrl,
+  fetchOllamaTags,
+  resolveInstalledOllamaModel,
+  buildOllamaPullHint,
+  DEFAULT_OLLAMA_MODEL,
+} from '../../src/providers/local-model-resolver.js';
+
+const INSTALLED = [
+  'llama3:latest',
+  'devstral-small-2:24b-instruct-2512-q4_K_M',
+  'qwen2.5:3b-instruct',
+  'gemma4:12b',
+];
+
+function fakeFetch(payload: unknown, init: { ok?: boolean; throws?: boolean } = {}): typeof fetch {
+  return (async () => {
+    if (init.throws) throw new Error('ECONNREFUSED');
+    return {
+      ok: init.ok ?? true,
+      json: async () => payload,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe('chooseInstalledOllamaModel', () => {
+  it('honors an exact requested tag when installed (case-insensitive)', () => {
+    expect(chooseInstalledOllamaModel(INSTALLED, 'qwen2.5:3b-instruct')).toBe('qwen2.5:3b-instruct');
+    expect(chooseInstalledOllamaModel(INSTALLED, 'QWEN2.5:3B-INSTRUCT')).toBe('qwen2.5:3b-instruct');
+  });
+
+  it('ignores a stale cloud slug and falls back to a coding model', () => {
+    // The core regression: grok-code-fast-1 is NOT installed → never returned.
+    const chosen = chooseInstalledOllamaModel(INSTALLED, 'grok-code-fast-1');
+    expect(chosen).toBe('devstral-small-2:24b-instruct-2512-q4_K_M');
+    expect(chosen).not.toBe('grok-code-fast-1');
+  });
+
+  it('ignores the advertised default when not installed, prefers a coder model', () => {
+    // qwen2.5-coder:7b is the onboarding default but not pulled here.
+    expect(chooseInstalledOllamaModel(INSTALLED, DEFAULT_OLLAMA_MODEL)).toBe(
+      'devstral-small-2:24b-instruct-2512-q4_K_M',
+    );
+  });
+
+  it('falls back to the first installed model when no coder model exists', () => {
+    expect(chooseInstalledOllamaModel(['llama3:latest', 'gemma4:12b'], 'grok-code-fast-1')).toBe(
+      'llama3:latest',
+    );
+  });
+
+  it('returns null when nothing is installed', () => {
+    expect(chooseInstalledOllamaModel([], 'grok-code-fast-1')).toBeNull();
+    expect(chooseInstalledOllamaModel(['', '  '])).toBeNull();
+  });
+});
+
+describe('ollamaTagsUrl', () => {
+  it('strips a trailing /v1 and points at /api/tags', () => {
+    expect(ollamaTagsUrl('http://localhost:11434/v1')).toBe('http://localhost:11434/api/tags');
+    expect(ollamaTagsUrl('http://localhost:11434')).toBe('http://localhost:11434/api/tags');
+    expect(ollamaTagsUrl('localhost:11434/v1/')).toBe('http://localhost:11434/api/tags');
+  });
+});
+
+describe('fetchOllamaTags', () => {
+  it('parses model names from an /api/tags response', async () => {
+    const fetchImpl = fakeFetch({
+      models: [{ name: 'llama3:latest' }, { model: 'devstral-small-2:24b' }],
+    });
+    expect(await fetchOllamaTags('http://localhost:11434/v1', { fetchImpl })).toEqual([
+      'llama3:latest',
+      'devstral-small-2:24b',
+    ]);
+  });
+
+  it('returns null (unreachable) when the fetch throws', async () => {
+    const fetchImpl = fakeFetch(null, { throws: true });
+    expect(await fetchOllamaTags('http://localhost:11434/v1', { fetchImpl })).toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    const fetchImpl = fakeFetch({}, { ok: false });
+    expect(await fetchOllamaTags('http://localhost:11434/v1', { fetchImpl })).toBeNull();
+  });
+});
+
+describe('resolveInstalledOllamaModel', () => {
+  it('resolves a real installed model instead of the requested cloud slug', async () => {
+    const fetchImpl = fakeFetch({ models: INSTALLED.map((name) => ({ name })) });
+    const res = await resolveInstalledOllamaModel({
+      baseURL: 'http://localhost:11434/v1',
+      requested: 'grok-code-fast-1',
+      fetchImpl,
+    });
+    expect(res.reachable).toBe(true);
+    expect(res.installedCount).toBe(INSTALLED.length);
+    expect(res.model).toBe('devstral-small-2:24b-instruct-2512-q4_K_M');
+  });
+
+  it('reports reachable-but-empty (no models installed)', async () => {
+    const fetchImpl = fakeFetch({ models: [] });
+    const res = await resolveInstalledOllamaModel({
+      baseURL: 'http://localhost:11434/v1',
+      requested: 'qwen2.5-coder:7b',
+      fetchImpl,
+    });
+    expect(res).toEqual({ model: null, reachable: true, installedCount: 0 });
+  });
+
+  it('reports unreachable when the server is down', async () => {
+    const fetchImpl = fakeFetch(null, { throws: true });
+    const res = await resolveInstalledOllamaModel({
+      baseURL: 'http://localhost:11434/v1',
+      fetchImpl,
+    });
+    expect(res).toEqual({ model: null, reachable: false, installedCount: 0 });
+  });
+});
+
+describe('buildOllamaPullHint', () => {
+  it('tells the user to pull a model when the server is reachable but empty', () => {
+    const hint = buildOllamaPullHint({
+      baseURL: 'http://localhost:11434/v1',
+      reachable: true,
+      requested: 'qwen2.5-coder:7b',
+    });
+    expect(hint).toContain('ollama pull qwen2.5-coder:7b');
+    expect(hint).not.toContain('grok');
+    expect(hint).not.toContain('404');
+  });
+
+  it('tells the user to start Ollama when unreachable', () => {
+    const hint = buildOllamaPullHint({ baseURL: 'http://localhost:11434/v1', reachable: false });
+    expect(hint).toContain('not reachable');
+    expect(hint).toContain('ollama serve');
+    expect(hint).toContain(`ollama pull ${DEFAULT_OLLAMA_MODEL}`);
+  });
+});


### PR DESCRIPTION
## The bug (README's central promise was broken)
`CODEBUDDY_PROVIDER=ollama buddy -p "hi"` auto-detected Ollama correctly but still sent the model id `grok-code-fast-1`, so Ollama replied `404 model not found`. This is the exact path a keyless evaluator (the "runs entirely on local Ollama `$0`" promise) takes — they hit a cryptic Grok error and bounce. Reproduced on a fresh 1.8.0 build; a real source bug, not a local artifact.

## The fix
- **New `src/providers/local-model-resolver.ts`** (pure, `fetch` injectable, 14 unit tests): probes `/api/tags`, picks a **really-installed** Ollama model (exact match → coder model → first installed), distinguishes "server down" from "no model", and builds a clear `ollama pull <model>` hint.
- **`src/index.ts`**: when the resolved provider is `ollama` and no model is given, resolve to an installed tag; if none, exit with the pull hint instead of the 404. `isModelCompatibleWithProvider` now also rejects stale cloud slugs (grok/gpt/claude/…) for local runtimes.
- **Invariant**: with no local provider detected, behavior is byte-identical; an explicit `-m` short-circuits entirely.

## Tested for real
- Zero-config Ollama now routes to an installed model (`$0`), no grok 404.
- Explicit `-m` still works.
- No model installed → clear `ollama pull` message (reachable + unreachable cases), exit 1.
- `npm run typecheck` exit 0; 14/14 unit tests pass.

Note: pure-default selection reuses the existing coder-preference heuristic (may pick a large model); a follow-up could prefer a small fast model for the very first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)