### PR TITLE
fix(ci): macOS — tmp realpath (/private/var) + platform injection + sandbox timeout/abort

### DIFF
--- a/src/capture/screen-recorder.ts
+++ b/src/capture/screen-recorder.ts
@@ -142,17 +142,19 @@ export function buildRecordArgs(
 export class ScreenRecorder {
   private proc: ChildProcess | null = null;
   private readonly doSpawn: SpawnLike;
+  private readonly platform: NodeJS.Platform;
 
-  constructor(opts: { spawnImpl?: SpawnLike } = {}) {
+  constructor(opts: { spawnImpl?: SpawnLike; platform?: NodeJS.Platform } = {}) {
     this.doSpawn = opts.spawnImpl ?? (spawn as unknown as SpawnLike);
+    this.platform = opts.platform ?? process.platform;
   }
 
   /** Capture one frame; resolves to the output path. */
   captureFrame(output: string, target: CaptureTarget = {}): Promise<string> {
-    if (process.platform === 'linux' && isWaylandSession()) {
+    if (this.platform === 'linux' && isWaylandSession()) {
       return Promise.reject(new Error('Wayland session: x11grab cannot capture. Use a portal/wf-recorder backend.'));
     }
-    const { cmd, args } = buildFrameArgs(output, target);
+    const { cmd, args } = buildFrameArgs(output, target, this.platform);
     return new Promise((resolve, reject) => {
       const p = this.doSpawn(cmd, args, { stdio: 'ignore' });
       p.on('error', reject);
@@ -163,11 +165,11 @@ export class ScreenRecorder {
   /** Start a video recording. Returns the output path; call stop() to finish. */
   start(output: string, opts: RecordOptions = {}): string {
     if (this.proc) throw new Error('already recording');
-    if (process.platform === 'linux' && isWaylandSession()) {
+    if (this.platform === 'linux' && isWaylandSession()) {
       throw new Error('Wayland session: x11grab cannot record. Use a portal/wf-recorder backend.');
     }
     fs.mkdirSync(path.dirname(path.resolve(output)), { recursive: true });
-    const { cmd, args } = buildRecordArgs(output, opts);
+    const { cmd, args } = buildRecordArgs(output, opts, this.platform);
     this.proc = this.doSpawn(cmd, args, { stdio: 'ignore' });
     return output;
   }

--- a/src/doctor/assistant-runtime.ts
+++ b/src/doctor/assistant-runtime.ts
@@ -327,8 +327,12 @@ function systemctlEnvironment(): NodeJS.ProcessEnv {
   return result;
 }
 
-async function execSystemctlUser(args: string[], timeoutMs: number): Promise<SystemctlResult> {
-  if (process.platform !== 'linux') return { ok: false, stdout: '' };
+async function execSystemctlUser(
+  args: string[],
+  timeoutMs: number,
+  platform: NodeJS.Platform = process.platform,
+): Promise<SystemctlResult> {
+  if (platform !== 'linux') return { ok: false, stdout: '' };
   return await new Promise<SystemctlResult>((resolve) => {
     execFile(
       'systemctl',
@@ -347,12 +351,15 @@ async function execSystemctlUser(args: string[], timeoutMs: number): Promise<Sys
 }
 
 class SystemdUserServiceController implements UserServiceController {
+  /** The platform is injected (not read from `process`) so the doctor's systemctl boundary is deterministic under test. */
+  constructor(private readonly platform: NodeJS.Platform = process.platform) {}
+
   async getActiveState(
     service: AssistantRepairService,
     timeoutMs: number,
   ): Promise<'active' | 'inactive' | 'failed' | 'unknown'> {
     if (!isAssistantRepairService(service)) return 'unknown';
-    const result = await execSystemctlUser(['is-active', `${service}.service`], timeoutMs);
+    const result = await execSystemctlUser(['is-active', `${service}.service`], timeoutMs, this.platform);
     if (result.stdout === 'active') return 'active';
     if (result.stdout === 'inactive') return 'inactive';
     if (result.stdout === 'failed') return 'failed';
@@ -364,6 +371,7 @@ class SystemdUserServiceController implements UserServiceController {
     const result = await execSystemctlUser(
       ['show', '--property=LoadState', '--value', `${service}.service`],
       timeoutMs,
+      this.platform,
     );
     if (result.stdout === 'loaded') return true;
     if (result.stdout === 'not-found' || result.stdout === 'masked') return false;
@@ -372,7 +380,7 @@ class SystemdUserServiceController implements UserServiceController {
 
   async restart(service: AssistantRepairService, timeoutMs: number): Promise<boolean> {
     if (!isAssistantRepairService(service)) return false;
-    const result = await execSystemctlUser(['restart', `${service}.service`], timeoutMs);
+    const result = await execSystemctlUser(['restart', `${service}.service`], timeoutMs, this.platform);
     return result.ok;
   }
 }
@@ -578,9 +586,9 @@ export async function runAssistantRuntimeDoctor(
   const now = dependencies.now ?? Date.now;
   const fetchImpl = dependencies.fetchImpl ?? ((url, init) => fetch(url, init));
   const tcpProbe = dependencies.tcpProbe ?? defaultTcpProbe;
-  const services = dependencies.services ?? new SystemdUserServiceController();
-  const stateStore = dependencies.repairStateStore ?? new FileAssistantRepairStateStore();
   const platform = dependencies.platform ?? process.platform;
+  const services = dependencies.services ?? new SystemdUserServiceController(platform);
+  const stateStore = dependencies.repairStateStore ?? new FileAssistantRepairStateStore();
   const probeTimeoutMs = boundedNumber(
     options.probeTimeoutMs,
     DEFAULT_PROBE_TIMEOUT_MS,

--- a/src/memory/enhanced-memory.ts
+++ b/src/memory/enhanced-memory.ts
@@ -1122,7 +1122,15 @@ export class EnhancedMemory extends EventEmitter {
       clearInterval(this.decayIntervalId);
       this.decayIntervalId = null;
     }
-    this.saveAll();
+    // Fire-and-forget by contract (dispose() is sync), but never let a late write
+    // surface as an unhandled rejection — e.g. a test that removes the data dir
+    // right after dispose() (ENOENT on bayesian-state.json) turned the whole
+    // vitest run red on CI.
+    void this.saveAll().catch((err) => {
+      logger.debug('enhanced-memory: saveAll on dispose failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
     this.memories.clear();
     this.projects.clear();
     this.summaries = [];

--- a/src/tools/bash/bash-tool.ts
+++ b/src/tools/bash/bash-tool.ts
@@ -401,6 +401,13 @@ export class BashTool implements Disposable {
           return { success: false, error: 'Command aborted by user' };
         }
         if (sandboxed.available && sandboxed.result) {
+          if (sandboxed.result.timedOut) {
+            return {
+              success: false,
+              error: `Command timed out after ${timeout}ms\n[sandbox:${sandboxed.result.backend}]`,
+              ...(sandboxed.result.stdout ? { output: sandboxed.result.stdout } : {}),
+            };
+          }
           if (sandboxed.result.exitCode === 0) {
             return this.formatProcessResult(
               sandboxed.result.stdout,

--- a/src/tools/bash/streaming-executor.ts
+++ b/src/tools/bash/streaming-executor.ts
@@ -89,8 +89,15 @@ export async function* executeStreaming(
 
   if (policy.action === 'sandbox') {
     const sandboxed = await executeInWorkspaceSandbox(executionCommand, cwd, timeout, signal);
+    if (signal?.aborted) {
+      return { success: false, error: 'Command aborted by user' };
+    }
     if (sandboxed.available && sandboxed.result) {
-      const { stdout, stderr, exitCode, backend } = sandboxed.result;
+      const { stdout, stderr, exitCode, backend, timedOut } = sandboxed.result;
+      if (timedOut) {
+        if (stdout) yield stdout;
+        return { success: false, error: `Command timed out after ${timeout}ms\n[sandbox:${backend}]` };
+      }
       if (exitCode === 0 || !isSandboxBoundaryFailure(sandboxed.result)) {
         if (stdout) yield stdout;
         if (stderr) yield stderr;

--- a/src/tools/lint-project-tool.ts
+++ b/src/tools/lint-project-tool.ts
@@ -99,6 +99,19 @@ export class LintProjectTool {
 
       const timeoutMs = Math.min(Math.max(Number(input.timeoutMs) || DEFAULT_TIMEOUT_MS, 1_000), MAX_TIMEOUT_MS);
       const { stdout, stderr, timedOut } = await runLocalBinary(eslintPath, ['.', '--format', 'json'], root, timeoutMs);
+      // ESLint reports absolute paths derived from its (canonical) cwd; when the
+      // root was given lexically through a symlink (macOS /var → /private/var),
+      // relativize against the canonical root too so summaries stay project-relative.
+      const rootReal = await fs.realpath(root).catch(() => root);
+      const relativize = (filePath: string): string => {
+        const rel = path.relative(root, filePath);
+        if (!rel) return filePath;
+        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+          const relReal = path.relative(rootReal, filePath);
+          if (relReal && !relReal.startsWith('..') && !path.isAbsolute(relReal)) return relReal;
+        }
+        return rel;
+      };
       const reports = parseJsonOutput(stdout);
       const files: LintProjectFileSummary[] = reports.filter(isRecord).map((report) => {
         const messages = Array.isArray(report.messages) ? report.messages.filter(isRecord).map((message) => ({
@@ -109,7 +122,7 @@ export class LintProjectTool {
           message: typeof message.message === 'string' ? message.message : '',
         })) : [];
         return {
-          filePath: typeof report.filePath === 'string' ? path.relative(root, report.filePath) || report.filePath : 'unknown',
+          filePath: typeof report.filePath === 'string' ? relativize(report.filePath) : 'unknown',
           errors: typeof report.errorCount === 'number' ? report.errorCount : messages.filter((m) => m.severity === 2).length,
           warnings: typeof report.warningCount === 'number' ? report.warningCount : messages.filter((m) => m.severity === 1).length,
           messages,

--- a/src/tools/review-gate-helper.ts
+++ b/src/tools/review-gate-helper.ts
@@ -12,8 +12,33 @@
  * @module tools/review-gate-helper
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
+
+/**
+ * Canonical form of a path whose leaf may not exist yet: realpath the nearest
+ * existing ancestor and re-append the rest. Needed so the containment check
+ * compares like with like — on macOS `os.tmpdir()`/`process.cwd()` yield the
+ * canonical `/private/var/...` while a configured base directory may still be
+ * the lexical `/var/...` symlink (same on any symlinked workspace).
+ */
+function canonicalize(target: string): string {
+  const resolved = path.resolve(target);
+  const pending: string[] = [];
+  let cursor = resolved;
+  for (;;) {
+    try {
+      const real = fs.realpathSync(cursor);
+      return pending.length ? path.join(real, ...pending.reverse()) : real;
+    } catch {
+      const parent = path.dirname(cursor);
+      if (parent === cursor) return resolved;
+      pending.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
 
 interface GatedWriteRequestBase {
   baseDirectory: string;
@@ -49,9 +74,13 @@ export async function maybeReviewGatedWrite(req: GatedWriteRequest): Promise<Gat
     ? req.changes
     : [{ path: path.relative(req.baseDirectory, req.resolvedPath), newContent: req.newContent }];
   const normalizedChanges: Array<{ path: string; newContent: string | null }> = [];
+  // Compare canonical forms on BOTH sides: a lexical base directory vs a
+  // canonical resolved path (symlinked tmp/workspace) must not be mistaken
+  // for an escape; a genuinely-outside path still fails closed below.
+  const canonicalBase = canonicalize(req.baseDirectory);
   for (const change of changes) {
-    const resolved = path.resolve(req.baseDirectory, change.path);
-    const rel = path.relative(path.resolve(req.baseDirectory), resolved);
+    const resolved = canonicalize(path.resolve(req.baseDirectory, change.path));
+    const rel = path.relative(canonicalBase, resolved);
     if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
       const displayPath = 'displayPath' in req ? req.displayPath : change.path;
       return {

--- a/src/workspace/workspace-isolation.ts
+++ b/src/workspace/workspace-isolation.ts
@@ -116,12 +116,47 @@ const BLOCKED_PATHS: readonly string[] = [
   '/etc/security',
 ];
 
+/**
+ * Canonical (symlink-resolved) form of a path, resolving through the nearest
+ * existing ancestor when the leaf does not exist yet. Returns `null` when no
+ * ancestor can be resolved. Needed because workspace roots and whitelist
+ * entries are often reached through benign system symlinks — on macOS
+ * `os.tmpdir()` is `/var/folders/…` → `/private/var/folders/…`, `/tmp` →
+ * `/private/tmp`, `/home` → `/System/Volumes/Data/home` — and `realpath` of a
+ * file below them would otherwise never match the lexical root.
+ */
+function canonicalizeViaExistingAncestor(resolvedPath: string): string | null {
+  let ancestor = resolvedPath;
+  while (!fs.existsSync(ancestor)) {
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) return null;
+    ancestor = parent;
+  }
+
+  try {
+    const canonicalAncestor = fs.realpathSync(ancestor);
+    const missingSuffix = path.relative(ancestor, resolvedPath);
+    return missingSuffix ? path.resolve(canonicalAncestor, missingSuffix) : canonicalAncestor;
+  } catch {
+    return null;
+  }
+}
+
+/** Lexical + canonical forms of a root (deduplicated). */
+function rootForms(root: string): string[] {
+  const lexical = path.resolve(root);
+  const canonical = canonicalizeViaExistingAncestor(lexical);
+  return canonical && canonical !== lexical ? [lexical, canonical] : [lexical];
+}
+
 // ============================================================================
 // Workspace Isolation Class
 // ============================================================================
 
 export class WorkspaceIsolation extends EventEmitter {
   private config: WorkspaceIsolationConfig;
+  /** Canonical (realpath) form of the workspace root, when it differs from the lexical one. */
+  private canonicalWorkspaceRoot: string | null = null;
   private blockedAccessLog: BlockedAccessLog[] = [];
   private systemWhitelist: Set<string>;
   private blockedPaths: Set<string>;
@@ -139,19 +174,20 @@ export class WorkspaceIsolation extends EventEmitter {
       ...config,
     };
 
-    // Normalize workspace root
+    // Normalize workspace root (lexical + canonical so a root reached through a
+    // benign symlink, e.g. macOS /var → /private/var, still contains its realpaths)
     this.config.workspaceRoot = path.resolve(this.config.workspaceRoot);
+    this.canonicalWorkspaceRoot = this.computeCanonicalRoot(this.config.workspaceRoot);
 
-    // Build whitelist set for fast lookup
+    // Build whitelist set for fast lookup (both forms of every entry)
     this.systemWhitelist = new Set(
-      [...SYSTEM_WHITELIST, ...this.config.additionalAllowedPaths]
-        .map(p => path.resolve(p))
+      [...SYSTEM_WHITELIST, ...this.config.additionalAllowedPaths].flatMap(rootForms)
     );
 
-    // Build blocked paths set
-    this.blockedPaths = new Set(
-      BLOCKED_PATHS.map(p => path.resolve(p))
-    );
+    // Build blocked paths set — both forms too, otherwise a secret reached
+    // through a symlinked $HOME would be whitelisted canonically (e.g.
+    // ~/.codebuddy) while only its lexical path is blocked.
+    this.blockedPaths = new Set(BLOCKED_PATHS.flatMap(rootForms));
   }
 
   /**
@@ -166,7 +202,13 @@ export class WorkspaceIsolation extends EventEmitter {
    */
   setWorkspaceRoot(root: string): void {
     this.config.workspaceRoot = path.resolve(root);
+    this.canonicalWorkspaceRoot = this.computeCanonicalRoot(this.config.workspaceRoot);
     this.emit('workspace:root-changed', this.config.workspaceRoot);
+  }
+
+  private computeCanonicalRoot(lexicalRoot: string): string | null {
+    const canonical = canonicalizeViaExistingAncestor(lexicalRoot);
+    return canonical && canonical !== lexicalRoot ? canonical : null;
   }
 
   /**
@@ -187,7 +229,9 @@ export class WorkspaceIsolation extends EventEmitter {
   addAllowedPath(allowedPath: string): void {
     const resolved = path.resolve(allowedPath);
     this.config.additionalAllowedPaths.push(resolved);
-    this.systemWhitelist.add(resolved);
+    for (const form of rootForms(resolved)) {
+      this.systemWhitelist.add(form);
+    }
   }
 
   /**
@@ -273,7 +317,11 @@ export class WorkspaceIsolation extends EventEmitter {
    */
   private isWithinWorkspace(resolvedPath: string): boolean {
     const normalizedPath = path.normalize(resolvedPath);
-    const roots = [this.config.workspaceRoot, ...(this.workspaceContext.getStore() ?? [])];
+    const roots = [
+      this.config.workspaceRoot,
+      ...(this.canonicalWorkspaceRoot ? [this.canonicalWorkspaceRoot] : []),
+      ...(this.workspaceContext.getStore() ?? []),
+    ];
     return roots.some((root) => {
       const normalizedWorkspace = path.normalize(root);
       return (
@@ -290,20 +338,7 @@ export class WorkspaceIsolation extends EventEmitter {
    * where `link` already points outside the workspace.
    */
   private resolveViaExistingAncestor(resolvedPath: string): string | null {
-    let ancestor = resolvedPath;
-    while (!fs.existsSync(ancestor)) {
-      const parent = path.dirname(ancestor);
-      if (parent === ancestor) return null;
-      ancestor = parent;
-    }
-
-    try {
-      const canonicalAncestor = fs.realpathSync(ancestor);
-      const missingSuffix = path.relative(ancestor, resolvedPath);
-      return path.resolve(canonicalAncestor, missingSuffix);
-    } catch {
-      return null;
-    }
+    return canonicalizeViaExistingAncestor(resolvedPath);
   }
 
   /**

--- a/tests/agent/tool-handler-code-exec-session.test.ts
+++ b/tests/agent/tool-handler-code-exec-session.test.ts
@@ -131,25 +131,29 @@ describe('ToolHandler code_exec logical-session isolation', () => {
     const sessionA = fs.mkdtempSync(path.join(workDir, 'session-a-'));
     const sessionB = fs.mkdtempSync(path.join(workDir, 'session-b-'));
     const hostCwd = process.cwd();
+    // `cd` stores the canonical (realpath) cwd; a restored value comes from that
+    // same store, so restore canonical paths too (os.tmpdir() is a symlink on macOS).
+    const realSessionA = fs.realpathSync(sessionA);
+    const realSessionB = fs.realpathSync(sessionB);
 
     handler.setRecoverySessionId('logical-session-a');
     const changed = await handler.executeTool(bashCall('cd-a', `cd ${sessionA}`));
     expect(changed.success).toBe(true);
-    expect(handler.getWorkingDirectory()).toBe(fs.realpathSync(sessionA));
+    expect(handler.getWorkingDirectory()).toBe(realSessionA);
     expect(process.cwd()).toBe(hostCwd);
 
-    handler.restoreWorkingDirectory(sessionB);
+    handler.restoreWorkingDirectory(realSessionB);
     handler.setRecoverySessionId('logical-session-b');
     const pwdB = await handler.executeTool(bashCall('pwd-b', 'pwd'));
     expect(pwdB.success).toBe(true);
-    expect(pwdB.output).toContain(fs.realpathSync(sessionB));
-    expect(pwdB.output).not.toContain(fs.realpathSync(sessionA));
+    expect(pwdB.output).toContain(realSessionB);
+    expect(pwdB.output).not.toContain(realSessionA);
     expect(handler.getRecoverySessionId()).toBe('logical-session-b');
 
-    handler.restoreWorkingDirectory(sessionA);
+    handler.restoreWorkingDirectory(realSessionA);
     handler.setRecoverySessionId('logical-session-a');
     const pwdA = await handler.executeTool(bashCall('pwd-a', 'pwd'));
-    expect(pwdA.output).toContain(fs.realpathSync(sessionA));
+    expect(pwdA.output).toContain(realSessionA);
     expect(handler.getRecoverySessionId()).toBe('logical-session-a');
     expect(process.cwd()).toBe(hostCwd);
   });

--- a/tests/agent/wide-research-checkpoint.test.ts
+++ b/tests/agent/wide-research-checkpoint.test.ts
@@ -1,7 +1,7 @@
 import { chmod, lstat, mkdir, readFile, readdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   assertWideResearchCheckpointCompatible,
@@ -19,7 +19,8 @@ import {
 const tempDirs: string[] = [];
 
 async function tempDirectory(): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), 'wide-research-checkpoint-'));
+  // Canonical base: macOS tmpdir lives behind a symlink, which the safety policy rejects.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), 'wide-research-checkpoint-')));
   tempDirs.push(directory);
   return directory;
 }

--- a/tests/agent/wide-research-files.test.ts
+++ b/tests/agent/wide-research-files.test.ts
@@ -1,4 +1,4 @@
-import { link, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { link, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -12,7 +12,8 @@ import {
 const tempDirs: string[] = [];
 
 async function tempDirectory(): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), 'wide-research-files-'));
+  // Canonical base: macOS tmpdir lives behind a symlink, which the safety policy rejects.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), 'wide-research-files-')));
   tempDirs.push(directory);
   return directory;
 }

--- a/tests/browser-automation/browser-operator-executor.test.ts
+++ b/tests/browser-automation/browser-operator-executor.test.ts
@@ -236,7 +236,8 @@ describe('BrowserOperatorExecutor', () => {
       expect(mockStagehandOptions?.env).toBe('LOCAL');
       expect(mockStagehandOptions?.localBrowserLaunchOptions).toMatchObject({
         headless: false,
-        userDataDir: path.join(tempDir, 'persistent-profile'),
+        // The profile resolver canonicalizes (realpath) the directory it created.
+        userDataDir: await fs.realpath(path.join(tempDir, 'persistent-profile')),
         preserveUserDataDir: true,
       });
       expect(lockHeldDuringInit).toBe(true);

--- a/tests/browser-automation/browser-operator-profile.test.ts
+++ b/tests/browser-automation/browser-operator-profile.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -22,8 +22,11 @@ describe('Browser Operator persistent profile', () => {
     directories.push(root);
     const profile = join(root, 'profile');
 
-    expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(profile);
-    expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(profile);
+    // The resolver returns the canonical profile path (symlink defence) —
+    // compare against realpath since os.tmpdir() itself is a symlink on macOS.
+    const resolved = resolvePersistentBrowserOperatorProfile(profile);
+    expect(resolved).toBe(await realpath(profile));
+    expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(resolved);
     const mode = (await lstat(profile)).mode & 0o777;
     expect(mode).toBe(0o700);
     const markerPath = join(profile, BROWSER_OPERATOR_PROFILE_MARKER);
@@ -54,7 +57,7 @@ describe('Browser Operator persistent profile', () => {
     await mkdir(join(profile, 'Default'));
     await writeFile(join(profile, 'Default', 'Cookies'), 'persisted sign-in');
 
-    expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(profile);
+    expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(await realpath(profile));
   });
 
   it('refuses a symlink profile instead of exposing another browser profile', async () => {

--- a/tests/capture/screen-recorder.test.ts
+++ b/tests/capture/screen-recorder.test.ts
@@ -82,7 +82,7 @@ describe('ScreenRecorder', () => {
       captured = { cmd, args };
       return proc as never;
     };
-    const rec = new ScreenRecorder({ spawnImpl });
+    const rec = new ScreenRecorder({ spawnImpl, platform: 'linux' });
     expect(rec.isRecording()).toBe(false);
     rec.start('/tmp/x/out.mp4', { display: ':5', fps: 20, screenSize: { width: 640, height: 480 } });
     expect(rec.isRecording()).toBe(true);

--- a/tests/commands/goal-cli.test.ts
+++ b/tests/commands/goal-cli.test.ts
@@ -523,7 +523,9 @@ describe('goal CLI working directory handling', () => {
     fs.mkdirSync(target);
     process.chdir(parent);
 
-    expect(resolveGoalCliWorkingDirectory(fakeDirectoryCommand('target'))).toBe(target);
+    // Resolved against process.cwd(), which is canonical after chdir through a
+    // symlinked tmpdir (macOS /var → /private/var).
+    expect(resolveGoalCliWorkingDirectory(fakeDirectoryCommand('target'))).toBe(fs.realpathSync(target));
   });
 
   it('applies the global --directory option before the headless goal run starts', () => {
@@ -531,8 +533,9 @@ describe('goal CLI working directory handling', () => {
 
     const cwd = applyGoalCliWorkingDirectory(fakeDirectoryCommand(target));
 
-    expect(cwd).toBe(target);
-    expect(process.cwd()).toBe(target);
+    // process.cwd() reports the canonical path after chdir (symlinked tmpdir on macOS).
+    expect(cwd).toBe(fs.realpathSync(target));
+    expect(process.cwd()).toBe(fs.realpathSync(target));
   });
 
   it('leaves cwd unchanged when no directory option is available', () => {

--- a/tests/commands/hermes-commands.test.ts
+++ b/tests/commands/hermes-commands.test.ts
@@ -2880,7 +2880,8 @@ describe('Hermes CLI commands', () => {
         priority: 'high',
         tags: ['hermes', 'parity'],
       });
-      expect(output.boardPath).toBe(path.join(tmpDir, '.codebuddy', 'kanban-board.json'));
+      // The registry roots on process.cwd(), canonical after chdir (symlinked tmpdir on macOS).
+      expect(output.boardPath).toBe(path.join(fs.realpathSync(tmpDir), '.codebuddy', 'kanban-board.json'));
 
       consoleLogSpy.mockClear();
       program = createProgram();

--- a/tests/commands/research/checkpoint-flags.test.ts
+++ b/tests/commands/research/checkpoint-flags.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -284,7 +284,8 @@ describe('buddy research checkpoint/resume flags', () => {
   });
 
   it('creates nested durable report directories and writes only scrubbed content', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'wide-research-cli-'));
+    // Canonical base: macOS tmpdir lives behind a symlink, which the durable-write policy rejects.
+    const directory = await realpath(await mkdtemp(join(tmpdir(), 'wide-research-cli-')));
     tempDirs.push(directory);
     const checkpointPath = join(directory, 'state', 'run.json');
     const reportPath = join(directory, 'reports', 'nested', 'report.md');

--- a/tests/identity/operational-self-model.test.ts
+++ b/tests/identity/operational-self-model.test.ts
@@ -21,7 +21,8 @@ const { computeDistDigest } = require('../../scripts/runtime-manifest-utils.cjs'
 };
 
 function tempRoot(prefix = 'code-buddy-self-model-'): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  // The resolver canonicalizes roots (realpath); os.tmpdir() is a symlink on macOS.
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
   roots.push(root);
   return root;
 }

--- a/tests/media/comfyui-recipe-registry.test.ts
+++ b/tests/media/comfyui-recipe-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -83,7 +83,8 @@ describe('ComfyUI recipe loader and registry', () => {
 });
 
 async function temporaryDirectory(): Promise<string> {
-  const root = await mkdtemp(path.join(tmpdir(), 'codebuddy-comfy-recipe-'));
+  // Canonical base: macOS tmpdir lives behind a symlink, which the recipe-root policy rejects.
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), 'codebuddy-comfy-recipe-')));
   temporaryRoots.push(root);
   return root;
 }

--- a/tests/media/comfyui-recipe-runtime.test.ts
+++ b/tests/media/comfyui-recipe-runtime.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -309,7 +309,8 @@ interface RuntimePaths {
 }
 
 async function runtimePaths(modelContents: string | undefined): Promise<RuntimePaths> {
-  const base = await mkdtemp(path.join(tmpdir(), 'codebuddy-comfy-runtime-'));
+  // Canonical base: macOS tmpdir lives behind a symlink, which the models/output root policy rejects.
+  const base = await realpath(await mkdtemp(path.join(tmpdir(), 'codebuddy-comfy-runtime-')));
   temporaryRoots.push(base);
   const modelsRoot = path.join(base, 'models');
   const outputRoot = path.join(base, 'outputs');

--- a/tests/memory/enhanced-memory-recall.test.ts
+++ b/tests/memory/enhanced-memory-recall.test.ts
@@ -39,7 +39,9 @@ afterEach(() => {
     /* ignore */
   }
   memory = null;
-  fs.rmSync(tmpHome, { recursive: true, force: true });
+  // dispose() kicks off a fire-and-forget saveAll(); retry so a write landing
+  // mid-removal can't leave the cleanup with ENOTEMPTY (seen on macOS CI).
+  fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 });
 
 /**

--- a/tests/sensory/camera-keyframe-policy.test.ts
+++ b/tests/sensory/camera-keyframe-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -30,7 +30,8 @@ describe('camera keyframe policy', () => {
     await writeFile(secret, Buffer.from([0xff, 0xd8, 0xff]));
     await symlink(secret, escape);
 
-    expect(await safeCameraKeyframePath(safe, { root })).toBe(safe);
+    // The policy returns the REAL path (symlink defence); os.tmpdir() is itself a symlink on macOS.
+    expect(await safeCameraKeyframePath(safe, { root })).toBe(await realpath(safe));
     expect(await safeCameraKeyframePath(text, { root })).toBeUndefined();
     expect(await safeCameraKeyframePath(secret, { root })).toBeUndefined();
     expect(await safeCameraKeyframePath(escape, { root })).toBeUndefined();

--- a/tests/tools/comfy-recipe-tool.test.ts
+++ b/tests/tools/comfy-recipe-tool.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { access, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -378,7 +378,8 @@ async function setupFixture() {
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  // Canonical base: macOS tmpdir lives behind a symlink, which the root realpath policy rejects.
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), prefix)));
   temporaryRoots.push(root);
   return root;
 }

--- a/tests/tools/comfyui-inpaint.test.ts
+++ b/tests/tools/comfyui-inpaint.test.ts
@@ -253,7 +253,8 @@ function comfyEnv(bundle: ReturnType<typeof inpaintBundle>): NodeJS.ProcessEnv {
 }
 
 async function temporaryWorkspace(): Promise<string> {
-  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'codebuddy-comfy-inpaint-'));
+  // Canonical base: outputPath is returned as a realpath, and macOS tmpdir lives behind a symlink.
+  const workspace = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'codebuddy-comfy-inpaint-')));
   workspaces.push(workspace);
   return workspace;
 }

--- a/tests/tools/meeting-notes-tool.test.ts
+++ b/tests/tools/meeting-notes-tool.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -102,8 +102,10 @@ describe('meeting_notes execution and workspace confinement', () => {
 
     expect(response.success).toBe(true);
     expect(response.output).toContain('# Sync équipe');
+    // The tool hands the REAL input path to the generator (symlink defence);
+    // os.tmpdir() is itself a symlink on macOS.
     expect(generate).toHaveBeenCalledWith(
-      { kind: 'file', path: input },
+      { kind: 'file', path: await realpath(input) },
       { language: 'fr', useAI: false },
     );
     expect((response.data as { paths: unknown }).paths).toBeNull();

--- a/tests/tools/video/film-output-confinement.test.ts
+++ b/tests/tools/video/film-output-confinement.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { spawn } from 'node:child_process';
@@ -88,8 +88,9 @@ describe('film output confinement', () => {
     );
 
     expect(result.success).toBe(true);
+    // The confined output dir is canonical (realpath); os.tmpdir() is a symlink on macOS.
     expect(result.outputPath).toBe(
-      path.join(rootDir, '.codebuddy', 'media-generation', 'films', 'finished.mp4'),
+      path.join(await realpath(rootDir), '.codebuddy', 'media-generation', 'films', 'finished.mp4'),
     );
     expect(seen.some((call) => call.includes(result.outputPath!))).toBe(true);
   });

--- a/tests/unit/tools-core.test.ts
+++ b/tests/unit/tools-core.test.ts
@@ -284,12 +284,13 @@ describe('BashTool', () => {
       process.chdir(originalCwd);
     });
 
-    // /tmp is a Unix-only path
+    // /tmp is a Unix-only path; on macOS it is a symlink to /private/tmp and
+    // `cd` tracks the canonical (realpath) directory.
     (isWindows ? test.skip : test)('should change to valid directory', async () => {
       const result = await bashTool.execute('cd /tmp');
       expect(result.success).toBe(true);
       expect(result.output).toContain('/tmp');
-      expect(bashTool.getCurrentDirectory()).toBe('/tmp');
+      expect(bashTool.getCurrentDirectory()).toBe(fs.realpathSync('/tmp'));
     });
 
     test('should fail for non-existent directory', async () => {

--- a/tests/unit/workspace-isolation-symlinked-home.test.ts
+++ b/tests/unit/workspace-isolation-symlinked-home.test.ts
@@ -1,0 +1,66 @@
+/**
+ * WorkspaceIsolation under a symlinked $HOME (macOS-style `/var` → `/private/var`,
+ * or any home reached through a link): the system whitelist AND the blocked
+ * secret paths must both be matched in lexical and canonical form, so a
+ * whitelisted `~/.codebuddy` can never let `~/.codebuddy/credentials.enc`
+ * through in its canonical spelling.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+type IsolationModule = typeof import('../../src/workspace/workspace-isolation.js');
+
+describe('WorkspaceIsolation with a symlinked HOME', () => {
+  const previousHome = process.env.HOME;
+  let realHome: string;
+  let linkHome: string;
+  let mod: IsolationModule;
+
+  beforeAll(async () => {
+    realHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ws-iso-real-home-')));
+    linkHome = path.join(fs.realpathSync(os.tmpdir()), `ws-iso-link-home-${process.pid}-${Date.now()}`);
+    fs.symlinkSync(realHome, linkHome, 'dir');
+    fs.mkdirSync(path.join(realHome, '.codebuddy'));
+    fs.mkdirSync(path.join(realHome, '.ssh'));
+    // BLOCKED_PATHS / SYSTEM_WHITELIST are computed from os.homedir() at import time.
+    process.env.HOME = linkHome;
+    vi.resetModules();
+    mod = await import('../../src/workspace/workspace-isolation.js');
+  });
+
+  afterAll(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    vi.resetModules();
+    fs.rmSync(linkHome, { force: true });
+    fs.rmSync(realHome, { recursive: true, force: true });
+  });
+
+  it('still blocks protected secrets in both their lexical and canonical spelling', () => {
+    expect(os.homedir()).toBe(linkHome);
+    const iso = new mod.WorkspaceIsolation({
+      workspaceRoot: path.join(realHome, 'project'),
+      logBlockedAccess: false,
+    });
+    for (const home of [linkHome, realHome]) {
+      const credentials = iso.validatePath(path.join(home, '.codebuddy', 'credentials.enc'));
+      expect(credentials.valid).toBe(false);
+      expect(credentials.reason).toBe('blocked_path');
+      const sshKey = iso.validatePath(path.join(home, '.ssh', 'id_ed25519'));
+      expect(sshKey.valid).toBe(false);
+      expect(sshKey.reason).toBe('blocked_path');
+    }
+  });
+
+  it('keeps whitelisting benign config in both spellings', () => {
+    const iso = new mod.WorkspaceIsolation({
+      workspaceRoot: path.join(realHome, 'project'),
+      logBlockedAccess: false,
+    });
+    for (const home of [linkHome, realHome]) {
+      expect(iso.validatePath(path.join(home, '.codebuddy', 'settings.json')).valid).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Cause

The macOS CI job has been red on `main` for a long time (31 failing test files, e.g. run 32576529622 / job 97039586223). This PR covers the path/realpath and platform-injection causes; the seatbelt sandbox profile (the bash-tool `[sandbox:seatbelt; exit code 1]` family) is split out into a separate PR (`fix/macos-seatbelt-profile`).

1. **`/private/var` realpath** — on macOS `os.tmpdir()` = `/var/folders/…` → symlink to `/private/var/…` (and `/tmp` → `/private/tmp`). Three source paths compared a *lexical* root against a *canonical* path:
   - `src/workspace/workspace-isolation.ts` — the realpath of a file under the workspace / system whitelist never matched the lexical root → every TextEditor / MultiEdit / write-gate op under a symlinked workspace was rejected (`Symlink traversal not allowed`, `Path outside workspace`). Now keeps lexical **and** canonical forms of the workspace root, of each whitelist entry **and of each blocked secret path** (review finding: otherwise a symlinked `$HOME` would whitelist `~/.codebuddy` canonically while only blocking `credentials.enc` lexically — proven by the new `tests/unit/workspace-isolation-symlinked-home.test.ts`, which fails without the fix).
   - `src/tools/review-gate-helper.ts` — canonicalize base dir and target on both sides (fail-closed for genuine escapes unchanged).
   - `src/tools/lint-project-tool.ts` — relativize ESLint's canonical file paths against the canonical root when the lexical one escapes.
   - Tests that compared a by-design realpath against a lexical tmp path now compare with `realpath(...)`; tests of the deliberate "no symlinked parent/root" policies (wide-research files, ComfyUI recipe root) build fixtures under a canonical tmp base — the policies themselves are untouched.
2. **Platform injection gaps** — `ScreenRecorder` and the assistant-runtime systemctl controller read `process.platform` even when a platform was injected (their tests ran the darwin branch on macOS).
3. **Sandbox timeout/abort reporting** (`src/tools/bash/bash-tool.ts`, `streaming-executor.ts`) — a sandboxed result with `timedOut`, or an aborted signal, is reported as "timed out" / "aborted by user" instead of a bare exit-1 (the direct path already did).

## Correctif

- Code: `src/workspace/workspace-isolation.ts`, `src/tools/review-gate-helper.ts`, `src/tools/lint-project-tool.ts`, `src/tools/bash/bash-tool.ts`, `src/tools/bash/streaming-executor.ts`, `src/capture/screen-recorder.ts`, `src/doctor/assistant-runtime.ts`.
- Tests: 18 test files adjusted (realpath comparisons / canonical fixtures / platform injection / robust cleanup) + new `tests/unit/workspace-isolation-symlinked-home.test.ts`.

## Vérification

- The macOS tmp behaviour is reproduced on Linux with a symlinked `TMPDIR` (`tmp-link → real-tmp` outside `/tmp`): the affected test files reproduce the CI failures before and pass after, with and without the override; `tests/unit/workspace-isolation-symlinked-home.test.ts` fails with the old lexical-only blocklist and passes with the fix.
- `npx tsc --noEmit -p tsconfig.json` clean; `npx eslint` on all touched files: 0 errors.
- The remaining macOS failures (bash-tool family under seatbelt) are addressed by the follow-up PR; the CI run here should show only those left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)