### PR TITLE
fix(git-tool): bisect completion detection on git >= 2.55 (CI red since runner upgrade)

### DIFF
--- a/src/tools/git-tool.ts
+++ b/src/tools/git-tool.ts
@@ -84,6 +84,9 @@ export interface CherryPickOptions {
   noCommit?: boolean;
 }
 
+/** Final bisect summary line, git-version agnostic (unquoted term < 2.55, quoted term >= 2.55 / custom terms). */
+const BISECT_DONE_PATTERN = /\bis the first '?[\w-]+'? commit\b/;
+
 export class GitTool {
   private confirmationService = ConfirmationService.getInstance();
   private attributionManager: AttributionManager;
@@ -714,8 +717,11 @@ export class GitTool {
       // both streams so completion detection is git-version agnostic.
       const combined = `${stdout}\n${stderr}`.trim();
 
-      // Check if bisect is done (found the first bad commit)
-      const isDone = combined.includes('is the first bad commit');
+      // Check if bisect is done (found the first bad commit). git < 2.55 prints
+      // "<sha> is the first bad commit"; git >= 2.55 quotes the term
+      // ("is the first 'bad' commit", or the custom --term-bad name), so match
+      // the phrase shape rather than one literal.
+      const isDone = BISECT_DONE_PATTERN.test(combined);
       // Surface both streams so callers (and tests) see the summary wherever git
       // put it; when only stdout is present this is identical to the old behavior.
       const output = combined;

--- a/tests/tools/git-tool.test.ts
+++ b/tests/tools/git-tool.test.ts
@@ -418,8 +418,9 @@ describe('GitTool.bisect', () => {
 
       if (stepResult.data && (stepResult.data as { done: boolean }).done) {
         done = true;
-        // The output should mention the first bad commit
-        expect(stepResult.output).toContain('is the first bad commit');
+        // The output should mention the first bad commit (git >= 2.55 quotes the term:
+        // "is the first 'bad' commit")
+        expect(stepResult.output).toMatch(/is the first '?bad'? commit/);
       }
     }
 


### PR DESCRIPTION
## Problème
`tests/tools/git-tool.test.ts > GitTool.bisect > should complete a full bisect workflow` est rouge sur TOUTES les PR (ubuntu/macOS) : les runners ont **git 2.55.0**, qui imprime `<sha> is the first 'bad' commit` (terme entre quotes), alors que `bisectStep()` ne reconnaissait que `is the first bad commit` → `data.done` jamais vrai.

Reproduit dans `alpine:edge` (git 2.55.0) : sortie `f48f… is the first 'bad' commit`.

## Correctif
- `BISECT_DONE_PATTERN = /\bis the first '?[\w-]+'? commit\b/` (couvre ancien format, nouveau format et `--term-bad` personnalisé).
- Le test accepte la même forme (`toMatch(/is the first '?bad'? commit/)`).

## Vérification
- `tests/tools/git-tool.test.ts` 46/46 en local (git 2.43) ; `tsc --noEmit` OK ; eslint 0 erreur (2 warnings préexistants).
- La CI de cette PR est la preuve sur git 2.55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)