### PR TITLE
fix(identity): long tasks mentioning Lisa no longer hijacked by local self-inspection

### DIFF
--- a/src/identity/lisa-introspection.ts
+++ b/src/identity/lisa-introspection.ts
@@ -150,7 +150,7 @@ const NON_ACTIONABLE_SELF_IMPROVEMENT = [
 ] as const;
 
 const SELF_IMPLEMENTATION_TARGET =
-  /\b(?:ton|ta|tes|votre|vos) (?:propre?s? )?(?:code(?: source)?|fonctionnement|architecture|implementation|systeme|memoire|outils?|sources?|composants?|internes?)\b|\b(?:lisa|l assistant|l assistante|l agent)\b.{0,96}\b(?:son |sa |ses )?(?:propre?s? )?(?:code|fonctionnement|architecture|implementation|systeme|memoire|outils?|sources?|composants?|internes?)\b|\byour (?:own )?(?:code|implementation|architecture|system|memory|tools?|sources?|components?|internals)\b/;
+  /\b(?:ton|ta|tes|votre|vos) (?:propre?s? )?(?:code(?: source)?|fonctionnement|architecture|implementation|systeme|memoire|outils?|sources?|composants?|internes?)\b|\b(?:lisa|l assistant|l assistante|l agent)\b.{0,96}\b(?:(?:son|sa|ses) (?:propre?s? )?|propre?s? )(?:code|fonctionnement|architecture|implementation|systeme|memoire|outils?|sources?|composants?|internes?)\b|\byour (?:own )?(?:code|implementation|architecture|system|memory|tools?|sources?|components?|internals)\b/;
 
 const INSPECT_PATTERNS = [
   /\b(?:introspection technique|auto inspection)\b/,
@@ -236,6 +236,25 @@ const EXPLICIT_PERSONAL_INTROSPECTION_SCOPE =
 
 function matchesAny(text: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Characters of context (each side) around a self-implementation target in
+ * which a no-mutation clause is read as binding on that target. A long,
+ * multi-section task (e.g. a headless mission whose guard-rails say "ne pas
+ * toucher aux services" twenty lines after an unrelated mention of Lisa) must
+ * not be downgraded to a local, provider-less inspection turn.
+ */
+const NO_MUTATION_PROXIMITY_CHARS = 160;
+
+function hasNoMutationNearSelfTarget(text: string): boolean {
+  const target = new RegExp(SELF_IMPLEMENTATION_TARGET.source, 'g');
+  for (const match of text.matchAll(target)) {
+    const start = Math.max(0, match.index - NO_MUTATION_PROXIMITY_CHARS);
+    const end = Math.min(text.length, match.index + match[0].length + NO_MUTATION_PROXIMITY_CHARS);
+    if (matchesAny(text.slice(start, end), NO_MUTATION_PATTERNS)) return true;
+  }
+  return false;
 }
 
 export type LisaOperationalResponseMode =
@@ -421,10 +440,7 @@ export function classifyLisaIntrospection(raw: string): LisaIntrospectionIntent 
 
   // An explicit no-mutation clause is authority, not just prose. It must win
   // over nearby verbs such as “corrige/répare” that appear under negation.
-  if (
-    SELF_IMPLEMENTATION_TARGET.test(text) &&
-    matchesAny(text, NO_MUTATION_PATTERNS)
-  ) {
+  if (hasNoMutationNearSelfTarget(text)) {
     return 'inspect';
   }
 

--- a/tests/identity/lisa-introspection.test.ts
+++ b/tests/identity/lisa-introspection.test.ts
@@ -158,6 +158,29 @@ const CASES: Record<LisaIntrospectionIntent, readonly string[]> = {
 };
 
 describe('Lisa introspection intent classifier', () => {
+  it('does not treat a long task that merely mentions Lisa as a self-inspection turn (regression 2026-08-22)', () => {
+    // A headless mission: the persona is the SUBJECT of the task, not the agent,
+    // and the only no-mutation clause is a guard-rail twenty lines away.
+    const mission = [
+      '# MISSION (mécanique, 5 min)',
+      'Dépôt : ~/.codebuddy/personas/lisa. Pour chaque short, écris le bloc titre/description.',
+      'Description : commencer par « Lisa est une présentatrice virtuelle. Les faits sont sourcés. », 2-4 phrases factuelles.',
+      'Lis les fiches SHORT-LISA-*.md et les narrations dans narrations-shorts/.',
+      '',
+      '## Garde-fous — non négociables',
+      '- Rester dans le dépôt indiqué. Ne jamais écrire ailleurs.',
+      '- Ne pas toucher aux services qui tournent (ComfyUI sur 8188/8189 notamment).',
+      '- Terminer par un bilan de dix lignes maximum.',
+    ].join('\n');
+    expect(classifyLisaIntrospection(mission)).toBeNull();
+    expect(classifyLisaIntrospection('Lisa est une présentatrice virtuelle. Les faits sont sourcés.')).toBeNull();
+  });
+
+  it('still reads a nearby no-mutation clause as an inspection boundary', () => {
+    expect(classifyLisaIntrospection('Analyse ton propre code sans le modifier.')).toBe('inspect');
+    expect(classifyLisaIntrospection('Lisa, examine son propre fonctionnement mais ne touche jamais aux fichiers.')).toBe('inspect');
+  });
+
   for (const [intent, requests] of Object.entries(CASES) as Array<
     [LisaIntrospectionIntent, readonly string[]]
   >) {


### PR DESCRIPTION
## Problème
Une mission headless (`buddy -p …`) dont le texte mentionne simplement Lisa (« Lisa est une présentatrice virtuelle. Les faits sont sourcés. ») et contient, 20 lignes plus loin, un garde-fou sans rapport (« Ne pas toucher aux services… ») était classée `inspect` par `classifyLisaIntrospection` : l'agent renvoyait le modèle de soi opérationnel local, **sans appeler le provider ni exécuter la tâche** (reproduit sur l'engine NVIDIA de la flotte, 22/08).

## Causes / correctifs
- `SELF_IMPLEMENTATION_TARGET` : la branche « Lisa … <nom> » acceptait un nom nu (`sources`, `outils`) sans possessif → exige désormais `son/sa/ses` ou `propre`.
- La clause de non-mutation doit être à ≤160 caractères de la cible (`hasNoMutationNearSelfTarget`) et non n'importe où dans le prompt.

## Vérification
- `tests/identity` 84/84 + `permission-modes`, `hybrid-reply`, `agent-reply` 122/122 ; `tsc --noEmit` OK ; eslint OK.
- Test de régression ajouté (forme réelle de la mission + la phrase seule → `null` ; clauses proches → toujours `inspect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)