### PR TITLE
fix(ci): windows — cwd override (3 derniers cas)

### DIFF
--- a/src/protocols/acp/acp-session-store.ts
+++ b/src/protocols/acp/acp-session-store.ts
@@ -17,6 +17,26 @@ export interface AcpSessionStoreConfig {
   storeDir?: string;
 }
 
+/**
+ * Atomic replace with a short retry: on Windows a rename onto a file that
+ * another handle still has open (a concurrent `load`, an indexer) fails with
+ * EPERM/EBUSY for a few milliseconds instead of succeeding as on POSIX.
+ */
+async function renameWithRetry(from: string, to: string): Promise<void> {
+  const delaysMs = [10, 25, 50, 100, 200];
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fs.promises.rename(from, to);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const delay = delaysMs[attempt];
+      if ((code !== 'EPERM' && code !== 'EBUSY') || delay === undefined) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
 export class AcpSessionStore {
   private readonly dir: string;
 
@@ -73,7 +93,12 @@ export class AcpSessionStore {
     const file = this.fileFor(session.sessionId);
     const temp = `${file}.tmp.${Date.now()}-${Math.random().toString(36).slice(2)}`;
     await fs.promises.writeFile(temp, JSON.stringify(session, null, 2), 'utf-8');
-    await fs.promises.rename(temp, file);
+    try {
+      await renameWithRetry(temp, file);
+    } catch (err) {
+      await fs.promises.rm(temp, { force: true }).catch(() => {});
+      throw err;
+    }
   }
 
   private fileFor(sessionId: string): string {

--- a/src/protocols/acp/acp-stdio-server.ts
+++ b/src/protocols/acp/acp-stdio-server.ts
@@ -33,6 +33,7 @@
 import { randomUUID } from 'crypto';
 import type { Readable, Writable } from 'node:stream';
 import { AcpSessionStore } from './acp-session-store.js';
+import { logger } from '../../utils/logger.js';
 
 export const ACP_PROTOCOL_VERSION = 1;
 
@@ -225,17 +226,28 @@ export class AcpStdioServer {
     });
   }
 
+  /**
+   * Fire-and-forget persistence (`void this.persistSession(...)`): a failed
+   * write must be logged, never surface as an unhandled rejection.
+   */
   private async persistSession(sessionId: string): Promise<void> {
     const s = this.sessions.get(sessionId);
     if (!s) return;
-    await this.store.save({
-      sessionId,
-      cwd: s.cwd,
-      history: s.history,
-      mcpServers: s.mcpServers,
-      title: s.title,
-      updatedAt: s.updatedAt,
-    });
+    try {
+      await this.store.save({
+        sessionId,
+        cwd: s.cwd,
+        history: s.history,
+        mcpServers: s.mcpServers,
+        title: s.title,
+        updatedAt: s.updatedAt,
+      });
+    } catch (err) {
+      logger.warn?.('[acp] failed to persist session', {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private requestClient(

--- a/tests/agent/tool-handler-code-exec-session.test.ts
+++ b/tests/agent/tool-handler-code-exec-session.test.ts
@@ -9,6 +9,7 @@ import {
   approveSandboxUnavailableEscalations,
   clearSandboxEscalationBridge,
 } from '../helpers/sandbox-escalation-bridge.js';
+import { canonical, canonicalShellPath } from '../helpers/shell-path.js';
 import { clearAllCodeExecSessions } from '../../src/tools/code-exec-tool.js';
 import { getFormalToolRegistry } from '../../src/tools/registry/index.js';
 import type { ITool, IToolExecutionContext } from '../../src/tools/registry/types.js';
@@ -165,7 +166,8 @@ describe('ToolHandler code_exec logical-session isolation', () => {
     handler.restoreWorkingDirectory(realSessionA);
     handler.setRecoverySessionId('logical-session-a');
     const pwdA = await handler.executeTool(bashCall('pwd-a', 'pwd'));
-    expect(pwdA.output).toContain(realSessionA);
+    // `pwd` prints the shell's spelling (MSYS `/tmp/...` under Git Bash).
+    expect(canonicalShellPath(pwdA.output ?? '')).toBe(canonical(realSessionA));
     expect(handler.getRecoverySessionId()).toBe('logical-session-a');
     expect(process.cwd()).toBe(hostCwd);
   });

--- a/tests/helpers/shell-path.ts
+++ b/tests/helpers/shell-path.ts
@@ -1,0 +1,31 @@
+/**
+ * Compare a path printed by the bash tool's shell with a Node path.
+ *
+ * On Windows the tool runs commands through Git Bash, whose `pwd` prints the
+ * MSYS spelling (`/tmp/x`, `/c/Users/x`) — `fs.realpathSync` on that string
+ * resolves `/tmp` on the process drive and throws ENOENT. `shellPathToNative`
+ * converts the MSYS form back with `cygpath -w` (shipped with Git Bash), and
+ * `canonical` uses the native realpath so 8.3 short names (`RUNNER~1`) and
+ * long names compare equal. Both are identity functions on POSIX hosts.
+ */
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+
+export function shellPathToNative(shellPath: string): string {
+  const trimmed = shellPath.trim();
+  if (process.platform !== 'win32' || !trimmed.startsWith('/')) return trimmed;
+  try {
+    return execFileSync('bash', ['-c', 'cygpath -w "$1"', '_', trimmed], { encoding: 'utf8' }).trim();
+  } catch {
+    return trimmed;
+  }
+}
+
+export function canonical(target: string): string {
+  return fs.realpathSync.native(target);
+}
+
+/** `pwd` output from the tool, canonicalised for an equality check against a Node path. */
+export function canonicalShellPath(shellPath: string): string {
+  return canonical(shellPathToNative(shellPath));
+}

--- a/tests/protocols/acp/acp-agentic-turn.test.ts
+++ b/tests/protocols/acp/acp-agentic-turn.test.ts
@@ -21,8 +21,12 @@
  * its second call. That's a true round-trip, not a shape check.
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PassThrough } from 'stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AcpSessionStore } from '../../../src/protocols/acp/acp-session-store.js';
 
 import {
   AcpStdioServer,
@@ -51,6 +55,7 @@ class SimulatedEditor {
   readonly messages: Array<Record<string, any>> = [];
   readonly clientRequests: Array<Record<string, any>> = [];
   readonly server: AcpStdioServer;
+  readonly storeDir: string;
   /** Records of fs/read_text_file requests the agent made. */
   readonly reads: Array<Record<string, any>> = [];
   /** Records of fs/write_text_file requests the agent made. */
@@ -75,10 +80,13 @@ class SimulatedEditor {
         }
       }
     });
+    // Persist into a private temp store, not the runner's real ~/.codebuddy.
+    this.storeDir = mkdtempSync(join(tmpdir(), 'acp-agentic-turn-'));
     this.server = new AcpStdioServer({
       input: this.input,
       output: this.output,
       promptRunner: runner,
+      store: new AcpSessionStore({ storeDir: this.storeDir }),
       // Keep the pending-request timer short so nothing lingers.
       clientRequestTimeoutMs: 2_000,
     });
@@ -160,6 +168,7 @@ describe('ACP agentic tool-using turn (real server + simulated editor)', () => {
 
   afterEach(() => {
     editor?.server.stop();
+    if (editor) rmSync(editor.storeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('runs a real tool round-trip: tool_call → permission → fs/read → tool_call_update → end_turn', async () => {

--- a/tests/tools/bash-tool.test.ts
+++ b/tests/tools/bash-tool.test.ts
@@ -25,6 +25,7 @@ import {
   approveSandboxUnavailableEscalations,
   clearSandboxEscalationBridge,
 } from '../helpers/sandbox-escalation-bridge.js';
+import { canonical, canonicalShellPath } from '../helpers/shell-path.js';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -130,7 +131,7 @@ describe('BashTool', () => {
 
     it('streams in the cwd override too (the path Cowork actually uses)', async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bash-stream-cwd-'));
-      const real = fs.realpathSync(dir);
+      const real = canonical(dir);
       const gen = bashTool.executeStreaming('pwd', 30000, dir);
       let out = '';
       let r = await gen.next();
@@ -140,19 +141,21 @@ describe('BashTool', () => {
       }
       const final = r.value;
       expect(final.success).toBe(true);
-      expect(fs.realpathSync((out || final.output || '').trim())).toBe(real);
+      // `pwd` prints the shell's spelling (MSYS `/tmp/...` under Git Bash).
+      expect(canonicalShellPath(out || final.output || '')).toBe(real);
       fs.rmSync(dir, { recursive: true, force: true });
     });
 
     it('runs in the cwd override when provided (embedded session workingDirectory)', async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bash-cwd-'));
-      const real = fs.realpathSync(dir);
+      const real = canonical(dir);
       const result = await bashTool.execute('pwd', 30000, dir);
       expect(result.success).toBe(true);
-      expect(fs.realpathSync(result.output!.trim())).toBe(real);
+      // `pwd` prints the shell's spelling (MSYS `/tmp/...` under Git Bash).
+      expect(canonicalShellPath(result.output!)).toBe(real);
       // Sans override : comportement historique (process cwd), pas le tmpdir.
       const legacy = await bashTool.execute('pwd');
-      expect(fs.realpathSync(legacy.output!.trim())).not.toBe(real);
+      expect(canonicalShellPath(legacy.output!)).not.toBe(real);
       fs.rmSync(dir, { recursive: true, force: true });
     });
 


### PR DESCRIPTION
## Contexte
Après PR #90 (9 → 2 fichiers rouges), run 32588902764 : 3 cas + **6 « Unhandled Rejection »** (qui font échouer le run vitest même à 0 test rouge).

## Diagnostic → correctif
| Cas | Cause | Correctif |
|---|---|---|
| `tests/tools/bash-tool.test.ts` « runs in the cwd override » / « streams in the cwd override », `tests/agent/tool-handler-code-exec-session.test.ts` « owns cd state locally » | Sous Git Bash, `pwd` imprime la forme MSYS `/tmp/bash-cwd-xxx` (MSYS monte `%TEMP%` sur `/tmp`) : `fs.realpathSync(output)` résout `/tmp` sur le lecteur du process (`ENOENT D:\tmp`), et la chaîne ne contient jamais `C:\…`. La sortie de l'outil est la forme du shell, par design (pas de bug code). | **TEST** : nouveau `tests/helpers/shell-path.ts` — `shellPathToNative` (`cygpath -w` via bash, identité sur POSIX) + `canonical` (realpath natif, insensible aux noms 8.3) ; les 3 assertions comparent des chemins natifs canoniques. |
| 6 unhandled rejections `EPERM rename …acp-sessions/<id>.json.tmp… -> <id>.json` (originaires de `tests/protocols/acp/acp-agentic-turn.test.ts`) | `void this.persistSession()` ×4 dans `acp-stdio-server.ts` sans catch ; sous Windows le rename atomique du store sur un fichier encore ouvert par un autre handle échoue EPERM → rejection non gérée. Le test écrivait de plus dans le vrai `~/.codebuddy/acp-sessions` du runner. | **CODE** : `persistSession` journalise au lieu de rejeter (fire-and-forget ne doit jamais remonter) ; `AcpSessionStore.writeUnlocked` réessaie EPERM/EBUSY (10→200 ms) et nettoie son tmp ; **TEST** : store temporaire privé injecté (`storeDir`) + cleanup. |

## Vérification
Linux : `npx vitest run` bash-tool + tool-handler + acp-agentic-turn → verts (107 + 5 tests) ; `tsc --noEmit` ✅ ; eslint ✅ (0 erreur). Réserve : non exécutable depuis Linux — preuve = jobs windows-latest de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)