### PR TITLE
fix(ci): windows — suite (9 fichiers restants)

### DIFF
--- a/src/agent/self-improvement/skill-mutator.ts
+++ b/src/agent/self-improvement/skill-mutator.ts
@@ -128,8 +128,7 @@ export interface MutationResult {
 
 /**
  * Rename a skill directory, tolerating the transient EPERM/EBUSY Windows
- * returns while a handle is still open inside it (the registry's
- * fire-and-forget `registerSkillFile` read, an indexer, an AV scan).
+ * returns while a handle is still open inside it (an indexer, an AV scan).
  */
 function renameDirWithRetry(from: string, to: string): void {
   const delaysMs = [10, 25, 50, 100, 200];
@@ -169,7 +168,13 @@ export class LiveSkillMutator implements SkillMutatorPort {
       getSkillRegistry().unload(name);
       return;
     }
-    void getSkillRegistry().registerSkillFile(file, 'workspace').catch(() => {});
+    // Synchronous: an async read still pending when archive()/restore() renames
+    // the directory right after makes that rename EPERM on Windows.
+    try {
+      getSkillRegistry().registerSkillFileSync(file, 'workspace');
+    } catch {
+      // A skill the registry refuses (scanner/validation) stays on disk, unloaded.
+    }
   }
 
   private readContent(name: string): string | null {

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -197,6 +197,23 @@ export class SkillRegistry extends EventEmitter {
     return skill;
   }
 
+  /**
+   * Synchronous twin of registerSkillFile for callers that immediately go on
+   * to move/remove the skill directory (the self-improvement mutator): no
+   * read handle is left pending on the event loop, which on Windows would make
+   * the subsequent directory rename fail with EPERM.
+   */
+  registerSkillFileSync(filePath: string, tier: SkillTier = 'workspace'): Skill {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const skill = parseSkillFile(content, filePath, tier);
+    const validation = validateSkill(skill);
+    if (!validation.valid) {
+      throw new Error(`Invalid skill: ${validation.errors.join(', ')}`);
+    }
+    this.registerSkill(skill);
+    return skill;
+  }
+
   // ==========================================================================
   // Retrieval
   // ==========================================================================

--- a/src/speculative/shadow-workspace.ts
+++ b/src/speculative/shadow-workspace.ts
@@ -5,7 +5,7 @@
  * @module speculative/shadow-workspace
  */
 
-import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -481,6 +481,15 @@ export class ShadowWorkspace {
           } catch {
             child.kill('SIGKILL');
           }
+        } else if (child.pid && process.platform === 'win32') {
+          // Kill the whole tree: `child.kill` only ends cmd.exe and leaves the
+          // validator running (holding the shadow directory open).
+          try {
+            spawnSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore', timeout: 5000 });
+          } catch {
+            // Fall through to the plain kill below.
+          }
+          child.kill('SIGKILL');
         } else {
           child.kill('SIGKILL');
         }

--- a/src/talk-mode/providers/pocket-tts.ts
+++ b/src/talk-mode/providers/pocket-tts.ts
@@ -45,7 +45,8 @@ const SAMPLE_RATE = 24000; // Pocket TTS emits 24 kHz mono WAV.
 
 /** A launcher from a command/path: a `…/uvx` needs the `pocket-tts` subcommand prefix. */
 function launcherFor(cmd: string): PocketLauncher {
-  return { command: cmd, argsPrefix: /(^|\/)uvx$/.test(cmd) ? ['pocket-tts'] : [] };
+  // `uvx`, `/abs/uvx`, `C:\…\uvx` or `uvx.exe` all launch Pocket through uvx.
+  return { command: cmd, argsPrefix: /(^|[\\/])uvx(\.exe)?$/i.test(cmd) ? ['pocket-tts'] : [] };
 }
 
 /**

--- a/tests/agent/tool-handler-code-exec-session.test.ts
+++ b/tests/agent/tool-handler-code-exec-session.test.ts
@@ -4,6 +4,11 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ToolHandler } from '../../src/agent/tool-handler.js';
+import { ConfirmationService } from '../../src/utils/confirmation-service.js';
+import {
+  approveSandboxUnavailableEscalations,
+  clearSandboxEscalationBridge,
+} from '../helpers/sandbox-escalation-bridge.js';
 import { clearAllCodeExecSessions } from '../../src/tools/code-exec-tool.js';
 import { getFormalToolRegistry } from '../../src/tools/registry/index.js';
 import type { ITool, IToolExecutionContext } from '../../src/tools/registry/types.js';
@@ -40,6 +45,9 @@ describe('ToolHandler code_exec logical-session isolation', () => {
   beforeEach(() => {
     clearAllCodeExecSessions();
     observedScopes.splice(0);
+    // The bash `pwd` below runs through the real ConfirmationService; hosts
+    // without a sandbox backend (Windows CI) escalate it to an exact grant.
+    approveSandboxUnavailableEscalations(ConfirmationService.getInstance());
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-exec-session-'));
     handler = new ToolHandler({
       checkpointManager: {
@@ -88,6 +96,7 @@ describe('ToolHandler code_exec logical-session isolation', () => {
   afterEach(() => {
     getFormalToolRegistry().unregister(PROBE_TOOL);
     clearAllCodeExecSessions();
+    clearSandboxEscalationBridge(ConfirmationService.getInstance());
     fs.rmSync(workDir, { recursive: true, force: true });
   });
 

--- a/tests/browser-automation/browser-operator-profile.test.ts
+++ b/tests/browser-automation/browser-operator-profile.test.ts
@@ -31,8 +31,10 @@ describe('Browser Operator persistent profile', () => {
     const resolved = resolvePersistentBrowserOperatorProfile(profile);
     expect(resolved).toBe(realpathSync(profile));
     expect(resolvePersistentBrowserOperatorProfile(profile)).toBe(resolved);
-    const mode = (await lstat(profile)).mode & 0o777;
-    expect(mode).toBe(0o700);
+    // POSIX mode bits only: Windows reports 0o666 whatever the chmod.
+    if (process.platform !== 'win32') {
+      expect((await lstat(profile)).mode & 0o777).toBe(0o700);
+    }
     const markerPath = join(profile, BROWSER_OPERATOR_PROFILE_MARKER);
     expect(JSON.parse(await readFile(markerPath, 'utf8'))).toMatchObject({
       schemaVersion: 1,

--- a/tests/helpers/sandbox-escalation-bridge.ts
+++ b/tests/helpers/sandbox-escalation-bridge.ts
@@ -1,0 +1,30 @@
+/**
+ * Test stand-in for the human who approves "run outside the workspace sandbox".
+ *
+ * On a host without any workspace sandbox backend (Windows without a Linux
+ * Docker daemon, a locked-down Linux without bwrap/docker), an ALLOWED command
+ * is escalated to an exact, human-approved grant — one the blanket
+ * `bashCommands` session flag deliberately does not cover, and which fails
+ * closed without a TTY ("Approval requires an interactive terminal"). Tests of
+ * command-execution semantics install this bridge so that ONLY that
+ * sandbox-unavailable escalation is approved; `ask`-policy commands (sudo, …)
+ * and sandbox-boundary denials still go through the real fail-closed path.
+ */
+import type { ConfirmationService } from '../../src/utils/confirmation-service.js';
+
+const SANDBOX_UNAVAILABLE = /\nBoundary: (No native or Docker workspace sandbox is available|Workspace sandbox unavailable)/;
+
+/** What the service answers without a TTY — kept verbatim so `ask` commands still read "Approval requires…". */
+const NO_TERMINAL_FEEDBACK = 'Approval requires an interactive terminal or configured remote approval channel';
+
+export function approveSandboxUnavailableEscalations(service: ConfirmationService): void {
+  service.setInteractiveBridge(async (options) =>
+    SANDBOX_UNAVAILABLE.test(options.content ?? '')
+      ? { confirmed: true }
+      : { confirmed: false, feedback: NO_TERMINAL_FEEDBACK },
+  );
+}
+
+export function clearSandboxEscalationBridge(service: ConfirmationService): void {
+  service.setInteractiveBridge(null);
+}

--- a/tests/sandbox/seatbelt-profile.test.ts
+++ b/tests/sandbox/seatbelt-profile.test.ts
@@ -34,7 +34,10 @@ function config(overrides: Partial<OSSandboxConfig>): OSSandboxConfig {
   };
 }
 
-describe('generateSeatbeltProfile', () => {
+// SBPL profiles are consumed by macOS sandbox-exec and embed POSIX paths
+// (`/tmp`, `<root>/.git`); the generator is never used on Windows, where the
+// `C:\…` forms would be meaningless. Pure-function coverage runs on POSIX hosts.
+describe.skipIf(process.platform === 'win32')('generateSeatbeltProfile', () => {
   let realRoot: string;
   let linkRoot: string;
 

--- a/tests/speculative/shadow-workspace.test.ts
+++ b/tests/speculative/shadow-workspace.test.ts
@@ -19,6 +19,9 @@ function createRepo(testRoot: string): string {
   git(repo, 'init', '-q');
   git(repo, 'config', 'user.email', 'shadow@example.test');
   git(repo, 'config', 'user.name', 'Shadow Test');
+  // Windows git defaults to core.autocrlf=true, which would check the shadow
+  // worktree out with CRLF and break the byte-exact content assertions.
+  git(repo, 'config', 'core.autocrlf', 'false');
   fs.writeFileSync(path.join(repo, 'tracked.txt'), 'committed-v1\n');
   git(repo, 'add', 'tracked.txt');
   git(repo, 'commit', '-m', 'initial');
@@ -46,7 +49,8 @@ describe('ShadowWorkspace', () => {
     delete process.env.CODEBUDDY_SHADOW_WORKSPACE;
     vi.restoreAllMocks();
     vi.doUnmock('../../src/speculative/shadow-workspace.js');
-    fs.rmSync(testRoot, { recursive: true, force: true });
+    // Retry: Windows may still hold a handle on a just-killed validator's cwd.
+    fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('creates lazily, writes proposals, and resyncs to the repository HEAD before each run', async () => {

--- a/tests/tools/bash-streaming.test.ts
+++ b/tests/tools/bash-streaming.test.ts
@@ -1,5 +1,9 @@
 import { BashTool } from '../../src/tools/bash';
 import { ConfirmationService } from '../../src/utils/confirmation-service.js';
+import {
+  approveSandboxUnavailableEscalations,
+  clearSandboxEscalationBridge,
+} from '../helpers/sandbox-escalation-bridge.js';
 
 describe('BashTool - Streaming Execution', () => {
   let bash: BashTool;
@@ -9,11 +13,15 @@ describe('BashTool - Streaming Execution', () => {
     // Auto-approve bash commands for tests
     const service = ConfirmationService.getInstance();
     service.setSessionFlag('bashCommands', true);
+    // Hosts without a sandbox backend (Windows CI) escalate every allowed
+    // command to an exact grant: stand in for the approving human.
+    approveSandboxUnavailableEscalations(service);
   });
 
   afterEach(() => {
     bash.dispose();
     const service = ConfirmationService.getInstance();
+    clearSandboxEscalationBridge(service);
     service.setSessionFlag('bashCommands', false);
   });
 

--- a/tests/tools/bash-tool.test.ts
+++ b/tests/tools/bash-tool.test.ts
@@ -21,6 +21,10 @@
 
 import { BashTool } from '../../src/tools/bash';
 import { ConfirmationService } from '../../src/utils/confirmation-service';
+import {
+  approveSandboxUnavailableEscalations,
+  clearSandboxEscalationBridge,
+} from '../helpers/sandbox-escalation-bridge.js';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -86,6 +90,9 @@ describe('BashTool', () => {
     confirmationService = ConfirmationService.getInstance();
     // Auto-approve bash commands for testing
     confirmationService.setSessionFlag('bashCommands', true);
+    // Hosts without a sandbox backend (Windows CI) escalate every allowed
+    // command to an exact grant: stand in for the approving human.
+    approveSandboxUnavailableEscalations(confirmationService);
 
     bashTool = new BashTool();
     jest.clearAllMocks();
@@ -94,6 +101,7 @@ describe('BashTool', () => {
   afterEach(() => {
     bashTool.dispose();
     if (confirmationService) {
+      clearSandboxEscalationBridge(confirmationService);
       confirmationService.dispose();
     }
     (ConfirmationService as unknown as { instance: ConfirmationService | undefined }).instance = undefined;


### PR DESCRIPTION
## Contexte
Après la PR #89 (58 → 9 fichiers rouges), run 32587500158 job « 22.x and windows-latest » : 43 cas dans 9 fichiers. Diagnostic cas par cas sur le log, même méthode.

## Diagnostic → correctif par fichier
| Fichier | Cas | Cause | Correctif |
|---|---|---|---|
| `tests/tools/bash-tool.test.ts` (29), `bash-streaming` (1), `agent/tool-handler-code-exec-session` (1) | 31 | Sans backend de sandbox (Windows sans Docker Linux), chaque commande **autorisée** est escaladée « Run command outside the workspace sandbox » avec `approvalKey` : le flag de session `bashCommands` ne couvre PAS cette approbation exacte (par design), et sans TTY le service échoue fermé (« Approval requires an interactive terminal »). Linux/macOS ne passent jamais par là (bwrap/docker/seatbelt). `tools-core`/`bash.test` passaient car ils mockent le service. | **TEST** : nouveau `tests/helpers/sandbox-escalation-bridge.ts` — un `interactiveBridge` qui remplace l'humain : approuve UNIQUEMENT l'escalade « sandbox indisponible » (match sur `Boundary: No native or Docker workspace sandbox is available / Workspace sandbox unavailable`), et répond le même refus fermé pour le reste (`sudo`/`chown`/`crontab` gardent « Approval requires »). |
| `agent/self-improvement/skill-mutator` (2), `skill-consolidator` (1) | 3 | EPERM rename malgré le retry : le `registerSkillFile` fire-and-forget fait un `fs.promises.readFile` dont la complétion/fermeture a besoin de l'event loop, que le retry synchrone bloque → le handle reste ouvert pendant tout le retry. | **CODE** : `SkillRegistry.registerSkillFileSync` (readFileSync) utilisé par `reload()` du mutateur — plus aucun handle en attente ; le retry reste en ceinture (indexeur/AV). |
| `speculative/shadow-workspace` (2) | 2 | (a) `committed-v2\r\n` : git Windows `autocrlf=true` checke le worktree fantôme en CRLF. (b) EBUSY rmdir au teardown : au timeout `child.kill` ne tue que cmd.exe, le validateur orphelin garde le dossier ouvert. | (a) **TEST** `core.autocrlf false` dans `createRepo`. (b) **CODE** `taskkill /pid /t /f` sur win32 au timeout + rm avec retries au teardown. |
| `sandbox/seatbelt-profile` (5) | 5 | Générateur SBPL macOS (sandbox-exec, chemins POSIX `/tmp`, `<root>/.git`) ; sous Windows les formes `C:\…` n'ont aucun sens et le test comparait des realpath 8.3. Jamais utilisé sous Windows. | **TEST** `describe.skipIf(win32)` commenté (couverture pure-fonction sur POSIX). |
| `talk-mode/providers/pocket-tts` (1) | 1 | `launcherFor` ne reconnaissait `uvx` que derrière `/` → sous Windows `…\uvx` n'avait pas `argsPrefix ['pocket-tts']`. | **CODE** regex `(^|[\\/])uvx(\.exe)?$`. |
| `browser-automation/browser-operator-profile` (1) | 1 | assertion de mode 0o700 (bits POSIX), démasquée par la correction précédente. | **TEST** gardée `platform !== 'win32'`. |

## Vérification
- Linux : `npx vitest run` sur les 9 fichiers + `tests/agent/self-improvement` + `tests/skills` → 55 fichiers / 718 tests verts (seatbelt tourne sur Linux, skip win32 seulement) ; `tsc --noEmit` ✅ ; eslint ✅ (0 erreur).
- **Réserve : non exécutable depuis Linux** — preuve = jobs windows-latest de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)