### PR TITLE
fix(cli): stale first-party model slug no longer sent to another first-party backend (404)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -582,31 +582,8 @@ async function saveCommandLineSettings(
 }
 
 /** Providers served by a local OpenAI-compatible runtime (no cloud model catalog). */
-const LOCAL_RUNTIME_PROVIDERS = new Set(['ollama', 'lmstudio', 'vllm']);
-
-/** A model id that only makes sense on a hosted cloud backend (never a local Ollama tag). */
-function looksLikeCloudModel(model: string): boolean {
-  return /grok|^gpt-|^o[1-9]|codex|claude|gemini/i.test(model);
-}
-
-/**
- * A saved/default model is only usable if it matches the detected provider's
- * backend: a `grok-*` slug 404s on the ChatGPT/Codex backend, and a `gpt-5.*`
- * slug 404s on xAI. We enforce this for the two cloud providers with a known
- * hard incompatibility (grok ↔ chatgpt), AND for local runtimes (Ollama / LM
- * Studio / vLLM) — a stale cloud slug like `grok-code-fast-1` left in
- * settings.json must never be sent to a local server (it 404s with a cryptic
- * "model not found"). Other providers are left untouched so OpenAI/Anthropic
- * model names pass through as before.
- */
-export function isModelCompatibleWithProvider(model: string, provider?: string): boolean {
-  if (!provider) return true;
-  const looksGrok = /grok/i.test(model);
-  if (provider === 'grok') return looksGrok;
-  if (provider === 'chatgpt') return /^(gpt-|o[1-9]|codex)/i.test(model) && !looksGrok;
-  if (LOCAL_RUNTIME_PROVIDERS.has(provider)) return !looksLikeCloudModel(model);
-  return true;
-}
+import { isModelCompatibleWithProvider } from './providers/model-provider-compat.js';
+export { isModelCompatibleWithProvider };
 
 // Load model from detected provider or user settings
 async function loadModel(): Promise<string | undefined> {

--- a/src/providers/model-provider-compat.ts
+++ b/src/providers/model-provider-compat.ts
@@ -1,0 +1,47 @@
+/**
+ * Model ↔ provider compatibility for the CLI model resolver (`loadModel`).
+ *
+ * A model saved in settings (or left over from a previous provider) must never
+ * be sent to a backend that cannot serve it: the result is a cryptic 404 on the
+ * very first turn. Gateways (OpenRouter, OmniRoute, Bedrock, Azure, Copilot,
+ * Together, …) legitimately re-serve first-party families, so they keep the
+ * permissive default; only first-party backends are strict.
+ */
+
+export const LOCAL_RUNTIME_PROVIDERS: ReadonlySet<string> = new Set(['ollama', 'lmstudio', 'vllm']);
+
+/** A model id that only makes sense on a hosted cloud backend (never a local Ollama tag). */
+export function looksLikeCloudModel(model: string): boolean {
+  return /grok|^gpt-|^o[1-9]|codex|claude|gemini/i.test(model);
+}
+
+/**
+ * First-party model families and the only first-party provider that serves
+ * them directly. A slug from one family sent to ANOTHER first-party backend
+ * (e.g. a stale `grok-code-fast-1` default against NVIDIA NIM, Anthropic or
+ * Gemini) can only 404.
+ */
+const FIRST_PARTY_MODEL_FAMILIES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/grok/i, 'grok'],
+  [/^claude-/i, 'anthropic'],
+  [/^gemini-/i, 'gemini'],
+  [/^(?:gpt-|o[1-9]\b|codex)/i, 'openai'],
+];
+
+/** Backends that serve exactly one vendor's catalog (never a cross-vendor gateway). */
+const FIRST_PARTY_PROVIDERS: ReadonlySet<string> = new Set([
+  'grok', 'anthropic', 'gemini', 'openai', 'chatgpt', 'nvidia', 'mistral', 'groq', 'cerebras', 'deepseek',
+]);
+
+export function isModelCompatibleWithProvider(model: string, provider?: string): boolean {
+  if (!provider) return true;
+  const looksGrok = /grok/i.test(model);
+  if (provider === 'grok') return looksGrok;
+  if (provider === 'chatgpt') return /^(gpt-|o[1-9]|codex)/i.test(model) && !looksGrok;
+  if (LOCAL_RUNTIME_PROVIDERS.has(provider)) return !looksLikeCloudModel(model);
+  if (FIRST_PARTY_PROVIDERS.has(provider)) {
+    const family = FIRST_PARTY_MODEL_FAMILIES.find(([pattern]) => pattern.test(model));
+    if (family && family[1] !== provider) return false;
+  }
+  return true;
+}

--- a/tests/providers/model-provider-compat.test.ts
+++ b/tests/providers/model-provider-compat.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { isModelCompatibleWithProvider } from '../../src/providers/model-provider-compat.js';
+
+describe('isModelCompatibleWithProvider', () => {
+  it('keeps the historical first-party rules', () => {
+    expect(isModelCompatibleWithProvider('grok-4-latest', 'grok')).toBe(true);
+    expect(isModelCompatibleWithProvider('gpt-5.5', 'grok')).toBe(false);
+    expect(isModelCompatibleWithProvider('gpt-5.6-sol', 'chatgpt')).toBe(true);
+    expect(isModelCompatibleWithProvider('grok-code-fast-1', 'chatgpt')).toBe(false);
+    expect(isModelCompatibleWithProvider('qwen2.5-coder:7b', 'ollama')).toBe(true);
+    expect(isModelCompatibleWithProvider('grok-code-fast-1', 'ollama')).toBe(false);
+    expect(isModelCompatibleWithProvider('anything', undefined)).toBe(true);
+  });
+
+  it('rejects a stale vendor slug against another first-party backend (regression: grok default → NVIDIA 404)', () => {
+    expect(isModelCompatibleWithProvider('grok-code-fast-1', 'nvidia')).toBe(false);
+    expect(isModelCompatibleWithProvider('grok-code-fast-1', 'anthropic')).toBe(false);
+    expect(isModelCompatibleWithProvider('gpt-5.5', 'gemini')).toBe(false);
+    expect(isModelCompatibleWithProvider('claude-sonnet-4-20250514', 'openai')).toBe(false);
+    expect(isModelCompatibleWithProvider('gemini-2.5-flash', 'nvidia')).toBe(false);
+  });
+
+  it('accepts a provider-native or unknown-family slug on a first-party backend', () => {
+    expect(isModelCompatibleWithProvider('moonshotai/kimi-k3', 'nvidia')).toBe(true);
+    expect(isModelCompatibleWithProvider('openai/gpt-oss-20b', 'nvidia')).toBe(true);
+    expect(isModelCompatibleWithProvider('claude-sonnet-4-20250514', 'anthropic')).toBe(true);
+    expect(isModelCompatibleWithProvider('gemini-2.5-flash', 'gemini')).toBe(true);
+    expect(isModelCompatibleWithProvider('gpt-4o', 'openai')).toBe(true);
+    expect(isModelCompatibleWithProvider('mistral-large-latest', 'mistral')).toBe(true);
+  });
+
+  it('stays permissive for gateways and unknown providers (they re-serve any family)', () => {
+    expect(isModelCompatibleWithProvider('grok-4-latest', 'openrouter')).toBe(true);
+    expect(isModelCompatibleWithProvider('claude-sonnet-4-20250514', 'bedrock')).toBe(true);
+    expect(isModelCompatibleWithProvider('gpt-4o', 'azure')).toBe(true);
+    expect(isModelCompatibleWithProvider('gpt-4o', 'copilot')).toBe(true);
+    expect(isModelCompatibleWithProvider('gemini-2.5-pro', 'omniroute')).toBe(true);
+    expect(isModelCompatibleWithProvider('grok-3', 'some-new-provider')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problème
Un `defaultModel` périmé dans `~/.codebuddy/user-settings.json` (`grok-code-fast-1`) était envoyé tel quel à NVIDIA NIM (provider détecté `nvidia`) → `404 page not found` au premier tour headless. `isModelCompatibleWithProvider` ne connaissait que grok / chatgpt / runtimes locaux.

## Correctif
- Règles extraites dans `src/providers/model-provider-compat.ts` (ré-exporté par `index.ts`, appels inchangés).
- Une famille first-party (`grok`, `claude-`, `gemini-`, `gpt-`/`o*`/`codex`) est incompatible avec un AUTRE backend first-party (`nvidia`, `anthropic`, `gemini`, `openai`, `mistral`, `groq`, `cerebras`, `deepseek`, …) ; gateways et providers inconnus restent permissifs ; règles historiques préservées.

## Vérification
- `tests/providers/model-provider-compat.test.ts` (4 cas : historiques, régression, natifs, gateways) ; `tsc --noEmit` OK ; eslint 0 erreur (1 warning préexistant `index.ts:1511`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)