### PR TITLE
fix(providers): support strict local chat templates (Qwen3 'system message must be at the beginning')

### DIFF
--- a/src/codebuddy/providers/provider-openai-compat.ts
+++ b/src/codebuddy/providers/provider-openai-compat.ts
@@ -123,6 +123,65 @@ export function resolveLlmExtraHeaders(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/** Flatten a chat message's `content` to plain text (string, or joined text parts). */
+function messageContentToText(content: CodeBuddyMessage['content']): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === 'object' && 'text' in part && typeof (part as { text?: unknown }).text === 'string'
+          ? (part as { text: string }).text
+          : '',
+      )
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+/**
+ * Normalize a message list so it carries **exactly one `system` message, in
+ * position 0** — required by strict chat templates (e.g. Qwen3's Jinja template
+ * raises `System message must be at the beginning` on any later/second system
+ * message; Ollama then returns HTTP 400 "Unable to generate parser").
+ *
+ * Code Buddy legitimately emits several `system` messages per turn: the base
+ * system prompt (front) plus per-turn context injections appended AFTER the
+ * conversation (`<lessons_context>`, `<todo_context>`, mention/middleware/
+ * companion context blocks — see agent-executor). Public cloud providers accept
+ * that ordering; strict local templates do not.
+ *
+ * The transform merges every `system` content, in original order, into a single
+ * leading system message and keeps all non-system messages in their original
+ * relative order. It is a no-op (returns the same array reference) when the list
+ * already has at most one system message and it is already at index 0, so
+ * runtimes that tolerate the current ordering are byte-identical.
+ *
+ * Exported for unit testing.
+ */
+export function mergeSystemMessagesToFront(messages: CodeBuddyMessage[]): CodeBuddyMessage[] {
+  const systemIndexes: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i]?.role === 'system') systemIndexes.push(i);
+  }
+  // Already compliant: 0 or 1 system message, and if present it leads the list.
+  if (systemIndexes.length === 0) return messages;
+  if (systemIndexes.length === 1 && systemIndexes[0] === 0) return messages;
+
+  const systemTexts: string[] = [];
+  const rest: CodeBuddyMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'system') {
+      const text = messageContentToText(msg.content);
+      if (text) systemTexts.push(text);
+    } else {
+      rest.push(msg);
+    }
+  }
+  const merged: CodeBuddyMessage = { role: 'system', content: systemTexts.join('\n\n') };
+  return [merged, ...rest];
+}
+
 export class OpenAICompatProvider implements Provider {
   private client: OpenAI;
   private apiKey: string;
@@ -453,6 +512,43 @@ export class OpenAICompatProvider implements Provider {
     return this.baseURL.includes('api.x.ai');
   }
 
+  /**
+   * Whether the target is a **local inference runtime** whose chat template may
+   * be strict about system-message placement (Ollama, LM Studio, vLLM). These
+   * embed the model's own Jinja template, so a second/late `system` message
+   * hard-fails (Qwen3: "System message must be at the beginning" → HTTP 400).
+   *
+   * Detection is by endpoint: loopback / private-LAN hosts and the well-known
+   * local ports, plus the `ollama`/`lmstudio`/`vllm` model providers. Public
+   * cloud hosts (api.x.ai, api.openai.com, api.anthropic.com, openrouter.ai, …)
+   * never match, so Grok/GPT/Claude payloads are left untouched.
+   */
+  private isStrictTemplateLocalRuntime(): boolean {
+    const url = this.baseURL.toLowerCase();
+    const provider = getModelInfo(this.currentModel).provider;
+    if (provider === 'ollama' || provider === 'lmstudio') return true;
+    // vLLM is served over an OpenAI-compat endpoint but is not a distinct
+    // ModelProvider value — detect it (and any self-hosted runtime) by env/URL.
+    if (process.env.VLLM_BASE_URL && url === process.env.VLLM_BASE_URL.toLowerCase()) return true;
+    if (url.includes('localhost') || url.includes('127.0.0.1') || url.includes('0.0.0.0')) return true;
+    if (url.includes('lmstudio') || url.includes('ollama') || url.includes('vllm')) return true;
+    // Private-LAN address ranges (self-hosted runtimes on the local network).
+    if (/(?:^|\/\/)(?:10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+)/.test(url)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Apply `mergeSystemMessagesToFront` when talking to a strict-template local
+   * runtime. No-op for cloud providers (preserves the exact current ordering,
+   * so Grok/GPT/Claude are byte-identical).
+   */
+  private normalizeMessagesForRuntime(messages: CodeBuddyMessage[]): CodeBuddyMessage[] {
+    if (!this.isStrictTemplateLocalRuntime()) return messages;
+    return mergeSystemMessagesToFront(messages);
+  }
+
   /** Gate legacy search_parameters by provider compatibility. */
   private shouldIncludeSearchParameters(searchParams?: SearchParameters): boolean {
     if (!searchParams) {
@@ -640,11 +736,13 @@ export class OpenAICompatProvider implements Provider {
     try {
       const useTools = !this.isLocalInference() && tools && tools.length > 0;
 
+      // Strict-template local runtimes (Ollama/LM Studio/vLLM) require a single
+      // leading system message — merge any late/duplicate system injections.
+      let finalMessages: CodeBuddyMessage[] = this.normalizeMessagesForRuntime(messages);
       // Inject Anthropic prompt-cache breakpoints (Manus AI #20).
-      let finalMessages: CodeBuddyMessage[] = messages;
       const modelInfo = getModelInfo(this.currentModel);
       if (modelInfo.provider === 'anthropic') {
-        finalMessages = injectAnthropicCacheBreakpoints(messages) as CodeBuddyMessage[];
+        finalMessages = injectAnthropicCacheBreakpoints(finalMessages) as CodeBuddyMessage[];
       }
 
       const requestPayload: ChatRequestPayload = {
@@ -803,8 +901,12 @@ export class OpenAICompatProvider implements Provider {
     try {
       const useTools = !this.isLocalInference() && tools && tools.length > 0;
 
-      // Convert tool messages for local models that don't support tool role.
-      let finalMessages = this.convertToolMessagesForLocalModels(messages);
+      // Strict-template local runtimes (Ollama/LM Studio/vLLM) require a single
+      // leading system message — merge any late/duplicate system injections
+      // before the tool-role conversion below.
+      let finalMessages = this.convertToolMessagesForLocalModels(
+        this.normalizeMessagesForRuntime(messages),
+      );
 
       // Anthropic message hooks — symmetry with chat() (Phase C4).
       // The pre-C4 chatStream() never called these, so Claude streams missed

--- a/tests/codebuddy/providers/provider-openai-compat-system-order.test.ts
+++ b/tests/codebuddy/providers/provider-openai-compat-system-order.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  OpenAICompatProvider,
+  mergeSystemMessagesToFront,
+} from '../../../src/codebuddy/providers/provider-openai-compat.js';
+import type { CodeBuddyMessage } from '../../../src/codebuddy/client.js';
+
+/**
+ * Regression: Qwen3 (and other strict Jinja chat templates served by Ollama /
+ * LM Studio / vLLM) raise "System message must be at the beginning" — surfaced
+ * as HTTP 400 "Unable to generate parser for this template" — whenever a second
+ * or late `system` message appears. Code Buddy injects per-turn `<todo_context>`
+ * etc. as `system` messages appended AFTER the conversation, which tripped it.
+ *
+ * The provider must normalize the payload for local runtimes so exactly one
+ * `system` message is emitted, in position 0.
+ */
+describe('mergeSystemMessagesToFront (pure)', () => {
+  it('merges multiple system messages into a single leading one', () => {
+    const messages: CodeBuddyMessage[] = [
+      { role: 'system', content: 'base system prompt' },
+      { role: 'user', content: 'Reply PONG' },
+      { role: 'system', content: '<todo_context>none</todo_context>' },
+    ];
+
+    const out = mergeSystemMessagesToFront(messages);
+
+    const systemCount = out.filter((m) => m.role === 'system').length;
+    expect(systemCount).toBe(1);
+    expect(out[0]?.role).toBe('system');
+    expect(out[0]?.content).toBe('base system prompt\n\n<todo_context>none</todo_context>');
+    // Non-system messages keep their relative order.
+    expect(out.slice(1).map((m) => m.role)).toEqual(['user']);
+    expect(out[1]?.content).toBe('Reply PONG');
+  });
+
+  it('moves a single non-leading system message to the front', () => {
+    const messages: CodeBuddyMessage[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: 'late system' },
+    ];
+    const out = mergeSystemMessagesToFront(messages);
+    expect(out.map((m) => m.role)).toEqual(['system', 'user']);
+    expect(out[0]?.content).toBe('late system');
+  });
+
+  it('is a no-op (same reference) when already compliant', () => {
+    const messages: CodeBuddyMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'yo' },
+    ];
+    expect(mergeSystemMessagesToFront(messages)).toBe(messages);
+  });
+
+  it('is a no-op when there is no system message', () => {
+    const messages: CodeBuddyMessage[] = [{ role: 'user', content: 'hi' }];
+    expect(mergeSystemMessagesToFront(messages)).toBe(messages);
+  });
+
+  it('flattens array-part system content when merging', () => {
+    const messages: CodeBuddyMessage[] = [
+      { role: 'system', content: [{ type: 'text', text: 'part-a' }] },
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: 'part-b' },
+    ];
+    const out = mergeSystemMessagesToFront(messages);
+    expect(out[0]?.content).toBe('part-a\n\npart-b');
+  });
+});
+
+describe('OpenAICompatProvider — system-message normalization by runtime', () => {
+  function makeProvider(baseURL: string, model: string): OpenAICompatProvider {
+    return new OpenAICompatProvider({
+      apiKey: 'test-key',
+      baseURL,
+      model,
+      defaultMaxTokens: 128,
+      getCircuitBreakerConfig: () => undefined,
+    });
+  }
+
+  function stubClient(provider: OpenAICompatProvider): { create: ReturnType<typeof vi.fn> } {
+    const create = vi.fn().mockResolvedValue({
+      id: 'x',
+      choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+    // Replace the OpenAI SDK client on the instance so no network call happens.
+    (provider as unknown as { client: unknown }).client = {
+      chat: { completions: { create } },
+    };
+    return { create };
+  }
+
+  const scattered: CodeBuddyMessage[] = [
+    { role: 'system', content: 'base system prompt' },
+    { role: 'user', content: 'Reply PONG' },
+    { role: 'system', content: '<todo_context>none</todo_context>' },
+  ];
+
+  it('LOCAL (Ollama): emits exactly one system message in position 0', async () => {
+    const provider = makeProvider('http://localhost:11434/v1', 'qwen3.8:27b');
+    const { create } = stubClient(provider);
+
+    await provider.chat(structuredClone(scattered));
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const sent = (create.mock.calls[0]![0] as { messages: CodeBuddyMessage[] }).messages;
+    const systemMsgs = sent.filter((m) => m.role === 'system');
+    expect(systemMsgs).toHaveLength(1);
+    expect(sent[0]?.role).toBe('system');
+  });
+
+  it('LOCAL (Ollama): also normalizes on the streaming path', async () => {
+    const provider = makeProvider('http://127.0.0.1:11434/v1', 'qwen3.8:27b');
+    const create = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield {
+          id: 'x',
+          choices: [{ delta: { content: 'ok' }, finish_reason: 'stop', index: 0 }],
+        };
+      })(),
+    );
+    (provider as unknown as { client: unknown }).client = {
+      chat: { completions: { create } },
+    };
+
+    const gen = provider.chatStream(structuredClone(scattered));
+    // Drain the generator so the request is actually issued.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of gen) { /* consume */ }
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const sent = (create.mock.calls[0]![0] as { messages: CodeBuddyMessage[] }).messages;
+    expect(sent.filter((m) => m.role === 'system')).toHaveLength(1);
+    expect(sent[0]?.role).toBe('system');
+  });
+
+  it('CLOUD (xAI/Grok): leaves the scattered system order untouched', async () => {
+    const provider = makeProvider('https://api.x.ai/v1', 'grok-3');
+    const { create } = stubClient(provider);
+
+    await provider.chat(structuredClone(scattered));
+
+    const sent = (create.mock.calls[0]![0] as { messages: CodeBuddyMessage[] }).messages;
+    // Byte-identical ordering: two system messages, the second still last.
+    expect(sent.filter((m) => m.role === 'system')).toHaveLength(2);
+    expect(sent.map((m) => m.role)).toEqual(['system', 'user', 'system']);
+  });
+});


### PR DESCRIPTION
## Bug
`buddy -m qwen3.8:27b -p "…"` (latest local Qwen via Ollama) failed with HTTP 400 `Jinja Exception: System message must be at the beginning`. Qwen3's chat template raises if a `system` message appears in 2nd position or after a non-system message. Code Buddy legitimately emits **several** `system` messages per turn (base prompt + per-turn injections: `<lessons_context>`, `<todo_context>`, mention blocks, middleware hints…). Cloud providers tolerate this; strict local templates don't. Breaks the "works with the latest LLMs (Qwen)" showcase promise.

## Fix (`provider-openai-compat.ts`)
- Pure `mergeSystemMessagesToFront(messages)` — merges all `system` contents (in order) into a single `system` at index 0; no-op if already compliant.
- `isStrictTemplateLocalRuntime()` — matches Ollama / LM Studio / vLLM / loopback-LAN only; cloud hosts (api.x.ai, api.openai.com, …) never match.
- Applied at the top of both `chat()` and `chatStream()`, local runtimes only.

Invariant: cloud providers get a strict no-op (byte-identical message order) — asserted by test.

## Tested for real
- `qwen3.8:27b` → `PONG`, exit 0 (no more 400). Also `qwen3:4b-instruct` (fast). Regression `qwen2.5:3b-instruct` OK.
- build + typecheck exit 0; new test suite + hooks regression → 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)