### PR TITLE
fix(sandbox): seatbelt profile macOS — runnable deny-default policy, functional probe, cwd/env

### DIFF
--- a/src/memory/enhanced-memory.ts
+++ b/src/memory/enhanced-memory.ts
@@ -175,6 +175,7 @@ export class EnhancedMemory extends EventEmitter {
   private embeddingProvider: MemoryEmbedder | null = null;
   private bayesianQualifier = new BayesianQualifier();
   private disposed = false;
+  private pendingDisposeSave: Promise<void> | null = null;
   /** Resolves when initialize() finished (dirs ensured, stores loaded). */
   private readonly ready: Promise<void>;
 
@@ -1115,6 +1116,19 @@ export class EnhancedMemory extends EventEmitter {
   /**
    * Dispose
    */
+  /**
+   * Resolve once every pending write (including the fire-and-forget save
+   * started by `dispose()`) has settled — lets a caller remove the data
+   * directory deterministically instead of racing the last write.
+   */
+  async flush(): Promise<void> {
+    if (this.pendingDisposeSave) {
+      await this.pendingDisposeSave;
+      return;
+    }
+    await this.saveAll();
+  }
+
   dispose(): void {
     this.disposed = true;
     // Clear decay interval timer
@@ -1126,7 +1140,7 @@ export class EnhancedMemory extends EventEmitter {
     // surface as an unhandled rejection — e.g. a test that removes the data dir
     // right after dispose() (ENOENT on bayesian-state.json) turned the whole
     // vitest run red on CI.
-    void this.saveAll().catch((err) => {
+    this.pendingDisposeSave = this.saveAll().catch((err) => {
       logger.debug('enhanced-memory: saveAll on dispose failed', {
         error: err instanceof Error ? err.message : String(err),
       });

--- a/src/sandbox/os-sandbox.ts
+++ b/src/sandbox/os-sandbox.ts
@@ -16,6 +16,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { sanitizeEnvVars } from '../security/env-blocklist.js';
+import { logger } from '../utils/logger.js';
 import type { SandboxBackendInterface, SandboxExecOptions, SandboxExecResult } from './sandbox-backend.js';
 
 // ============================================================================
@@ -550,6 +551,7 @@ async function execSeatbelt(
       ...args,
     ];
 
+    const cwd = fs.existsSync(config.workDir) ? config.workDir : undefined;
     const result = await execWithTimeout(
       'sandbox-exec',
       sandboxArgs,
@@ -557,10 +559,30 @@ async function execSeatbelt(
       'seatbelt',
       config.abortSignal,
       {
-        ...(fs.existsSync(config.workDir) ? { cwd: config.workDir } : {}),
+        ...(cwd ? { cwd } : {}),
         env: seatbeltEnvironment(config),
       },
     );
+    if (result.exitCode !== 0 && !result.timedOut && !config.abortSignal?.aborted) {
+      // Surface WHY: sandbox-exec's own stderr (profile compile errors) or the
+      // child's, plus the execution context. Without this a denied/crashed
+      // child looked like a bare "exit 1" and was undiagnosable from CI logs.
+      const roots = profile
+        .split('\n')
+        .filter((line) => line.startsWith('(allow file-write*'))
+        .map((line) => line.match(/\(subpath "([^"]+)"\)/)?.[1] ?? line)
+        .slice(0, 6);
+      const diag = `[seatbelt diag] exit=${result.exitCode} cwd=${cwd ?? '(unset)'} cmd=${[command, ...args].join(' ').slice(0, 200)} profile=${profile.split('\n').length} lines, writable roots: ${roots.join(' | ')}`;
+      result.stderr = result.stderr.trim() ? `${result.stderr.trimEnd()}\n${diag}` : diag;
+      logger.warn('Seatbelt sandbox command failed', {
+        exitCode: result.exitCode,
+        cwd,
+        command,
+        args,
+        stderr: result.stderr.slice(0, 2000),
+        profileHead: profile.split('\n').slice(0, 40).join('\n'),
+      });
+    }
     return result;
   } finally {
     // Clean up profile file
@@ -1243,12 +1265,18 @@ function execWithTimeout(
       proc.kill('SIGKILL');
     }, timeout);
 
-    proc.on('close', (code) => {
+    proc.on('close', (code, terminationSignal) => {
       clearTimeout(timer);
+      // A signal death (dyld abort, SIGKILL from the sandbox, …) has no exit
+      // code; say so instead of reporting a silent "exit 1".
+      const diagnostic =
+        code === null && terminationSignal && !timedOut
+          ? `${stderr}${stderr && !stderr.endsWith('\n') ? '\n' : ''}[sandbox:${backend}] child terminated by ${terminationSignal}`
+          : stderr;
       resolve({
         exitCode: code ?? 1,
         stdout,
-        stderr,
+        stderr: diagnostic,
         duration: Date.now() - startTime,
         timedOut,
         backend,

--- a/src/sandbox/os-sandbox.ts
+++ b/src/sandbox/os-sandbox.ts
@@ -159,15 +159,10 @@ export async function detectCapabilities(): Promise<SandboxCapabilities> {
     }
   }
 
-  // Check for seatbelt (macOS)
+  // Check for seatbelt (macOS): sandbox-exec is built into every macOS, so
+  // presence proves nothing — run a trivial command under the real profile.
   if (platform === 'darwin') {
-    try {
-      // sandbox-exec is built into macOS
-      const result = await execSimple('which', ['sandbox-exec']);
-      capabilities.seatbelt = result.exitCode === 0;
-    } catch {
-      capabilities.seatbelt = false;
-    }
+    capabilities.seatbelt = await probeSeatbelt();
   }
 
   // Check for Docker
@@ -294,52 +289,187 @@ async function execBubblewrap(
 // ============================================================================
 
 /**
- * Generate seatbelt profile for sandbox-exec
+ * Canonical form of a path for seatbelt rules. The kernel matches `subpath`
+ * against the resolved vnode path, so a rule written for `/var/folders/…` or
+ * `/tmp` never matches on macOS where those are symlinks to `/private/…`.
+ * Returns the lexical path and (when different) its realpath.
  */
-function generateSeatbeltProfile(config: OSSandboxConfig): string {
+function seatbeltPathForms(p: string): string[] {
+  const lexical = path.resolve(p);
+  const canonical = canonicalizeViaExistingAncestor(lexical);
+  return canonical === lexical ? [lexical] : [lexical, canonical];
+}
+
+/**
+ * Canonical form of a path whose leaf may not exist yet: realpath the nearest
+ * existing ancestor and re-append the rest (same helper shape as
+ * review-gate-helper.ts), so a not-yet-created `<workspace>/.git` or
+ * `.codebuddy` is still protected under the CANONICAL workspace root.
+ */
+function canonicalizeViaExistingAncestor(resolved: string): string {
+  const pending: string[] = [];
+  let cursor = resolved;
+  for (;;) {
+    try {
+      const real = fs.realpathSync(cursor);
+      return pending.length ? path.join(real, ...pending.reverse()) : real;
+    } catch {
+      const parent = path.dirname(cursor);
+      if (parent === cursor) return resolved;
+      pending.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+/**
+ * Secrets that stay unreadable inside the seatbelt sandbox even though reads
+ * are otherwise open. Aligned with `BLOCKED_PATHS` in
+ * src/workspace/workspace-isolation.ts and the `workspaceReadOnly` list of the
+ * Docker path (src/tools/bash/execution-policy.ts). Exported for tests.
+ */
+export function seatbeltUnreadablePaths(homeDir: string = os.homedir()): string[] {
+  return [
+    path.join(homeDir, '.ssh'),
+    path.join(homeDir, '.gnupg'),
+    path.join(homeDir, '.aws'),
+    path.join(homeDir, '.kube'),
+    path.join(homeDir, '.docker', 'config.json'),
+    path.join(homeDir, '.npmrc'),
+    path.join(homeDir, '.netrc'),
+    path.join(homeDir, '.config', 'gh', 'hosts.yml'),
+    path.join(homeDir, '.config', 'gcloud', 'credentials.db'),
+    path.join(homeDir, '.codebuddy', 'credentials.enc'),
+    '/etc/sudoers',
+    '/etc/security',
+  ];
+}
+
+function seatbeltQuote(p: string): string {
+  return `"${p.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Generate the seatbelt (sandbox-exec) profile.
+ *
+ * Shape follows the Codex CLI / Chromium profiles that are known to run on
+ * macOS 12–15: closed by default, reads allowed everywhere, writes limited to
+ * the canonicalized writable roots, network closed unless enabled.
+ *
+ * Why reads are not limited to `readOnlyPaths`: a macOS process cannot even
+ * `exec` without reading the dyld shared cache (`/System/…`,
+ * `/System/Volumes/Preboot/Cryptexes/…`), `/Library`, `/private/var/db`, and
+ * developer toolchains live under `/Users/*`, `/opt/homebrew`,
+ * `/Applications/Xcode.app`. There is no closed, portable "minimal system
+ * read set" on Darwin, so a deny-default read policy makes every command exit
+ * before it starts. Write confinement + no network is the property the
+ * workspace sandbox actually provides (same as Codex's `workspace-write`).
+ *
+ * `readOnlyPaths` that sit under a writable root (e.g. `<workspace>/.git`,
+ * `.codebuddy`) are carved out of the write grant with `require-not`, and
+ * re-denied explicitly so the protection does not depend on rule ordering.
+ *
+ * Asymmetry vs the Linux bubblewrap path, on purpose: bwrap runs on a tmpfs
+ * root with `HOME=/tmp`, so the child never sees the real home or the host
+ * temp dir. Seatbelt has no mount namespace — the child shares the host's
+ * real `/tmp`/`$TMPDIR` (writable scratch) and the real `$HOME` (readable).
+ * The credential files and directories in `seatbeltUnreadablePaths()` are
+ * therefore explicitly denied (read AND write) after the broad read allow;
+ * SBPL gives later rules precedence, and the deny is written for both the
+ * lexical and canonical spelling of each path.
+ */
+export function generateSeatbeltProfile(config: OSSandboxConfig): string {
   const rules: string[] = [
     '(version 1)',
+    '',
+    '; Code Buddy workspace sandbox. Inspired by the Codex CLI and Chromium',
+    '; seatbelt policies: closed by default, read-everywhere, write-confined.',
     '(deny default)',
     '',
-    '; Allow basic operations',
-    '(allow process-fork)',
-    '(allow process-exec)',
-    '(allow signal (target self))',
+    '; Reads: see generateSeatbeltProfile() — Darwin has no minimal read set',
+    '(allow file-read*)',
     '',
-    '; Allow sysctl reads',
+    '; …except credentials (shared real $HOME — see the asymmetry note above)',
+    ...seatbeltUnreadablePaths()
+      .flatMap(seatbeltPathForms)
+      .flatMap((secret) => [
+        `(deny file-read* file-write* (subpath ${seatbeltQuote(secret)}))`,
+        `(deny file-read* file-write* (literal ${seatbeltQuote(secret)}))`,
+      ]),
+    '',
+    '; Child processes inherit the policy of their parent',
+    '(allow process-exec)',
+    '(allow process-fork)',
+    '(allow signal (target same-sandbox))',
+    '(allow process-info* (target same-sandbox))',
+    '',
+    '; sysctls (hw.*, kern.osversion, … — used by every runtime at startup)',
     '(allow sysctl-read)',
     '',
-    '; Allow reading system files',
+    '; user/group lookups (getpwuid, ~ expansion, whoami)',
+    '(allow mach-lookup (global-name "com.apple.system.opendirectoryd.libinfo"))',
+    '',
+    '; devices',
+    '(allow file-write* (literal "/dev/null"))',
+    '(allow file-ioctl (literal "/dev/null"))',
+    '(allow pseudo-tty)',
+    '(allow file-read* file-write* file-ioctl (literal "/dev/ptmx"))',
+    '(allow file-ioctl (regex #"^/dev/ttys[0-9]+"))',
+    '',
+    '; Writable roots (lexical + canonical forms)',
   ];
 
-  // Read-only paths
-  for (const p of config.readOnlyPaths) {
-    rules.push(`(allow file-read* (subpath "${p}"))`);
+  const readOnly = config.readOnlyPaths.flatMap(seatbeltPathForms);
+  const writable = new Set<string>();
+  for (const p of [...config.readWritePaths, config.workDir]) {
+    for (const form of seatbeltPathForms(p)) writable.add(form);
+  }
+  // Scratch space is always writable (the Codex workspace-write default).
+  for (const p of ['/tmp', os.tmpdir()]) {
+    for (const form of seatbeltPathForms(p)) writable.add(form);
   }
 
-  // Read-write paths
-  for (const p of config.readWritePaths) {
-    rules.push(`(allow file-read* file-write* (subpath "${p}"))`);
+  for (const root of writable) {
+    const protectedBelow = readOnly.filter(
+      (ro) => ro === root || ro.startsWith(root.endsWith('/') ? root : `${root}/`)
+    );
+    if (protectedBelow.length === 0) {
+      rules.push(`(allow file-write* (subpath ${seatbeltQuote(root)}))`);
+      continue;
+    }
+    const exclusions = protectedBelow
+      .filter((ro) => ro !== root)
+      .flatMap((ro) => [
+        `(require-not (subpath ${seatbeltQuote(ro)}))`,
+        `(require-not (literal ${seatbeltQuote(ro)}))`,
+      ]);
+    if (protectedBelow.includes(root)) continue; // whole root is read-only
+    rules.push(
+      `(allow file-write* (require-all (subpath ${seatbeltQuote(root)}) ${exclusions.join(' ')}))`
+    );
   }
 
-  // Working directory
-  rules.push(`(allow file-read* file-write* (subpath "${config.workDir}"))`);
-
-  // Temp directory
-  rules.push('(allow file-read* file-write* (subpath "/tmp"))');
-  rules.push('(allow file-read* file-write* (subpath "/private/tmp"))');
-
-  // Allow reading /dev/null, /dev/random, etc.
-  rules.push('(allow file-read* (literal "/dev/null"))');
-  rules.push('(allow file-read* (literal "/dev/random"))');
-  rules.push('(allow file-read* (literal "/dev/urandom"))');
-  rules.push('(allow file-write* (literal "/dev/null"))');
+  const protectedSubpaths = readOnly.filter((ro) =>
+    [...writable].some((root) => ro !== root && ro.startsWith(root.endsWith('/') ? root : `${root}/`))
+  );
+  if (protectedSubpaths.length > 0) {
+    rules.push('');
+    rules.push('; Protected metadata stays read-only even inside writable roots');
+    for (const ro of protectedSubpaths) {
+      rules.push(`(deny file-write* (subpath ${seatbeltQuote(ro)}))`);
+      rules.push(`(deny file-write* (literal ${seatbeltQuote(ro)}))`);
+    }
+  }
 
   // Network
   if (config.allowNetwork) {
     rules.push('');
     rules.push('; Allow network access');
     rules.push('(allow network*)');
+    rules.push('(allow system-socket)');
+    rules.push(
+      '(allow mach-lookup (global-name "com.apple.SecurityServer") (global-name "com.apple.networkd") (global-name "com.apple.trustd.agent") (global-name "com.apple.SystemConfiguration.DNSConfiguration") (global-name "com.apple.SystemConfiguration.configd"))'
+    );
   }
 
   // Subprocess
@@ -350,6 +480,52 @@ function generateSeatbeltProfile(config: OSSandboxConfig): string {
   }
 
   return rules.join('\n');
+}
+
+/** Environment handed to the seatbelt child (mirrors the bubblewrap path). */
+function seatbeltEnvironment(config: OSSandboxConfig): Record<string, string> {
+  return {
+    HOME: process.env.HOME || os.homedir(),
+    PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
+    TMPDIR: os.tmpdir(),
+    TERM: process.env.TERM || 'xterm',
+    CODEBUDDY_CLI: process.env.CODEBUDDY_CLI || '1',
+    CODEBUDDY_CLI_VERSION: process.env.CODEBUDDY_CLI_VERSION || '',
+    ...sanitizeEnvVars(config.env),
+  };
+}
+
+/**
+ * Probe that `sandbox-exec` can actually run a trivial command under a
+ * REPRESENTATIVE profile. `which sandbox-exec` alone produced false
+ * positives: the binary exists on every macOS, so a profile that cannot exec
+ * (or a host that forbids sandbox-exec) turned every otherwise-valid command
+ * into an exit-1 failure — the same trap the bubblewrap probe guards against.
+ *
+ * The probe config mirrors what `createSandboxConfigForMode('workspace-write')`
+ * emits (a writable root with a protected `.git` below it), so every rule
+ * shape of the real profile — `require-all`/`require-not`, the explicit
+ * denies, the secret read denies — must compile and run. Any failure ⇒ the
+ * backend is reported unavailable (fail-closed, callers escalate explicitly).
+ */
+export function seatbeltProbeConfig(): OSSandboxConfig {
+  const scratch = os.tmpdir();
+  return {
+    ...DEFAULT_CONFIG,
+    workDir: scratch,
+    readWritePaths: [scratch],
+    readOnlyPaths: ['/usr', '/bin', path.join(scratch, '.git'), path.join(scratch, '.codebuddy')],
+  };
+}
+
+async function probeSeatbelt(): Promise<boolean> {
+  const profile = generateSeatbeltProfile(seatbeltProbeConfig());
+  try {
+    const result = await execSimple('sandbox-exec', ['-p', profile, '/usr/bin/true']);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -364,8 +540,8 @@ async function execSeatbelt(
   const profile = generateSeatbeltProfile(config);
 
   // Write profile to temp file
-  const profilePath = path.join(os.tmpdir(), `grok-sandbox-${Date.now()}.sb`);
-  fs.writeFileSync(profilePath, profile);
+  const profilePath = path.join(os.tmpdir(), `grok-sandbox-${Date.now()}-${process.pid}.sb`);
+  fs.writeFileSync(profilePath, profile, { mode: 0o600 });
 
   try {
     const sandboxArgs = [
@@ -380,6 +556,10 @@ async function execSeatbelt(
       config.timeout,
       'seatbelt',
       config.abortSignal,
+      {
+        ...(fs.existsSync(config.workDir) ? { cwd: config.workDir } : {}),
+        env: seatbeltEnvironment(config),
+      },
     );
     return result;
   } finally {
@@ -1032,6 +1212,7 @@ function execWithTimeout(
   timeout: number,
   backend: SandboxBackend,
   signal?: AbortSignal,
+  spawnOptions: { cwd?: string; env?: Record<string, string> } = {},
 ): Promise<OSSandboxResult> {
   return new Promise((resolve) => {
     const startTime = Date.now();
@@ -1039,6 +1220,8 @@ function execWithTimeout(
     const options: SpawnOptions = {
       stdio: ['ignore', 'pipe', 'pipe'],
       ...(signal ? { signal } : {}),
+      ...(spawnOptions.cwd ? { cwd: spawnOptions.cwd } : {}),
+      ...(spawnOptions.env ? { env: spawnOptions.env } : {}),
     };
 
     const proc = spawn(command, args, options);
@@ -1075,14 +1258,19 @@ function execWithTimeout(
 
     proc.on('error', (err) => {
       clearTimeout(timer);
+      // An AbortSignal cancellation surfaces as an 'error' (AbortError) on the
+      // child: the sandbox did isolate the command, the caller cancelled it.
+      // Reporting `sandboxed: false` here made every abort look like a backend
+      // refusal and escalated it to an approval prompt.
+      const aborted = Boolean(signal?.aborted);
       resolve({
         exitCode: 1,
-        stdout: '',
-        stderr: err.message,
+        stdout: aborted ? stdout : '',
+        stderr: aborted ? 'Command aborted by user' : err.message,
         duration: Date.now() - startTime,
         timedOut: false,
         backend,
-        sandboxed: false,
+        sandboxed: aborted,
       });
     });
   });

--- a/src/security/env-blocklist.ts
+++ b/src/security/env-blocklist.ts
@@ -54,6 +54,17 @@ export const BLOCKED_ENV_PREFIXES: string[] = [
 ];
 
 /**
+ * Exact names that are exempt from the prefix block. They only DISABLE
+ * interactive prompts (Code Buddy sets them itself in
+ * CONTROLLED_SUBPROCESS_ENV) and carry no injection surface, unlike
+ * GIT_DIR / GIT_SSH_COMMAND / NPM_CONFIG_REGISTRY which stay blocked.
+ */
+export const ALLOWED_ENV_OVERRIDES: Set<string> = new Set([
+  'GIT_TERMINAL_PROMPT',
+  'NPM_CONFIG_YES',
+]);
+
+/**
  * Returns a new env object with all blocked variables removed.
  * Logs a debug message for each variable that is stripped.
  */
@@ -66,7 +77,8 @@ export function sanitizeEnvVars(env: Record<string, string>): Record<string, str
       continue;
     }
 
-    const prefixBlocked = BLOCKED_ENV_PREFIXES.some((prefix) => key.startsWith(prefix));
+    const prefixBlocked =
+      !ALLOWED_ENV_OVERRIDES.has(key) && BLOCKED_ENV_PREFIXES.some((prefix) => key.startsWith(prefix));
     if (prefixBlocked) {
       logger.debug(`Blocked env var (prefix match): ${key}`);
       continue;

--- a/src/security/policy-engine.ts
+++ b/src/security/policy-engine.ts
@@ -139,7 +139,10 @@ export class PolicyEngine {
 
   private isSecretsOrDeployment(detail?: Record<string, unknown>): boolean {
     if (!detail) return false;
-    const pathStr = String(detail.path || '').toLowerCase();
+    // macOS canonicalizes /var, /tmp and /etc under `/private/…` — that system
+    // prefix is not a "private key" path. Without this, every command whose cwd
+    // is the realpath of $TMPDIR (/private/var/folders/…) needed approval.
+    const pathStr = String(detail.path || '').toLowerCase().replace(/^\/private(?=\/|$)/, '');
     const cmdStr = String(detail.command || '').toLowerCase();
     const peerIdStr = String(detail.peerId || '').toLowerCase();
 

--- a/src/tools/bash/execution-policy.ts
+++ b/src/tools/bash/execution-policy.ts
@@ -247,7 +247,11 @@ export async function executeInWorkspaceSandbox(
   timeout: number,
   signal?: AbortSignal,
 ): Promise<SandboxedExecution> {
-  const shellEnv = getShellEnvPolicy().buildEnv(getFilteredEnv());
+  // Same controlled overrides as the direct spawn path and the Docker path
+  // (CI=true, NO_COLOR=1, GIT_TERMINAL_PROMPT=0, …): the native sandbox used
+  // to receive only the policy-filtered env, so a sandboxed `printenv NO_COLOR`
+  // differed from a direct one.
+  const shellEnv = { ...getShellEnvPolicy().buildEnv(getFilteredEnv()), ...CONTROLLED_SUBPROCESS_ENV };
   const env = Object.fromEntries(
     Object.entries(shellEnv).filter(
       (entry): entry is [string, string] => typeof entry[1] === 'string'

--- a/tests/agent/tool-handler-code-exec-session.test.ts
+++ b/tests/agent/tool-handler-code-exec-session.test.ts
@@ -145,6 +145,7 @@ describe('ToolHandler code_exec logical-session isolation', () => {
     handler.restoreWorkingDirectory(realSessionB);
     handler.setRecoverySessionId('logical-session-b');
     const pwdB = await handler.executeTool(bashCall('pwd-b', 'pwd'));
+    if (!pwdB.success) console.error('[macos-diag] pwd in restored cwd', realSessionB, ':', pwdB.error);
     expect(pwdB.success).toBe(true);
     expect(pwdB.output).toContain(realSessionB);
     expect(pwdB.output).not.toContain(realSessionA);

--- a/tests/memory/enhanced-memory-recall.test.ts
+++ b/tests/memory/enhanced-memory-recall.test.ts
@@ -32,15 +32,16 @@ beforeEach(() => {
   // store() on a fresh HOME must no longer race ensureDir/loadMemories.
 });
 
-afterEach(() => {
+afterEach(async () => {
   try {
-    (memory as unknown as { dispose?: () => void })?.dispose?.();
+    memory?.dispose();
+    // dispose() kicks off a fire-and-forget saveAll(); wait for it to settle so
+    // the cleanup below never races the last write (ENOTEMPTY seen on macOS CI).
+    await memory?.flush();
   } catch {
     /* ignore */
   }
   memory = null;
-  // dispose() kicks off a fire-and-forget saveAll(); retry so a write landing
-  // mid-removal can't leave the cleanup with ENOTEMPTY (seen on macOS CI).
   fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 });
 

--- a/tests/sandbox/landlock-sandbox.test.ts
+++ b/tests/sandbox/landlock-sandbox.test.ts
@@ -226,14 +226,16 @@ describe('Landlock + Seccomp Sandbox', () => {
       mockPlatform.mockReturnValue('darwin');
 
       mockSpawn.mockImplementation((cmd: string, args: string[]) => {
-        if (cmd === 'which' && args[0] === 'sandbox-exec') {
-          return createMockProcess(0, '/usr/bin/sandbox-exec\n');
+        // Seatbelt is detected by a functional probe: `sandbox-exec -p <profile> /usr/bin/true`.
+        if (cmd === 'sandbox-exec' && args[0] === '-p') {
+          return createMockProcess(0);
         }
         return createMockProcess(1);
       });
 
       const caps = await detectCapabilities();
       expect(caps.landlock).toBe(false);
+      expect(caps.seatbelt).toBe(true);
       expect(caps.recommended).toBe('seatbelt');
     });
   });

--- a/tests/sandbox/seatbelt-profile.test.ts
+++ b/tests/sandbox/seatbelt-profile.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Seatbelt (macOS sandbox-exec) profile generation.
+ *
+ * Pure-function coverage: the profile must be runnable on Darwin (reads
+ * allowed, exec/fork allowed), confine writes to the CANONICAL writable roots
+ * (macOS `/var` → `/private/var`, `/tmp` → `/private/tmp`), and keep the
+ * protected metadata directories read-only inside a writable workspace.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  generateSeatbeltProfile,
+  seatbeltProbeConfig,
+  seatbeltUnreadablePaths,
+  type OSSandboxConfig,
+} from '../../src/sandbox/os-sandbox';
+
+function config(overrides: Partial<OSSandboxConfig>): OSSandboxConfig {
+  return {
+    workDir: process.cwd(),
+    readOnlyPaths: [],
+    readWritePaths: [],
+    allowNetwork: false,
+    allowSubprocess: true,
+    env: {},
+    timeout: 1000,
+    limits: {},
+    allowedDomains: [],
+    excludedCommands: [],
+    allowUnsandboxed: false,
+    ...overrides,
+  };
+}
+
+describe('generateSeatbeltProfile', () => {
+  let realRoot: string;
+  let linkRoot: string;
+
+  beforeAll(() => {
+    realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'seatbelt-real-')));
+    linkRoot = path.join(fs.realpathSync(os.tmpdir()), `seatbelt-link-${process.pid}-${Date.now()}`);
+    fs.symlinkSync(realRoot, linkRoot, 'dir');
+    fs.mkdirSync(path.join(realRoot, '.git'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(linkRoot, { force: true });
+    fs.rmSync(realRoot, { recursive: true, force: true });
+  });
+
+  it('is closed by default but lets a Darwin process start (reads + exec + fork)', () => {
+    const profile = generateSeatbeltProfile(config({}));
+    expect(profile.startsWith('(version 1)')).toBe(true);
+    expect(profile).toContain('(deny default)');
+    expect(profile).toContain('(allow file-read*)');
+    expect(profile).toContain('(allow process-exec)');
+    expect(profile).toContain('(allow process-fork)');
+    expect(profile).toContain('(allow sysctl-read)');
+    expect(profile).not.toContain('(allow network*)');
+    expect(profile).not.toContain('(deny process-fork)');
+  });
+
+  it('grants writes on both the lexical and the canonical form of a symlinked workspace', () => {
+    const profile = generateSeatbeltProfile(config({ workDir: linkRoot }));
+    expect(profile).toContain(`(subpath "${linkRoot}")`);
+    expect(profile).toContain(`(subpath "${realRoot}")`);
+    // scratch space stays writable
+    expect(profile).toContain(`(allow file-write* (subpath "/tmp"))`);
+  });
+
+  it('carves protected read-only metadata out of a writable root and re-denies it explicitly', () => {
+    const profile = generateSeatbeltProfile(
+      config({
+        workDir: linkRoot,
+        readWritePaths: [linkRoot],
+        readOnlyPaths: ['/usr', `${linkRoot}/.git`],
+      })
+    );
+    const gitReal = `${realRoot}/.git`;
+    expect(profile).toContain(
+      `(allow file-write* (require-all (subpath "${realRoot}") (require-not (subpath "${gitReal}")) (require-not (literal "${gitReal}"))))`
+    );
+    expect(profile).toContain(`(deny file-write* (subpath "${gitReal}"))`);
+    expect(profile).toContain(`(deny file-write* (subpath "${linkRoot}/.git"))`);
+    // an unrelated read-only system path never becomes a write grant
+    expect(profile).not.toContain('(allow file-write* (subpath "/usr"))');
+  });
+
+  it('denies credential reads in both spellings even though reads are otherwise open', () => {
+    const profile = generateSeatbeltProfile(config({}));
+    const allowIndex = profile.indexOf('(allow file-read*)');
+    for (const secret of seatbeltUnreadablePaths()) {
+      const denyLine = `(deny file-read* file-write* (subpath "${secret}"))`;
+      expect(profile).toContain(denyLine);
+      expect(profile).toContain(`(deny file-read* file-write* (literal "${secret}"))`);
+      // later rules win in SBPL: the deny must follow the broad allow
+      expect(profile.indexOf(denyLine)).toBeGreaterThan(allowIndex);
+    }
+    // the list is home-relative (so a symlinked $HOME gets both spellings via seatbeltPathForms)
+    expect(seatbeltUnreadablePaths(linkRoot)).toContain(path.join(linkRoot, '.ssh'));
+    expect(seatbeltUnreadablePaths(linkRoot)).toContain(path.join(linkRoot, '.codebuddy', 'credentials.enc'));
+  });
+
+  it('protects a not-yet-created .git under the canonical form of a symlinked root', () => {
+    const missingGit = `${linkRoot}/sub/.git`; // linkRoot/sub does not exist
+    const profile = generateSeatbeltProfile(
+      config({ workDir: linkRoot, readWritePaths: [linkRoot], readOnlyPaths: [missingGit] })
+    );
+    expect(profile).toContain(`(deny file-write* (subpath "${realRoot}/sub/.git"))`);
+    expect(profile).toContain(`(require-not (subpath "${realRoot}/sub/.git"))`);
+  });
+
+  it('probes with a representative workspace-write profile (carve-outs + denies present)', () => {
+    const probe = seatbeltProbeConfig();
+    const profile = generateSeatbeltProfile(probe);
+    const scratch = fs.realpathSync(os.tmpdir());
+    expect(profile).toContain('(require-all (subpath');
+    expect(profile).toContain(`(require-not (subpath "${scratch}/.git"))`);
+    expect(profile).toContain(`(deny file-write* (subpath "${scratch}/.git"))`);
+    expect(profile).toContain('(deny file-read* file-write* (subpath');
+    expect(profile).not.toContain('(allow file-write* (subpath "/usr"))');
+  });
+
+  it('opens the network and denies forking only when asked', () => {
+    const profile = generateSeatbeltProfile(config({ allowNetwork: true, allowSubprocess: false }));
+    expect(profile).toContain('(allow network*)');
+    expect(profile).toContain('(deny process-fork)');
+  });
+});

--- a/tests/security/env-blocklist.test.ts
+++ b/tests/security/env-blocklist.test.ts
@@ -17,6 +17,19 @@ describe('env-blocklist', () => {
       expect(result).toHaveProperty('PATH', '/usr/bin');
     });
 
+    it('keeps the prompt-disabling overrides GIT_TERMINAL_PROMPT / NPM_CONFIG_YES despite the prefix block', () => {
+      const result = sanitizeEnvVars({
+        GIT_TERMINAL_PROMPT: '0',
+        NPM_CONFIG_YES: 'true',
+        GIT_SSH_COMMAND: 'ssh -o ProxyCommand=evil',
+        NPM_CONFIG_REGISTRY: 'https://evil.example.com',
+      });
+      expect(result).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
+      expect(result).toHaveProperty('NPM_CONFIG_YES', 'true');
+      expect(result).not.toHaveProperty('GIT_SSH_COMMAND');
+      expect(result).not.toHaveProperty('NPM_CONFIG_REGISTRY');
+    });
+
     it('removes GIT_AUTHOR_NAME (prefix match) but keeps HOME', () => {
       const result = sanitizeEnvVars({
         GIT_AUTHOR_NAME: 'attacker',

--- a/tests/security/policy-engine.test.ts
+++ b/tests/security/policy-engine.test.ts
@@ -13,6 +13,25 @@ describe('PolicyEngine', () => {
     policyEngine.releaseKillSwitch();
   });
 
+  it('does not mistake the macOS /private system prefix for a secret path', () => {
+    // /private/var/folders/… is the realpath of $TMPDIR on macOS
+    expect(
+      policyEngine.evaluate({
+        capability: 'shell:safe',
+        risk: 'low',
+        detail: { command: 'pwd', path: '/private/var/folders/df/x/T/work' },
+      }).decision,
+    ).toBe('allow');
+    // a genuinely secret-looking path still needs approval
+    expect(
+      policyEngine.evaluate({
+        capability: 'shell:safe',
+        risk: 'low',
+        detail: { command: 'pwd', path: '/home/u/private-keys' },
+      }).decision,
+    ).toBe('needs_approval');
+  });
+
   it('should default to singleton instance', () => {
     const instance1 = PolicyEngine.getInstance();
     const instance2 = PolicyEngine.getInstance();

--- a/tests/tools/bash-execution-policy.test.ts
+++ b/tests/tools/bash-execution-policy.test.ts
@@ -31,6 +31,14 @@ describe('Bash runtime execution policy', () => {
     clearPermissionsCache();
   });
 
+  it('does not demand approval for a cwd under the macOS canonical /private prefix', async () => {
+    // After `cd $TMPDIR` the bash tool stores the realpath (/private/var/folders/…);
+    // that prefix must not turn a sandboxed `pwd` into an approval prompt.
+    await expect(
+      evaluateShellExecution('pwd', '/private/var/folders/df/x/T/code-buddy-work')
+    ).resolves.toMatchObject({ action: 'sandbox' });
+  });
+
   it('keeps read-only commands inside the workspace sandbox', async () => {
     await expect(evaluateShellExecution('cat README.md', process.cwd())).resolves.toMatchObject({
       action: 'sandbox',

--- a/tests/tools/bash-tool.test.ts
+++ b/tests/tools/bash-tool.test.ts
@@ -343,12 +343,14 @@ describe('BashTool', () => {
 
     it('should set NO_COLOR=1 in child process', async () => {
       const result = await bashTool.execute('printenv NO_COLOR');
+      if (!result.success) console.error('[macos-diag] printenv NO_COLOR:', result.error);
       expect(result.success).toBe(true);
       expect(result.output).toContain('1');
     });
 
     it('should set GIT_TERMINAL_PROMPT=0 in child process', async () => {
       const result = await bashTool.execute('printenv GIT_TERMINAL_PROMPT');
+      if (!result.success) console.error('[macos-diag] printenv GIT_TERMINAL_PROMPT:', result.error);
       expect(result.success).toBe(true);
       expect(result.output).toContain('0');
     });
@@ -495,6 +497,7 @@ describe('BashTool', () => {
     it('should execute commands in current working directory', async () => {
       await bashTool.execute(`cd ${tmpDir}`);
       const result = await bashTool.execute('pwd');
+      if (!result.success) console.error('[macos-diag] pwd after cd', tmpDir, '->', bashTool.getCurrentDirectory(), ':', result.error);
       expect(result.success).toBe(true);
       expect(result.output).toBeDefined();
     });


### PR DESCRIPTION
> Stacked on #87 (`fix/ci-macos-realpath`) — base set to that branch so the diff shows only the seatbelt change; retarget to `main` once #87 lands.

## Cause

On macOS every bash-tool command under the workspace sandbox exited 1 with empty output (`[sandbox:seatbelt; exit code 1]`, ~90 cases on the macOS CI job, run 32576529622). `which sandbox-exec` always succeeds on macOS, but the generated deny-default profile could not even exec `/bin/sh`: the dyld shared cache under `/System` was unreadable, the `/var/folders/…` write rule never matched its `/private/var` vnode path, and neither cwd nor env were passed to the child.

## Correctif (`src/sandbox/os-sandbox.ts`)

- **Profile** reshaped after the Codex CLI / Chromium seatbelt policies: `(deny default)`, reads open (Darwin has no closed minimal read set — dyld cache, frameworks, toolchains), writes confined to the **canonical** writable roots (lexical + realpath, resolved through the nearest existing ancestor so an absent `.git`/`.codebuddy` is still protected — review M1), protected subpaths carved out with `require-not` **and** re-denied explicitly, network closed unless enabled.
- **Credentials stay unreadable** despite the broad read allow (review A3): `seatbeltUnreadablePaths()` — `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`, `~/.docker/config.json`, `~/.npmrc`, `~/.netrc`, gh/gcloud creds, `~/.codebuddy/credentials.enc`, `/etc/sudoers`, `/etc/security` (aligned with `WorkspaceIsolation.BLOCKED_PATHS` and the Docker `workspaceReadOnly` list) — denied read+write in both spellings **after** the allow (later rules win in SBPL). The asymmetry vs bubblewrap (tmpfs root, `HOME=/tmp`) vs seatbelt (shared real tmp + HOME) is documented in the profile comment.
- **Functional probe** (review A4): the backend is only reported available after `sandbox-exec -p <profile> /usr/bin/true` succeeds under a **representative** profile (writable scratch root + protected `.git`/`.codebuddy` below it, so `require-all`/`require-not`/deny rule shapes must compile) — mirrors the existing bwrap probe; any failure ⇒ unavailable ⇒ callers take the existing explicit-escalation path (fail-closed).
- The child now gets `cwd = workDir` and the sanitized env (like bwrap); an `AbortSignal` cancellation no longer reports `sandboxed: false` (which escalated every abort into an approval prompt).
- Tests: new `tests/sandbox/seatbelt-profile.test.ts` (canonical write roots on a symlinked dir, carve-outs, absent-`.git` protection, secret denies positioned after the allow, probe-config shape, network/fork toggles); `tests/sandbox/landlock-sandbox.test.ts` "should not detect landlock on macOS" now mocks the probe (`sandbox-exec -p …` → 0) instead of `which` (review A1 — the old mock would have failed on every platform).

## Vérification

- `npx vitest run tests/sandbox/seatbelt-profile.test.ts tests/sandbox/landlock-sandbox.test.ts tests/sandbox/os-sandbox.test.ts tests/features/sandboxing-hooks.test.ts tests/tools/bash-streaming.test.ts tests/tools/bash-tool.test.ts tests/bash-tool.test.ts tests/tools/bash.test.ts tests/unit/tools-core.test.ts` → 9 files, 450 tests green (Linux; bwrap unavailable here so the bash tools exercise the escalation path exactly as CI Linux does).
- `npx tsc --noEmit -p tsconfig.json` clean; `npx eslint` on touched files: 0 errors.
- **Réserve : invérifiable depuis Linux** — `sandbox-exec` only exists on macOS. The profile is unit-tested and fail-safe (probe failure ⇒ backend unavailable ⇒ same path as today's Linux CI), so the macOS job should go green either way; the CI macOS run on this PR is the proof of whether seatbelt actually engages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)