### PR TITLE
feat(onboarding): 2-minute $0 start with zero env vars (onboard/doctor/try)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,29 +35,71 @@ npm install -g @phuetz/code-buddy
 npx @phuetz/code-buddy@latest
 ```
 
-## First Run
+## First Run — free, in under 2 minutes
+
+You do **not** need an API key, and you do **not** need to edit any environment
+variable. Pick whichever line matches you:
 
 ```bash
-# Set your API key (Grok/xAI is the default provider)
-export GROK_API_KEY=your_api_key
+buddy try            # ← start here: a 60-second, zero-config coding demo.
+                     #    Detects a running Ollama or a signed-in ChatGPT and
+                     #    proves it works (writes FizzBuzz + tests, runs them).
 
-# Start interactive mode
-buddy
+buddy onboard        # Guided setup. Auto-detects what's on your machine and
+                     #    defaults to the FREE path — one "yes" and you're done.
+                     #    Writes the config for you (no env var to type).
 
-# Or with a specific task
-buddy --prompt "analyze the codebase structure"
+buddy login          # Sign in with a ChatGPT Plus/Pro subscription — $0 marginal
+                     #    cost, no API key. (Grok/xAI: `buddy login xai`.)
 
-# Use a local LLM (LM Studio)
-buddy --base-url http://localhost:1234/v1 --api-key lm-studio
-
-# Use Ollama
-buddy --base-url http://localhost:11434/v1 --model llama3
-
-# Full autonomy mode
-buddy --yolo
+buddy                # Start chatting once a provider is configured.
+buddy --prompt "analyze the codebase structure"   # one-shot / headless
 ```
 
-Code Buddy auto-detects your provider from the API key environment variables. Set any of `GROK_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `MISTRAL_API_KEY`, etc.
+### The two $0 paths in detail
+
+- **Local & private (Ollama).** Install [Ollama](https://ollama.ai), then run
+  `buddy onboard` — it detects the running server, offers to pull a small coding
+  model if you have none, and saves the choice. Nothing leaves your machine.
+- **ChatGPT subscription.** `buddy login` reuses your existing ChatGPT plan
+  through the Codex backend at **$0 marginal cost** — no key, no billing setup.
+
+> Stuck? `buddy doctor` tells you in one line whether you're ready to chat, and
+> **`buddy doctor --fix`** auto-configures a running Ollama for you.
+
+### Advanced: bring your own API key
+
+Code Buddy auto-detects a provider from API-key environment variables when one
+is set — any of `GROK_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`GOOGLE_API_KEY`, `MISTRAL_API_KEY`, etc. This is entirely optional; the free
+paths above need none of them.
+
+```bash
+export GROK_API_KEY=your_api_key   # optional — only if you prefer a paid API
+buddy
+buddy --yolo                       # full autonomy (see Special Modes)
+```
+
+## The 8 commands that matter (everything else is optional)
+
+`buddy --help` lists 60+ commands and the docs mention ~120 environment
+variables. **Ignore almost all of it to start.** These are the only ones a new
+user needs; the rest (companion/voice, film, robot, fleet, self-improvement, …)
+are opt-in and stay out of your way until you go looking for them.
+
+| Command | What it does |
+|---|---|
+| `buddy try` | Zero-config proof it works (60-second coding demo). |
+| `buddy onboard` | Guided setup; defaults to the free path, writes your config. |
+| `buddy login` | Sign in with a ChatGPT subscription ($0, no API key). |
+| `buddy` | Start an interactive session. |
+| `buddy -p "…"` | One-shot / headless (great for scripts and CI). |
+| `buddy doctor [--fix]` | Am I ready? Auto-fix the fixable. |
+| `buddy --continue` | Resume your last session. |
+| `buddy --init` | Drop a `.codebuddy/` + `AGENTS.md` into the current repo. |
+
+Nothing above needs an environment variable. Everything advanced is gated behind
+its own opt-in flag, so the defaults stay small and predictable.
 
 ## Onboarding the Cowork GUI (Ollama, $0)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,18 +148,30 @@ npm link            # exposes `buddy` globally
 
 ---
 
-## First run
+## First run — free, no env var to edit
 
-Whichever path you took:
+Whichever path you took, the fastest way in is one command:
 
 ```sh
-buddy login          # ChatGPT Plus/Pro OAuth → $0 marginal cost, no API key
-# …or a free, fully local brain:
-export CODEBUDDY_PROVIDER=ollama
-buddy                # start chatting
-
-buddy --prompt "analyze the codebase structure"   # one-shot / headless
+buddy try            # 60-second zero-config demo — detects Ollama or a
+                     # signed-in ChatGPT and proves it works. Start here.
 ```
+
+To make it your default, either sign in with a subscription or let the wizard
+configure a local model — **no API key, no environment variable**:
+
+```sh
+buddy onboard        # guided: auto-detects your machine, defaults to the free
+                     # path, and writes the config for you
+buddy login          # ChatGPT Plus/Pro OAuth → $0 marginal cost, no API key
+buddy                # start chatting
+```
+
+Have [Ollama](https://ollama.ai) installed? `buddy onboard` detects the running
+server, offers to pull a small coding model if you have none, and saves the
+choice — you never touch `OLLAMA_HOST`. Not sure you're ready?
+**`buddy doctor`** answers in one line (and `buddy doctor --fix` configures a
+running Ollama automatically).
 
 See [Getting Started](getting-started.md) for headless mode, sessions, and
 typical workflows, and [Deployment](deployment.md) for running the server in

--- a/install.sh
+++ b/install.sh
@@ -305,19 +305,22 @@ main() {
   fi
 
   info ""
-  printf '%s\n' "${C_BOLD}Get started${C_RESET}"
-  # Adapt the first step to what's actually on this machine — one obvious move.
+  printf '%s\n' "${C_BOLD}Get started — no API key, no env var to edit${C_RESET}"
+  # One obvious first move for everyone: the zero-config demo proves it works,
+  # then onboard/login make it your default.
   if detect_ollama; then
-    ok "Local Ollama detected — start chatting for \$0 right now:"
-    info "    ${C_BOLD}export CODEBUDDY_PROVIDER=ollama && buddy${C_RESET}"
+    ok "Local Ollama detected — prove it works for \$0 right now:"
+    info "    ${C_BOLD}buddy try${C_RESET}         — 60-second zero-config coding demo"
+    info "    ${C_BOLD}buddy onboard${C_RESET}     — save it as your default (detects Ollama, no env var)"
     info ""
     info "  ${C_DIM}Prefer a hosted brain? ${C_RESET}${C_BOLD}buddy login${C_RESET}${C_DIM} — ChatGPT Plus/Pro OAuth, \$0 marginal cost.${C_RESET}"
   else
-    info "  1. ${C_BOLD}buddy login${C_RESET}     — sign in with ChatGPT Plus/Pro (OAuth, \$0 marginal cost)"
-    info "     ${C_DIM}...or 'export CODEBUDDY_PROVIDER=ollama' if you run a local model.${C_RESET}"
-    info "  2. ${C_BOLD}buddy onboard${C_RESET}   — guided setup wizard (pick a model, keys optional)"
+    info "  1. ${C_BOLD}buddy try${C_RESET}       — 60-second zero-config demo (start here)"
+    info "  2. ${C_BOLD}buddy login${C_RESET}     — sign in with ChatGPT Plus/Pro (OAuth, \$0 marginal cost)"
+    info "     ${C_DIM}...or install Ollama (https://ollama.ai) and run 'buddy onboard' — it configures it for you.${C_RESET}"
     info "  3. ${C_BOLD}buddy${C_RESET}           — start chatting"
   fi
+  info "  ${C_DIM}Not sure you're ready? ${C_RESET}${C_BOLD}buddy doctor${C_RESET}${C_DIM} (add --fix to auto-configure a running Ollama).${C_RESET}"
   info ""
   info "${C_DIM}Full guide: https://github.com/phuetz/code-buddy/blob/main/docs/install.md${C_RESET}"
 }

--- a/src/commands/cli/utility-commands.ts
+++ b/src/commands/cli/utility-commands.ts
@@ -31,7 +31,20 @@ export function registerUtilityCommands(program: Command): void {
 
       const icons = { ok: '✅', warn: '⚠️', error: '❌' };
 
+      // Headline verdict: the first question a newcomer has is "can I chat yet?"
+      const readiness = checks.find((c) => c.name === 'AI provider ready');
+      if (readiness) {
+        if (readiness.status === 'ok') {
+          console.log(`  ✅ Ready to chat — a provider is configured (${readiness.message})`);
+          console.log('     Start now:  buddy         (or try the demo:  buddy try)');
+        } else {
+          console.log(`  ⚠️  Not ready to chat yet — ${readiness.message}`);
+        }
+        console.log('');
+      }
+
       for (const check of checks) {
+        if (check.name === 'AI provider ready') continue; // already shown as the headline
         if (options.verbose || check.status !== 'ok') {
           const fixTag = check.fixable ? ' [fixable]' : '';
           console.log(`  ${icons[check.status]} ${check.name}: ${check.message}${fixTag}`);

--- a/src/commands/try.ts
+++ b/src/commands/try.ts
@@ -63,24 +63,24 @@ interface OllamaTagsResponse {
   models?: Array<{ name?: unknown; model?: unknown }>;
 }
 
-export const TRY_DEMO_PROMPT = `Tu pilotes une démo courte d'agent de code dans un dossier temporaire vide.
+export const TRY_DEMO_PROMPT = `You are driving a short coding-agent demo in an empty temporary folder.
 
-Objectif exact :
-1. Crée fizzbuzz.js en CommonJS. Exporte une fonction fizzBuzz(value) qui renvoie le nombre sous forme de chaîne, "Fizz" pour les multiples de 3, "Buzz" pour ceux de 5 et "FizzBuzz" pour ceux de 15.
-2. Crée fizzbuzz.test.js avec node:test et node:assert/strict. Teste au minimum 1, 3, 5 et 15.
-3. Exécute exactement : node --test fizzbuzz.test.js
-4. Si un test échoue, corrige le code et relance-le.
-5. Termine par un bilan très court indiquant les deux fichiers créés et le résultat des tests.
+Exact goal:
+1. Create fizzbuzz.js in CommonJS. Export a function fizzBuzz(value) that returns the number as a string, "Fizz" for multiples of 3, "Buzz" for multiples of 5, and "FizzBuzz" for multiples of 15.
+2. Create fizzbuzz.test.js using node:test and node:assert/strict. Test at least 1, 3, 5, and 15.
+3. Run exactly: node --test fizzbuzz.test.js
+4. If a test fails, fix the code and run it again.
+5. Finish with a very short summary naming the two files you created and the test result.
 
-Utilise directement les outils de fichier et de terminal. Ne demande aucune confirmation, n'installe aucune dépendance et ne modifie rien hors du dossier de travail.`;
+Write everything in English. Use the file and terminal tools directly. Do not ask for any confirmation, do not install any dependency, and do not change anything outside the working folder.`;
 
 export const NO_TRY_PROVIDER_MESSAGE = [
-  'Aucun provider gratuit prêt pour la démo.',
+  'No free provider is ready for the demo.',
   '',
-  '1. Recommandé — connecte ton compte ChatGPT (OAuth, sans clé API, coût marginal $0 avec ton plan) :',
+  '1. Recommended — sign in with your ChatGPT account (OAuth, no API key, $0 marginal cost with your plan):',
   '   buddy login',
   '',
-  '2. Ou utilise Ollama en local :',
+  '2. Or run a model locally with Ollama:',
   '   ollama pull qwen2.5-coder:7b',
   '   buddy try',
 ].join('\n');
@@ -177,9 +177,10 @@ async function createDefaultAgent(
   const confirmation = ConfirmationService.getInstance();
   const previousFlags = confirmation.getSessionFlags();
   confirmation.setSessionFlag('allOperations', true);
-  // Le permission mode est vérifié AVANT les session flags : en mode `default` et sans TTY,
-  // create_file est refusé (« User cancelled »). La démo tourne dans un bac à sable temporaire
-  // isolé (workspace), donc on auto-approuve tout le temps de la démo puis on restaure le mode.
+  // The permission mode is checked BEFORE session flags: in `default` mode with
+  // no TTY, create_file is refused ("User cancelled"). The demo runs in an
+  // isolated temporary sandbox (workspace), so we auto-approve for the duration
+  // of the demo and then restore the previous mode.
   const permMgr = getPermissionModeManager();
   const previousMode = permMgr.getMode();
   permMgr.setMode('bypassPermissions');
@@ -278,39 +279,39 @@ export async function runTryDemo(options: RunTryDemoOptions = {}): Promise<numbe
   ];
   let agent: TryDemoAgent | undefined;
 
-  write('Code Buddy — démo agent de code (~60 secondes)');
-  write(`[1/3] Provider : ${provider.label}`);
-  write(`[2/3] Bac à sable : ${workspace}`);
-  write('      L’agent crée FizzBuzz, écrit ses tests et les exécute…');
+  write('Code Buddy — coding-agent demo (~60 seconds)');
+  write(`[1/3] Provider: ${provider.label}`);
+  write(`[2/3] Sandbox: ${workspace}`);
+  write('      The agent is creating FizzBuzz, writing its tests, and running them…');
 
   try {
     agent = await createAgent(provider, workspace);
     await agent.systemPromptReady;
     const entries = await agent.processUserMessage(TRY_DEMO_PROMPT, { surface: 'cli' });
     const toolNames = invokedToolNames(entries);
-    if (toolNames.length > 0) write(`      Outils utilisés : ${toolNames.join(', ')}`);
+    if (toolNames.length > 0) write(`      Tools used: ${toolNames.join(', ')}`);
     const assistantMessage = latestAssistantMessage(entries);
-    if (assistantMessage) write(`      Agent : ${assistantMessage}`);
+    if (assistantMessage) write(`      Agent: ${assistantMessage}`);
 
-    write('[3/3] Vérification indépendante : node --test fizzbuzz.test.js');
+    write('[3/3] Independent verification: node --test fizzbuzz.test.js');
     const verification = await verify(workspace);
     if (!verification.success) {
-      writeError('❌ La démo n’a pas produit un test vert. Le bac à sable est conservé pour inspection.');
+      writeError('❌ The demo did not produce a green test. The sandbox is kept for inspection.');
       if (verification.output) writeError(verification.output);
       writeError(`   ${workspace}`);
       return 1;
     }
 
-    write('✅ Démo réussie : le code a été écrit et ses tests passent.');
+    write('✅ Demo succeeded: the code was written and its tests pass.');
     if (verification.output) {
       const passLine = verification.output.split('\n').find((line) => /pass/i.test(line));
       if (passLine) write(`   ${passLine.trim()}`);
     }
-    write(`   Fichiers à inspecter : ${workspace}`);
+    write(`   Files to inspect: ${workspace}`);
     return 0;
   } catch (error) {
-    writeError(`❌ Démo interrompue : ${error instanceof Error ? error.message : String(error)}`);
-    writeError(`   Le bac à sable est conservé : ${workspace}`);
+    writeError(`❌ Demo interrupted: ${error instanceof Error ? error.message : String(error)}`);
+    writeError(`   The sandbox is kept: ${workspace}`);
     return 1;
   } finally {
     agent?.dispose?.({ skipSessionLearning: true });

--- a/src/commands/try.ts
+++ b/src/commands/try.ts
@@ -1,0 +1,327 @@
+/**
+ * `buddy try` — an isolated, zero-configuration coding-agent demonstration.
+ *
+ * The demo intentionally accepts only the two free paths advertised during
+ * onboarding: an existing ChatGPT OAuth login, then a reachable local Ollama.
+ * Ambient paid API keys are never selected implicitly.
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import type { ChatEntry } from '../agent/types.js';
+import { normalizeOllamaBaseUrl } from './ollama.js';
+import { hasCodexCredentials } from '../providers/codex-oauth.js';
+import { resolveProviderFromCatalog } from '../providers/provider-catalog.js';
+
+const OLLAMA_PROBE_TIMEOUT_MS = 2_000;
+const DEMO_MAX_TOOL_ROUNDS = 12;
+
+type EnvLike = Record<string, string | undefined>;
+
+export interface TryProvider {
+  kind: 'chatgpt' | 'ollama';
+  label: string;
+  apiKey: string;
+  baseURL: string;
+  model: string;
+}
+
+export interface TryDemoAgent {
+  systemPromptReady?: Promise<unknown>;
+  processUserMessage(
+    prompt: string,
+    options?: { surface?: string },
+  ): Promise<ChatEntry[]>;
+  dispose?(options?: { skipSessionLearning?: boolean }): void;
+}
+
+export interface TryVerification {
+  success: boolean;
+  output: string;
+}
+
+interface ResolveTryProviderOptions {
+  env?: EnvLike;
+  hasChatGptCredentials?: () => boolean;
+  fetchImpl?: typeof fetch;
+  ollamaProbeTimeoutMs?: number;
+}
+
+export interface RunTryDemoOptions extends ResolveTryProviderOptions {
+  resolveProvider?: () => Promise<TryProvider | null>;
+  createWorkspace?: () => Promise<string>;
+  createAgent?: (provider: TryProvider, workspace: string) => Promise<TryDemoAgent>;
+  verify?: (workspace: string) => Promise<TryVerification>;
+  stdout?: (message: string) => void;
+  stderr?: (message: string) => void;
+}
+
+interface OllamaTagsResponse {
+  models?: Array<{ name?: unknown; model?: unknown }>;
+}
+
+export const TRY_DEMO_PROMPT = `Tu pilotes une démo courte d'agent de code dans un dossier temporaire vide.
+
+Objectif exact :
+1. Crée fizzbuzz.js en CommonJS. Exporte une fonction fizzBuzz(value) qui renvoie le nombre sous forme de chaîne, "Fizz" pour les multiples de 3, "Buzz" pour ceux de 5 et "FizzBuzz" pour ceux de 15.
+2. Crée fizzbuzz.test.js avec node:test et node:assert/strict. Teste au minimum 1, 3, 5 et 15.
+3. Exécute exactement : node --test fizzbuzz.test.js
+4. Si un test échoue, corrige le code et relance-le.
+5. Termine par un bilan très court indiquant les deux fichiers créés et le résultat des tests.
+
+Utilise directement les outils de fichier et de terminal. Ne demande aucune confirmation, n'installe aucune dépendance et ne modifie rien hors du dossier de travail.`;
+
+export const NO_TRY_PROVIDER_MESSAGE = [
+  'Aucun provider gratuit prêt pour la démo.',
+  '',
+  '1. Recommandé — connecte ton compte ChatGPT (OAuth, sans clé API, coût marginal $0 avec ton plan) :',
+  '   buddy login',
+  '',
+  '2. Ou utilise Ollama en local :',
+  '   ollama pull qwen2.5-coder:7b',
+  '   buddy try',
+].join('\n');
+
+/** Pick a coding-oriented local model without assuming one exact Ollama tag. */
+export function chooseOllamaModel(models: readonly string[], requested?: string): string | null {
+  const usable = models.map((model) => model.trim()).filter(Boolean);
+  const requestedModel = requested?.trim();
+  if (requestedModel) {
+    const exact = usable.find((model) => model.toLowerCase() === requestedModel.toLowerCase());
+    if (exact) return exact;
+  }
+
+  for (const pattern of [/qwen.*coder/i, /devstral/i, /codestral/i, /coder/i, /code/i]) {
+    const match = usable.find((model) => pattern.test(model));
+    if (match) return match;
+  }
+  return usable[0] ?? null;
+}
+
+function normalizeTryOllamaHost(rawHost?: string): string {
+  let host = normalizeOllamaBaseUrl(rawHost);
+  if (!/^https?:\/\//i.test(host)) host = `http://${host}`;
+  return host;
+}
+
+function parseOllamaModels(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  const models = (value as OllamaTagsResponse).models;
+  if (!Array.isArray(models)) return [];
+  return models
+    .map((entry) => {
+      const candidate = entry.name ?? entry.model;
+      return typeof candidate === 'string' ? candidate : null;
+    })
+    .filter((model): model is string => Boolean(model));
+}
+
+/** Resolve only the free demo routes: ChatGPT OAuth first, local Ollama second. */
+export async function resolveTryProvider(
+  options: ResolveTryProviderOptions = {},
+): Promise<TryProvider | null> {
+  const env = options.env ?? process.env;
+  const hasChatGpt = (options.hasChatGptCredentials ?? hasCodexCredentials)();
+  if (hasChatGpt) {
+    const provider = resolveProviderFromCatalog({
+      env,
+      providerOverride: 'chatgpt',
+      hasChatGptOAuth: true,
+    });
+    if (provider) {
+      return {
+        kind: 'chatgpt',
+        label: 'ChatGPT OAuth',
+        apiKey: provider.apiKey,
+        baseURL: provider.baseURL,
+        model: provider.defaultModel,
+      };
+    }
+  }
+
+  const host = normalizeTryOllamaHost(env.OLLAMA_HOST);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  try {
+    const response = await fetchImpl(`${host}/api/tags`, {
+      signal: AbortSignal.timeout(options.ollamaProbeTimeoutMs ?? OLLAMA_PROBE_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const models = parseOllamaModels(await response.json());
+    const model = chooseOllamaModel(models, env.OLLAMA_MODEL);
+    if (!model) return null;
+    return {
+      kind: 'ollama',
+      label: `Ollama local (${model})`,
+      apiKey: 'ollama',
+      baseURL: `${host}/v1`,
+      model,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function createDefaultAgent(
+  provider: TryProvider,
+  workspace: string,
+): Promise<TryDemoAgent> {
+  const [{ CodeBuddyAgent }, { ConfirmationService }, { getPermissionModeManager }] =
+    await Promise.all([
+      import('../agent/codebuddy-agent.js'),
+      import('../utils/confirmation-service.js'),
+      import('../security/permission-modes.js'),
+    ]);
+  const confirmation = ConfirmationService.getInstance();
+  const previousFlags = confirmation.getSessionFlags();
+  confirmation.setSessionFlag('allOperations', true);
+  // Le permission mode est vérifié AVANT les session flags : en mode `default` et sans TTY,
+  // create_file est refusé (« User cancelled »). La démo tourne dans un bac à sable temporaire
+  // isolé (workspace), donc on auto-approuve tout le temps de la démo puis on restaure le mode.
+  const permMgr = getPermissionModeManager();
+  const previousMode = permMgr.getMode();
+  permMgr.setMode('bypassPermissions');
+  try {
+    const agent = new CodeBuddyAgent(
+      provider.apiKey,
+      provider.baseURL,
+      provider.model,
+      DEMO_MAX_TOOL_ROUNDS,
+      true,
+      undefined,
+      workspace,
+    );
+    return {
+      systemPromptReady: agent.systemPromptReady,
+      processUserMessage: (prompt, options) => agent.processUserMessage(prompt, options),
+      dispose: (options) => {
+        try {
+          agent.dispose(options);
+        } finally {
+          confirmation.setSessionFlag('fileOperations', previousFlags.fileOperations);
+          confirmation.setSessionFlag('bashCommands', previousFlags.bashCommands);
+          confirmation.setSessionFlag('allOperations', previousFlags.allOperations);
+          permMgr.setMode(previousMode);
+        }
+      },
+    };
+  } catch (error) {
+    confirmation.setSessionFlag('fileOperations', previousFlags.fileOperations);
+    confirmation.setSessionFlag('bashCommands', previousFlags.bashCommands);
+    confirmation.setSessionFlag('allOperations', previousFlags.allOperations);
+    permMgr.setMode(previousMode);
+    throw error;
+  }
+}
+
+async function verifyDefaultDemo(workspace: string): Promise<TryVerification> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ['--test', 'fizzbuzz.test.js'],
+      { cwd: workspace, timeout: 30_000, maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const output = `${stdout}${stderr}`.trim();
+        resolve({ success: error === null, output });
+      },
+    );
+  });
+}
+
+function latestAssistantMessage(entries: readonly ChatEntry[]): string | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.type === 'assistant' && entry.content.trim()) return entry.content.trim();
+  }
+  return null;
+}
+
+function invokedToolNames(entries: readonly ChatEntry[]): string[] {
+  const names = new Set<string>();
+  for (const entry of entries) {
+    if (entry.toolCall?.function.name) names.add(entry.toolCall.function.name);
+    for (const toolCall of entry.toolCalls ?? []) names.add(toolCall.function.name);
+  }
+  return [...names];
+}
+
+function setTemporaryEnv(key: string, value: string): () => void {
+  const previous = process.env[key];
+  process.env[key] = value;
+  return () => {
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  };
+}
+
+/** Execute the scripted demo. Returns a process-style exit code. */
+export async function runTryDemo(options: RunTryDemoOptions = {}): Promise<number> {
+  const write = options.stdout ?? ((message: string) => process.stdout.write(`${message}\n`));
+  const writeError = options.stderr ?? ((message: string) => process.stderr.write(`${message}\n`));
+  const resolveProvider = options.resolveProvider ?? (() => resolveTryProvider(options));
+  const provider = await resolveProvider();
+  if (!provider) {
+    writeError(NO_TRY_PROVIDER_MESSAGE);
+    return 2;
+  }
+
+  const createWorkspace = options.createWorkspace
+    ?? (() => mkdtemp(join(tmpdir(), 'code-buddy-try-')));
+  const workspace = await createWorkspace();
+  const createAgent = options.createAgent ?? createDefaultAgent;
+  const verify = options.verify ?? verifyDefaultDemo;
+  const restoreEnv = [
+    setTemporaryEnv('CODEBUDDY_HEADLESS', 'true'),
+    setTemporaryEnv('CODEBUDDY_DISABLE_MCP', 'true'),
+  ];
+  let agent: TryDemoAgent | undefined;
+
+  write('Code Buddy — démo agent de code (~60 secondes)');
+  write(`[1/3] Provider : ${provider.label}`);
+  write(`[2/3] Bac à sable : ${workspace}`);
+  write('      L’agent crée FizzBuzz, écrit ses tests et les exécute…');
+
+  try {
+    agent = await createAgent(provider, workspace);
+    await agent.systemPromptReady;
+    const entries = await agent.processUserMessage(TRY_DEMO_PROMPT, { surface: 'cli' });
+    const toolNames = invokedToolNames(entries);
+    if (toolNames.length > 0) write(`      Outils utilisés : ${toolNames.join(', ')}`);
+    const assistantMessage = latestAssistantMessage(entries);
+    if (assistantMessage) write(`      Agent : ${assistantMessage}`);
+
+    write('[3/3] Vérification indépendante : node --test fizzbuzz.test.js');
+    const verification = await verify(workspace);
+    if (!verification.success) {
+      writeError('❌ La démo n’a pas produit un test vert. Le bac à sable est conservé pour inspection.');
+      if (verification.output) writeError(verification.output);
+      writeError(`   ${workspace}`);
+      return 1;
+    }
+
+    write('✅ Démo réussie : le code a été écrit et ses tests passent.');
+    if (verification.output) {
+      const passLine = verification.output.split('\n').find((line) => /pass/i.test(line));
+      if (passLine) write(`   ${passLine.trim()}`);
+    }
+    write(`   Fichiers à inspecter : ${workspace}`);
+    return 0;
+  } catch (error) {
+    writeError(`❌ Démo interrompue : ${error instanceof Error ? error.message : String(error)}`);
+    writeError(`   Le bac à sable est conservé : ${workspace}`);
+    return 1;
+  } finally {
+    agent?.dispose?.({ skipSessionLearning: true });
+    for (const restore of restoreEnv.reverse()) restore();
+  }
+}
+
+export function createTryCommand(): Command {
+  return new Command('try')
+    .description('Run an isolated 60-second coding-agent demo (ChatGPT OAuth or local Ollama)')
+    .action(async () => {
+      process.exitCode = await runTryDemo();
+    });
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -476,6 +476,111 @@ async function fixStaleLockFiles(lockFiles: string[]): Promise<FixResult> {
 }
 
 // ============================================================================
+// Provider readiness — the ONE thing a newcomer needs answered
+// ============================================================================
+
+/**
+ * Answer "can `buddy` actually talk to a model on the next run?" — the single
+ * most important diagnostic for someone who just installed. It distinguishes
+ * "a brain is reachable" (a live Ollama on localhost) from "buddy is pointed at
+ * it" (env var / onboarded settings / OAuth / API key), because a running
+ * Ollama that was never selected still dead-ends the first chat.
+ */
+async function checkProviderReadiness(): Promise<DoctorCheck> {
+  const { detectEnvironment } = await import('../wizard/environment-detection.js');
+  const snap = await detectEnvironment();
+
+  const oauthOrKey = snap.capabilities.some(
+    (c) => c.available && (c.kind === 'oauth' || c.kind === 'api-key'),
+  );
+  const ollama = snap.capabilities.find((c) => c.id === 'ollama');
+  const ollamaModels = ollama?.models?.length ?? 0;
+
+  let onboardedLocal = false;
+  try {
+    const { getSettingsManager } = await import('../utils/settings-manager.js');
+    const p = (getSettingsManager().loadUserSettings().provider || '').toLowerCase();
+    onboardedLocal = p === 'ollama' || p === 'lmstudio';
+  } catch {
+    /* settings unreadable — treat as not onboarded */
+  }
+  const envLocal = Boolean(process.env.OLLAMA_HOST || process.env.LMSTUDIO_HOST);
+  const configured = oauthOrKey || ((envLocal || onboardedLocal) && ollamaModels > 0);
+
+  if (configured) {
+    const rec = snap.recommended;
+    return {
+      name: 'AI provider ready',
+      status: 'ok',
+      message: rec ? `${rec.label} — ${rec.detail}` : 'a provider is configured',
+    };
+  }
+
+  if (ollama?.available && ollamaModels > 0 && ollama.baseURL) {
+    const model = ollama.models![0]!;
+    const baseURL = ollama.baseURL;
+    return {
+      name: 'AI provider ready',
+      status: 'warn',
+      message: `Ollama is running (${ollamaModels} model${ollamaModels === 1 ? '' : 's'}) but not selected — run \`buddy onboard\`, or --fix to select ${model} ($0)`,
+      fixable: true,
+      fix: async () => fixSelectRunningOllama(baseURL, model),
+    };
+  }
+
+  if (ollama?.available && ollama.baseURL) {
+    const baseURL = ollama.baseURL;
+    return {
+      name: 'AI provider ready',
+      status: 'warn',
+      message: 'Ollama is running but has no model — run `buddy onboard`, or --fix to pull qwen2.5-coder:7b ($0)',
+      fixable: true,
+      fix: async () => fixPullAndSelectOllama(baseURL),
+    };
+  }
+
+  return {
+    name: 'AI provider ready',
+    status: 'warn',
+    message: 'no provider configured — run `buddy onboard` (guided) or `buddy login` (ChatGPT subscription, $0)',
+  };
+}
+
+/** Point buddy at an already-running Ollama by writing user-settings (no download). */
+async function fixSelectRunningOllama(baseURL: string, model: string): Promise<FixResult> {
+  try {
+    const { getSettingsManager } = await import('../utils/settings-manager.js');
+    getSettingsManager().saveUserSettings({ provider: 'ollama', baseURL, model, defaultModel: model });
+    return {
+      success: true,
+      message: `Selected local Ollama model ${model} (written to user-settings.json) — try: buddy try`,
+      action: 'select-running-ollama',
+    };
+  } catch (err) {
+    return {
+      success: false,
+      message: `Failed to write provider selection: ${err instanceof Error ? err.message : String(err)}`,
+      action: 'select-running-ollama',
+    };
+  }
+}
+
+/** Pull a small coding model with Ollama, then select it. */
+async function fixPullAndSelectOllama(baseURL: string): Promise<FixResult> {
+  const model = 'qwen2.5-coder:7b';
+  try {
+    execSync(`ollama pull ${model}`, { stdio: 'inherit' });
+  } catch (err) {
+    return {
+      success: false,
+      message: `Failed to pull ${model}: ${err instanceof Error ? err.message : String(err)}. Install Ollama from https://ollama.ai`,
+      action: 'pull-ollama-model',
+    };
+  }
+  return fixSelectRunningOllama(baseURL, model);
+}
+
+// ============================================================================
 // Public API
 // ============================================================================
 
@@ -483,6 +588,7 @@ export async function runDoctorChecks(cwd?: string): Promise<DoctorCheck[]> {
   const dir = cwd ?? process.cwd();
   const { checkLlmKeysLive } = await import('./llm-key-check.js');
   return [
+    await checkProviderReadiness(),
     checkNodeVersion(),
     await checkNativeSqlite(),
     ...checkDependencies(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1731,12 +1731,13 @@ program
         if (!recovered) {
           logger.error(
             [
-              "❌ No AI provider configured. Pick one to get started:",
-              "   • Guided setup (recommended) — interactive wizard:     buddy onboard",
+              "❌ No AI provider configured yet. Fastest ways to start — no env var to edit:",
+              "   • 60-second demo, zero config — just run:               buddy try",
+              "   • Guided setup (recommended) — interactive wizard:      buddy onboard",
               "   • Free, no API key — sign in with your ChatGPT plan:    buddy login",
-              "   • Local & free — run a model with Ollama, then:         export OLLAMA_HOST=http://localhost:11434",
+              "   • Local & free — install Ollama, then let onboard use it: buddy onboard",
               "   • API key — set GROK_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY (or pass --api-key)",
-              "   Run  buddy doctor  to check your setup.",
+              "   Check anytime:  buddy doctor   (add --fix to auto-configure a running Ollama).",
             ].join("\n")
           );
           process.exit(1);
@@ -2312,12 +2313,13 @@ gitCommand
       if (!apiKey) {
         logger.error(
           [
-            "❌ No AI provider configured. Pick one to get started:",
-            "   • Guided setup (recommended) — interactive wizard:     buddy onboard",
+            "❌ No AI provider configured yet. Fastest ways to start — no env var to edit:",
+            "   • 60-second demo, zero config — just run:               buddy try",
+            "   • Guided setup (recommended) — interactive wizard:      buddy onboard",
             "   • Free, no API key — sign in with your ChatGPT plan:    buddy login",
-            "   • Local & free — run a model with Ollama, then:         export OLLAMA_HOST=http://localhost:11434",
+            "   • Local & free — install Ollama, then let onboard use it: buddy onboard",
             "   • API key — set GROK_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY (or pass --api-key)",
-            "   Run  buddy doctor  to check your setup.",
+            "   Check anytime:  buddy doctor   (add --fix to auto-configure a running Ollama).",
           ].join("\n")
         );
         process.exit(1);
@@ -3158,6 +3160,19 @@ addLazyCommandGroup(program, 'widgets', 'Inline conversation widgets: list, prev
   const { registerWidgetsCommand } = await import('./commands/widgets.js');
   registerWidgetsCommand(program);
 });
+
+// `buddy try` — an isolated 60-second coding-agent demo on a free path
+// (ChatGPT OAuth or a local Ollama). The fastest "does it work?" for a
+// newcomer; the onboarding wizard chains to it.
+addLazyCommand(
+  program,
+  'try',
+  'Run an isolated 60-second coding-agent demo (ChatGPT OAuth or local Ollama)',
+  async () => {
+    const { createTryCommand } = await import('./commands/try.js');
+    return createTryCommand();
+  },
+);
 
 // Utility commands (doctor, security-audit, onboard, webhook) are all registered
 // by a single registerUtilityCommands() call, so we must remove all stubs before

--- a/src/wizard/environment-detection.ts
+++ b/src/wizard/environment-detection.ts
@@ -1,0 +1,233 @@
+/**
+ * Environment capability detection for onboarding / `buddy try` / `buddy doctor`.
+ *
+ * The single job of this module: answer "what can this machine talk to RIGHT
+ * NOW, and which of those costs $0?" — so the setup surfaces can default to the
+ * free path (Ollama local, or a signed-in ChatGPT subscription) instead of
+ * asking a newcomer to understand 8 providers and 120 env vars.
+ *
+ * Every probe is best-effort, short-timeout, and never throws — a detection
+ * failure just means "not available", never a crash.
+ */
+
+export type CapabilityKind = 'local' | 'oauth' | 'api-key';
+
+export interface DetectedCapability {
+  /** Stable id used by the wizard / try command. */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  kind: CapabilityKind;
+  /** True when using it has $0 marginal cost (local runtime or a subscription). */
+  free: boolean;
+  /** Whether it is reachable / configured right now. */
+  available: boolean;
+  /** One-line human detail, e.g. "running · 2 models" or "signed in as x@y". */
+  detail: string;
+  /** Installed/served models, when the probe returned them. */
+  models?: string[];
+  /** OpenAI-compatible base URL, for local runtimes. */
+  baseURL?: string;
+  /** Command that finishes setup for this capability (login / pull / etc.). */
+  setupCommand?: string;
+}
+
+export interface EnvironmentSnapshot {
+  capabilities: DetectedCapability[];
+  /** The best AVAILABLE free path, if any (Ollama-with-model → ChatGPT → xAI). */
+  recommendedFree?: DetectedCapability;
+  /** The best available path of any kind (free preferred, else an API key). */
+  recommended?: DetectedCapability;
+  /** True when at least one capability is usable right now. */
+  ready: boolean;
+}
+
+const OLLAMA_DEFAULT_HOST = 'http://localhost:11434';
+const LMSTUDIO_DEFAULT_HOST = 'http://localhost:1234';
+
+async function fetchJson(url: string, timeoutMs = 1500): Promise<unknown | null> {
+  try {
+    const res = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHost(raw: string): string {
+  let host = raw.trim();
+  if (!/^https?:\/\//i.test(host)) host = `http://${host}`;
+  return host.replace(/\/+$/, '');
+}
+
+/** Probe a local Ollama runtime (respects OLLAMA_HOST when set). */
+export async function detectOllama(): Promise<DetectedCapability> {
+  const host = normalizeHost(process.env.OLLAMA_HOST || OLLAMA_DEFAULT_HOST);
+  const body = (await fetchJson(`${host}/api/tags`)) as { models?: { name: string }[] } | null;
+  const base: DetectedCapability = {
+    id: 'ollama',
+    label: 'Ollama (local, $0)',
+    kind: 'local',
+    free: true,
+    available: false,
+    detail: 'not running',
+    baseURL: `${host}/v1`,
+    setupCommand: 'ollama serve',
+  };
+  if (!body) return base;
+  const models = (body.models ?? []).map((m) => m.name).filter(Boolean);
+  return {
+    ...base,
+    available: true,
+    models,
+    detail: models.length
+      ? `running · ${models.length} model${models.length === 1 ? '' : 's'}`
+      : 'running · no model pulled yet (run: ollama pull qwen2.5-coder:7b)',
+    setupCommand: models.length ? undefined : 'ollama pull qwen2.5-coder:7b',
+  };
+}
+
+/** Probe a local LM Studio server. */
+export async function detectLmStudio(): Promise<DetectedCapability> {
+  const host = normalizeHost(process.env.LMSTUDIO_HOST || LMSTUDIO_DEFAULT_HOST);
+  const body = (await fetchJson(`${host}/v1/models`)) as { data?: { id: string }[] } | null;
+  const base: DetectedCapability = {
+    id: 'lmstudio',
+    label: 'LM Studio (local, $0)',
+    kind: 'local',
+    free: true,
+    available: false,
+    detail: 'not running',
+    baseURL: `${host}/v1`,
+    setupCommand: 'Start the LM Studio local server',
+  };
+  if (!body) return base;
+  const models = (body.data ?? []).map((m) => m.id).filter(Boolean);
+  return {
+    ...base,
+    available: models.length > 0,
+    models,
+    detail: models.length ? `running · ${models.length} model${models.length === 1 ? '' : 's'}` : 'running · no model loaded',
+  };
+}
+
+/** Check the ChatGPT (Codex) OAuth credential file. */
+export async function detectChatGptOAuth(): Promise<DetectedCapability> {
+  const base: DetectedCapability = {
+    id: 'chatgpt',
+    label: 'ChatGPT subscription (OAuth, $0)',
+    kind: 'oauth',
+    free: true,
+    available: false,
+    detail: 'not signed in',
+    setupCommand: 'buddy login',
+  };
+  try {
+    const { hasCodexCredentials, getChatGptAuth } = await import('../providers/codex-oauth.js');
+    if (!hasCodexCredentials()) return base;
+    const auth = await getChatGptAuth().catch(() => null);
+    const who = auth?.email ? `signed in as ${auth.email}` : 'signed in';
+    return { ...base, available: true, detail: who, setupCommand: undefined };
+  } catch {
+    return base;
+  }
+}
+
+/** Check the xAI (Grok) OAuth credential file. */
+export async function detectXaiOAuth(): Promise<DetectedCapability> {
+  const base: DetectedCapability = {
+    id: 'xai',
+    label: 'Grok / xAI subscription (OAuth, $0)',
+    kind: 'oauth',
+    free: true,
+    available: false,
+    detail: 'not signed in',
+    setupCommand: 'buddy login xai',
+  };
+  try {
+    const { hasXaiCredentials } = await import('../providers/xai-oauth.js');
+    if (!hasXaiCredentials()) return base;
+    return { ...base, available: true, detail: 'signed in', setupCommand: undefined };
+  } catch {
+    return base;
+  }
+}
+
+interface ApiKeySpec {
+  id: string;
+  label: string;
+  envVars: string[];
+}
+
+const API_KEY_PROVIDERS: ApiKeySpec[] = [
+  { id: 'grok', label: 'Grok / xAI API key', envVars: ['GROK_API_KEY', 'XAI_API_KEY'] },
+  { id: 'openai', label: 'OpenAI API key', envVars: ['OPENAI_API_KEY'] },
+  { id: 'anthropic', label: 'Anthropic Claude API key', envVars: ['ANTHROPIC_API_KEY'] },
+  { id: 'gemini', label: 'Google Gemini API key', envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'] },
+  { id: 'openrouter', label: 'OpenRouter API key', envVars: ['OPENROUTER_API_KEY'] },
+];
+
+/** Report API keys present in the environment (not billed to us, so free:false). */
+export function detectApiKeys(): DetectedCapability[] {
+  return API_KEY_PROVIDERS.map((spec) => {
+    const hit = spec.envVars.find((v) => Boolean(process.env[v]));
+    return {
+      id: spec.id,
+      label: spec.label,
+      kind: 'api-key' as const,
+      free: false,
+      available: Boolean(hit),
+      detail: hit ? `${hit} set` : 'not set',
+    };
+  });
+}
+
+/**
+ * One call to learn everything the setup surfaces need. Free local/OAuth probes
+ * run in parallel; the API-key scan is synchronous.
+ */
+export async function detectEnvironment(): Promise<EnvironmentSnapshot> {
+  const [ollama, lmstudio, chatgpt, xai] = await Promise.all([
+    detectOllama(),
+    detectLmStudio(),
+    detectChatGptOAuth(),
+    detectXaiOAuth(),
+  ]);
+  const apiKeys = detectApiKeys();
+  const capabilities = [ollama, lmstudio, chatgpt, xai, ...apiKeys];
+
+  // Free path priority: a local Ollama that actually has a model → ChatGPT
+  // subscription → xAI subscription → LM Studio with a model. A running Ollama
+  // with zero models is NOT recommendable (nothing to chat with yet).
+  const ollamaReady = ollama.available && (ollama.models?.length ?? 0) > 0;
+  const lmReady = lmstudio.available && (lmstudio.models?.length ?? 0) > 0;
+  const freeOrder: Array<DetectedCapability | undefined> = [
+    ollamaReady ? ollama : undefined,
+    chatgpt.available ? chatgpt : undefined,
+    xai.available ? xai : undefined,
+    lmReady ? lmstudio : undefined,
+  ];
+  const recommendedFree = freeOrder.find(Boolean) ?? undefined;
+
+  const anyApiKey = apiKeys.find((k) => k.available);
+  const recommended = recommendedFree ?? anyApiKey ?? undefined;
+
+  return {
+    capabilities,
+    ...(recommendedFree ? { recommendedFree } : {}),
+    ...(recommended ? { recommended } : {}),
+    ready: Boolean(recommended),
+  };
+}
+
+/** Compact human summary of what was detected — used by wizard + doctor. */
+export function renderDetectionSummary(snapshot: EnvironmentSnapshot): string {
+  const lines: string[] = ['  Detected on this machine:'];
+  for (const cap of snapshot.capabilities) {
+    const mark = cap.available ? '✓' : '○';
+    const cost = cap.available && cap.free ? '  ($0)' : '';
+    lines.push(`    ${mark} ${cap.label} — ${cap.detail}${cost}`);
+  }
+  return lines.join('\n');
+}

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -1,4 +1,5 @@
 import * as readline from 'readline';
+import { spawn } from 'child_process';
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import {
@@ -6,6 +7,11 @@ import {
   validateProviderKey,
   type ProviderOnboardingConfig,
 } from './provider-onboarding.js';
+import {
+  detectEnvironment,
+  renderDetectionSummary,
+  type EnvironmentSnapshot,
+} from './environment-detection.js';
 
 export interface OnboardingResult {
   provider: string;
@@ -451,7 +457,147 @@ function renderCapabilitiesFooter(): string {
   ].join('\n');
 }
 
+/** Reorder the provider menu so detected/available options come first, with the
+ *  recommended free path at index 0. Availability annotations are appended to
+ *  the label so the newcomer sees "(detected)" without extra prose. */
+export function orderGuidesByDetection(snapshot: EnvironmentSnapshot): OnboardingProviderGuide[] {
+  const availableIds = new Set(snapshot.capabilities.filter((c) => c.available).map((c) => c.id));
+  const recommendedId = snapshot.recommended?.id;
+  const annotate = (g: OnboardingProviderGuide): OnboardingProviderGuide =>
+    availableIds.has(g.id) ? { ...g, label: `${g.label} — detected ✓` } : g;
+  const scored = PROVIDER_GUIDES.map(annotate);
+  return scored.sort((a, b) => {
+    const rank = (g: OnboardingProviderGuide): number => {
+      if (g.id === recommendedId) return 0;
+      if (availableIds.has(g.id)) return 1;
+      return 2;
+    };
+    return rank(a) - rank(b);
+  });
+}
+
+/** Pull an Ollama model, streaming progress to the console. Resolves to the
+ *  model name on success, or null on failure (never throws). */
+async function pullOllamaModel(model: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    try {
+      console.log(`\n  Pulling ${model} with Ollama (this can take a few minutes)…\n`);
+      const child = spawn('ollama', ['pull', model], { stdio: 'inherit' });
+      child.on('error', () => resolve(null));
+      child.on('close', (code) => resolve(code === 0 ? model : null));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Offer to start the newcomer on the best detected $0 path with a single "yes"
+ * — no provider menu, no key to paste. Returns a completed OnboardingResult when
+ * the fast path was taken, or null to fall through to the full manual wizard.
+ *
+ * Priority (mirrors detectEnvironment): a live local Ollama/LM Studio with a
+ * model → a signed-in ChatGPT/xAI subscription. When Ollama is running but has
+ * no model, we offer to pull a small coding model so the free path still works.
+ */
+async function runQuickStart(
+  rl: readline.Interface,
+  snapshot: EnvironmentSnapshot
+): Promise<OnboardingResult | null> {
+  const free = snapshot.recommendedFree;
+  const ollama = snapshot.capabilities.find((c) => c.id === 'ollama');
+
+  // Case A: a ready free path exists — offer it directly.
+  if (free) {
+    const answer = (
+      await ask(rl, `Start now on ${free.label} — free, no API key needed? (Y/n)`, 'y')
+    ).toLowerCase();
+    if (answer === 'y' || answer === 'yes' || answer === '') {
+      const guide = getProviderGuide(free.id);
+
+      if (free.id === 'ollama' || free.id === 'lmstudio') {
+        const model = await selectModel(rl, guide, free.models);
+        await persistProviderSelection({ ...guide, baseURL: free.baseURL ?? guide.baseURL }, model, '');
+        return finishQuickStart(free.id, model, free.baseURL);
+      }
+
+      // OAuth path (chatgpt / xai) — already signed in, just persist the choice.
+      const model = guide.defaultModel;
+      await persistProviderSelection(guide, model, '');
+      return finishQuickStart(free.id, model, guide.baseURL);
+    }
+    return null; // user declined the fast path → full menu
+  }
+
+  // Case B: Ollama is running but empty — offer to pull a model, then use it.
+  if (ollama?.available && !(ollama.models?.length)) {
+    const DEFAULT_PULL = 'qwen2.5-coder:7b';
+    const answer = (
+      await ask(
+        rl,
+        `Ollama is running but has no model. Pull ${DEFAULT_PULL} now (free, ~4.5 GB)? (Y/n)`,
+        'y'
+      )
+    ).toLowerCase();
+    if (answer === 'y' || answer === 'yes' || answer === '') {
+      const pulled = await pullOllamaModel(DEFAULT_PULL);
+      if (pulled) {
+        const guide = getProviderGuide('ollama');
+        await persistProviderSelection({ ...guide, baseURL: ollama.baseURL ?? guide.baseURL }, pulled, '');
+        return finishQuickStart('ollama', pulled, ollama.baseURL);
+      }
+      console.log('  ⚠️ Pull did not complete — falling back to the full setup menu.');
+    }
+  }
+
+  return null;
+}
+
+/** Persist config.json + build the OnboardingResult for a fast-path selection. */
+function finishQuickStart(provider: string, model: string, baseURL?: string): OnboardingResult {
+  const guide = getProviderGuide(provider);
+  const result: OnboardingResult = {
+    provider,
+    apiKey: '',
+    model,
+    ttsEnabled: false,
+    authMode: guide.authMode,
+    recommendedNextCommands: buildRecommendedNextCommands({ provider, apiKey: '', model }),
+  };
+  writeConfig(join(process.cwd(), '.codebuddy'), result);
+  console.log('');
+  console.log('  ✅ You\'re set — no environment variable needed.');
+  console.log('');
+  console.log(`  Provider:  ${provider}${baseURL ? ` (${baseURL})` : ''}`);
+  console.log(`  Model:     ${model}`);
+  console.log('');
+  return result;
+}
+
+/** Offer to run the isolated 60-second demo right after setup — ending the
+ *  wizard on proof (a green test), not prose. */
+async function offerTry(rl: readline.Interface): Promise<void> {
+  const answer = (await ask(rl, 'Run the 60-second demo now to confirm it works? (Y/n)', 'y')).toLowerCase();
+  if (answer === 'y' || answer === 'yes' || answer === '') {
+    try {
+      const { runTryDemo } = await import('../commands/try.js');
+      rl.pause();
+      await runTryDemo();
+      rl.resume();
+    } catch {
+      console.log('\n  Run it yourself anytime with:  buddy try\n');
+    }
+  } else {
+    console.log('\n  When you\'re ready:  buddy try\n');
+  }
+}
+
 export async function runOnboarding(): Promise<OnboardingResult> {
+  // 0. Detect what's already usable BEFORE opening readline — the probes are
+  //    async (~1.5s), and holding an open readline across them can race a
+  //    piped/non-interactive stdin to EOF. Detection needs no input anyway.
+  const snapshot = await detectEnvironment();
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -465,14 +611,27 @@ export async function runOnboarding(): Promise<OnboardingResult> {
     console.log('');
     console.log('  This wizard will help you configure Code Buddy.');
     console.log('');
+    console.log(renderDetectionSummary(snapshot));
+    console.log('');
+
+    const quick = await runQuickStart(rl, snapshot);
+    if (quick) {
+      console.log(renderCapabilitiesFooter());
+      console.log('');
+      await offerTry(rl);
+      return quick;
+    }
+
     console.log(renderOnboardingRoadmap());
     console.log('');
 
-    // 1. Provider selection
+    // 1. Provider selection — detected/free options float to the top, and the
+    //    default lands on the recommended free path when there is one.
+    const orderedGuides = orderGuidesByDetection(snapshot);
     const provider = await askChoice(
       rl,
       'Which AI provider do you want to use?',
-      PROVIDER_GUIDES.map((guide) => `${guide.id} — ${guide.label}`),
+      orderedGuides.map((guide) => `${guide.id} — ${guide.label}`),
       0
     ).then((choice) => choice.split(/\s+—\s+/)[0] ?? choice);
     const guide = getProviderGuide(provider);
@@ -586,6 +745,11 @@ export async function runOnboarding(): Promise<OnboardingResult> {
     console.log('');
     console.log(renderOnboardingRoadmap(result));
     console.log('');
+
+    // Close with a real, runnable test so the wizard ends on proof, not prose.
+    if (ready) {
+      await offerTry(rl);
+    }
 
     return result;
   } finally {

--- a/tests/commands/try.test.ts
+++ b/tests/commands/try.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatEntry } from '../../src/agent/types.js';
+import {
+  NO_TRY_PROVIDER_MESSAGE,
+  TRY_DEMO_PROMPT,
+  chooseOllamaModel,
+  resolveTryProvider,
+  runTryDemo,
+  type TryProvider,
+} from '../../src/commands/try.js';
+
+const chatGptProvider: TryProvider = {
+  kind: 'chatgpt',
+  label: 'ChatGPT OAuth',
+  apiKey: 'oauth-chatgpt',
+  baseURL: 'https://chatgpt.com/backend-api/codex',
+  model: 'gpt-5.6-sol',
+};
+
+describe('buddy try', () => {
+  it('prefers a coding-oriented Ollama model while honoring an installed request', () => {
+    const models = ['llama3.2:latest', 'qwen2.5-coder:7b', 'devstral:latest'];
+
+    expect(chooseOllamaModel(models)).toBe('qwen2.5-coder:7b');
+    expect(chooseOllamaModel(models, 'devstral:latest')).toBe('devstral:latest');
+    expect(chooseOllamaModel([])).toBeNull();
+  });
+
+  it('uses ChatGPT OAuth before probing Ollama', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    const provider = await resolveTryProvider({
+      env: {},
+      hasChatGptCredentials: () => true,
+      fetchImpl,
+    });
+
+    expect(provider).toMatchObject(chatGptProvider);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('probes localhost and selects an installed Ollama model as the fallback', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      models: [{ name: 'llama3.2:latest' }, { name: 'qwen3-coder:30b' }],
+    }), { status: 200 }));
+
+    const provider = await resolveTryProvider({
+      env: {},
+      hasChatGptCredentials: () => false,
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:11434/api/tags',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(provider).toMatchObject({
+      kind: 'ollama',
+      apiKey: 'ollama',
+      baseURL: 'http://localhost:11434/v1',
+      model: 'qwen3-coder:30b',
+    });
+  });
+
+  it('explains login first and Ollama second when neither free provider is ready', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const createAgent = vi.fn();
+
+    const exitCode = await runTryDemo({
+      resolveProvider: async () => null,
+      createAgent,
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([NO_TRY_PROVIDER_MESSAGE]);
+    expect(stderr[0]!.indexOf('buddy login')).toBeLessThan(stderr[0]!.indexOf('Ollama'));
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it('runs the scripted agent in an isolated workspace and verifies its test', async () => {
+    const stdout: string[] = [];
+    const dispose = vi.fn();
+    const entries: ChatEntry[] = [
+      {
+        type: 'tool_call',
+        content: 'write',
+        timestamp: new Date(),
+        toolCall: {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'write_file', arguments: '{}' },
+        },
+      },
+      {
+        type: 'assistant',
+        content: 'Deux fichiers créés, tests verts.',
+        timestamp: new Date(),
+      },
+    ];
+    const processUserMessage = vi.fn(async () => entries);
+    const createAgent = vi.fn(async () => ({
+      systemPromptReady: Promise.resolve(),
+      processUserMessage,
+      dispose,
+    }));
+    const verify = vi.fn(async () => ({ success: true, output: '# pass 4\n# fail 0' }));
+
+    const exitCode = await runTryDemo({
+      resolveProvider: async () => chatGptProvider,
+      createWorkspace: async () => '/tmp/code-buddy-try-test',
+      createAgent,
+      verify,
+      stdout: (message) => stdout.push(message),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(createAgent).toHaveBeenCalledWith(chatGptProvider, '/tmp/code-buddy-try-test');
+    expect(processUserMessage).toHaveBeenCalledWith(TRY_DEMO_PROMPT, { surface: 'cli' });
+    expect(verify).toHaveBeenCalledWith('/tmp/code-buddy-try-test');
+    expect(stdout.join('\n')).toContain('Outils utilisés : write_file');
+    expect(stdout.join('\n')).toContain('✅ Démo réussie');
+    expect(dispose).toHaveBeenCalledWith({ skipSessionLearning: true });
+  });
+});

--- a/tests/commands/try.test.ts
+++ b/tests/commands/try.test.ts
@@ -97,7 +97,7 @@ describe('buddy try', () => {
       },
       {
         type: 'assistant',
-        content: 'Deux fichiers créés, tests verts.',
+        content: 'Two files created, tests green.',
         timestamp: new Date(),
       },
     ];
@@ -121,8 +121,8 @@ describe('buddy try', () => {
     expect(createAgent).toHaveBeenCalledWith(chatGptProvider, '/tmp/code-buddy-try-test');
     expect(processUserMessage).toHaveBeenCalledWith(TRY_DEMO_PROMPT, { surface: 'cli' });
     expect(verify).toHaveBeenCalledWith('/tmp/code-buddy-try-test');
-    expect(stdout.join('\n')).toContain('Outils utilisés : write_file');
-    expect(stdout.join('\n')).toContain('✅ Démo réussie');
+    expect(stdout.join('\n')).toContain('Tools used: write_file');
+    expect(stdout.join('\n')).toContain('✅ Demo succeeded');
     expect(dispose).toHaveBeenCalledWith({ skipSessionLearning: true });
   });
 });

--- a/tests/wizard/environment-detection.test.ts
+++ b/tests/wizard/environment-detection.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Neutralise any real ChatGPT/xAI OAuth credentials on the test machine so the
+// recommendation logic is driven only by the env/local state each test sets up.
+vi.mock('../../src/providers/codex-oauth.js', () => ({
+  hasCodexCredentials: () => false,
+  getChatGptAuth: async () => null,
+}));
+vi.mock('../../src/providers/xai-oauth.js', () => ({
+  hasXaiCredentials: () => false,
+}));
+
+import {
+  detectApiKeys,
+  detectEnvironment,
+  renderDetectionSummary,
+  type EnvironmentSnapshot,
+} from '../../src/wizard/environment-detection.js';
+import { orderGuidesByDetection } from '../../src/wizard/onboarding.js';
+
+describe('environment-detection', () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear every provider key so detection starts from a known-empty baseline.
+    for (const k of [
+      'GROK_API_KEY',
+      'XAI_API_KEY',
+      'OPENAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'GEMINI_API_KEY',
+      'GOOGLE_API_KEY',
+      'OPENROUTER_API_KEY',
+      'OLLAMA_HOST',
+      'LMSTUDIO_HOST',
+    ]) {
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.restoreAllMocks();
+  });
+
+  describe('detectApiKeys', () => {
+    it('reports a key as available when its env var is set, and marks it not-free', () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const caps = detectApiKeys();
+      const openai = caps.find((c) => c.id === 'openai');
+      expect(openai?.available).toBe(true);
+      expect(openai?.free).toBe(false);
+      expect(openai?.detail).toContain('OPENAI_API_KEY');
+    });
+
+    it('reports not-set keys as unavailable', () => {
+      const caps = detectApiKeys();
+      expect(caps.every((c) => c.available === false)).toBe(true);
+    });
+
+    it('accepts either alias for a provider (GOOGLE_API_KEY for gemini)', () => {
+      process.env.GOOGLE_API_KEY = 'g-test';
+      const gemini = detectApiKeys().find((c) => c.id === 'gemini');
+      expect(gemini?.available).toBe(true);
+    });
+  });
+
+  describe('detectEnvironment recommendation', () => {
+    // Force both local probes to fail so only the injected key drives the result.
+    function stubNoLocal(): void {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no server')));
+    }
+
+    it('recommends nothing free when only a paid API key is present', async () => {
+      stubNoLocal();
+      process.env.GROK_API_KEY = 'x';
+      const snap = await detectEnvironment();
+      expect(snap.ready).toBe(true);
+      expect(snap.recommendedFree).toBeUndefined();
+      expect(snap.recommended?.id).toBe('grok');
+      expect(snap.recommended?.free).toBe(false);
+    });
+
+    it('is not ready when nothing is configured', async () => {
+      stubNoLocal();
+      const snap = await detectEnvironment();
+      expect(snap.ready).toBe(false);
+      expect(snap.recommended).toBeUndefined();
+    });
+  });
+
+  describe('renderDetectionSummary', () => {
+    it('marks available capabilities with a check and free ones with $0', () => {
+      const snapshot: EnvironmentSnapshot = {
+        capabilities: [
+          { id: 'ollama', label: 'Ollama', kind: 'local', free: true, available: true, detail: 'running · 1 model' },
+          { id: 'openai', label: 'OpenAI API key', kind: 'api-key', free: false, available: false, detail: 'not set' },
+        ],
+        ready: true,
+      };
+      const out = renderDetectionSummary(snapshot);
+      expect(out).toContain('✓ Ollama');
+      expect(out).toContain('($0)');
+      expect(out).toContain('○ OpenAI API key');
+    });
+  });
+
+  describe('orderGuidesByDetection', () => {
+    it('floats the recommended provider to the front and annotates detected ones', () => {
+      const snapshot: EnvironmentSnapshot = {
+        capabilities: [
+          { id: 'ollama', label: 'Ollama local model', kind: 'local', free: true, available: true, detail: 'running' },
+        ],
+        recommended: { id: 'ollama', label: 'Ollama local model', kind: 'local', free: true, available: true, detail: 'running' },
+        ready: true,
+      };
+      const ordered = orderGuidesByDetection(snapshot);
+      expect(ordered[0]?.id).toBe('ollama');
+      expect(ordered[0]?.label).toContain('detected');
+    });
+  });
+});


### PR DESCRIPTION
Makes Code Buddy's **install → configure → first run** path soigné and simple — the tech-showcase goal. A new dev goes from clone to "the agent did a real thing" in <2 minutes **without editing a single environment variable**.

## What changed
- **New `src/wizard/environment-detection.ts`** — one best-effort, never-throws probe (Ollama/LM Studio + models, ChatGPT/xAI OAuth, API keys) that prioritizes the **`$0`** path. Shared source of truth for the wizard and doctor.
- **`buddy onboard` reworked** — shows what's detected, offers a **one-"yes" quick start** on the best free path, proposes `ollama pull` if Ollama runs without a model, **writes config to `user-settings.json` (no env var to type)**, and ends on a **green `buddy try`**.
- **`buddy try` ported** from the sibling branch (real agent demo: writes FizzBuzz + tests, runs them, `$0`) + its test.
- **`buddy doctor`** — leads with a verdict (`✅ Ready to chat` / `⚠️ Not ready — …`) and gains **`doctor --fix`** (selects a running Ollama model or pulls one).
- **First-run/error messages** lead with `buddy try` / `onboard` / `login` — no more `export OLLAMA_HOST=…`.
- **Docs** (`getting-started.md`, `install.md`, `install.sh`) lead with the zero-config `$0` path + an "8 commands that matter, the rest is optional" note.

## Proof (real)
`doctor --fix` on a fresh HOME with Ollama running → selects `qwen3.8:27b ($0)`, writes settings; then `buddy -p` in a clean env (no `OLLAMA_HOST`, no key) → `Auto-detected provider: ollama … cost: $0.0000`. Build + typecheck ✅; 48 tests green.

## Merge notes
Touches `src/index.ts` outside the frozen 350-370 zone (try registration + 2 dead-end messages) and `src/wizard/onboarding.ts` (additive detection/quick-start). Coordinate with the Ollama and media branches to avoid double-registering `try`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)