### PR TITLE
fix(ci): windows — derniers cas Node 22 (migration-e2e, execute-code RPC)

### DIFF
--- a/tests/database/migration-e2e.test.ts
+++ b/tests/database/migration-e2e.test.ts
@@ -21,6 +21,24 @@ import { tmpdir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+// Real SQLite I/O (one fsync per commit, rollback journal, no WAL): an upgrade
+// takes ~3 s on Windows CI runners with ~5× jitter (0.8–4.4 s across runs) and
+// occasional I/O stall bursts — run 32590054137 (Node 22 job) spent 22 s in
+// each of two adjacent upgrades that the three previous runs finished in <5 s.
+// Give the e2e file the same 60 s budget as the other real-I/O suites and log
+// slow phases so a stall is attributable.
+vi.setConfig({ testTimeout: 60_000 });
+
+const SLOW_PHASE_MS = 5_000;
+async function initializeTimed(manager: { initialize(): Promise<void> }, label: string): Promise<void> {
+  const started = Date.now();
+  await manager.initialize();
+  const elapsed = Date.now() - started;
+  if (elapsed > SLOW_PHASE_MS) {
+    console.error(`[migration-e2e] slow ${label}.initialize(): ${elapsed}ms on ${process.platform}/node ${process.version}`);
+  }
+}
+
 // Probe the native module the same way tests/database.test.ts does:
 // skip the whole suite when better-sqlite3 isn't loadable at this Node ABI.
 let hasBetterSqlite3 = false;
@@ -176,7 +194,7 @@ describe.skipIf(!hasBetterSqlite3)('Database migration E2E (old install → curr
       const applied: number[] = [];
       manager.on('db:migration', (e: { version: number }) => applied.push(e.version));
 
-      await manager.initialize();
+      await initializeTimed(manager, 'manager');
 
       // Every migration after v1 was applied, in order
       const expected = [];
@@ -217,7 +235,7 @@ describe.skipIf(!hasBetterSqlite3)('Database migration E2E (old install → curr
       createOldInstallDb(dbPath, 1);
 
       const manager = new DatabaseManager({ dbPath, walMode: false });
-      await manager.initialize();
+      await initializeTimed(manager, 'manager');
       const db = manager.getDatabase();
 
       db.prepare(
@@ -240,7 +258,7 @@ describe.skipIf(!hasBetterSqlite3)('Database migration E2E (old install → curr
       const applied: number[] = [];
       manager.on('db:migration', (e: { version: number }) => applied.push(e.version));
 
-      await manager.initialize();
+      await initializeTimed(manager, 'manager');
 
       const expected = [];
       for (let v = 3; v <= SCHEMA_VERSION; v++) expected.push(v);
@@ -256,7 +274,7 @@ describe.skipIf(!hasBetterSqlite3)('Database migration E2E (old install → curr
       const applied: number[] = [];
       manager.on('db:migration', (e: { version: number }) => applied.push(e.version));
 
-      await manager.initialize();
+      await initializeTimed(manager, 'manager');
 
       expect(applied).toEqual([...Array(SCHEMA_VERSION).keys()].map(i => i + 1));
       expect(manager.getDatabaseStats().version).toBe(SCHEMA_VERSION);
@@ -268,13 +286,13 @@ describe.skipIf(!hasBetterSqlite3)('Database migration E2E (old install → curr
       createOldInstallDb(dbPath, 1);
 
       const first = new DatabaseManager({ dbPath, walMode: false });
-      await first.initialize();
+      await initializeTimed(first, 'first');
       first.close();
 
       const second = new DatabaseManager({ dbPath, walMode: false });
       const applied: number[] = [];
       second.on('db:migration', (e: { version: number }) => applied.push(e.version));
-      await second.initialize();
+      await initializeTimed(second, 'second');
 
       expect(applied).toEqual([]);
       expect(second.getDatabaseStats().version).toBe(SCHEMA_VERSION);

--- a/tests/tools/execute-code-tool-rpc.test.ts
+++ b/tests/tools/execute-code-tool-rpc.test.ts
@@ -48,7 +48,8 @@ describe('execute_code → tool RPC (opt-in, OFF by default)', () => {
   afterEach(async () => {
     delete process.env.CODEBUDDY_EXECUTE_CODE_TOOL_RPC;
     delete process.env.CODEBUDDY_EXECUTE_CODE_RPC_TOOLS;
-    await fs.rm(tempWorkspace, { recursive: true, force: true });
+    // Retry: a script killed on timeout may still hold its run dir on Windows.
+    await fs.rm(tempWorkspace, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('OFF by default: script RPC attempt is refused and no tool runs', async () => {
@@ -233,16 +234,27 @@ describe('execute_code → tool RPC (opt-in, OFF by default)', () => {
       "print('__RPC__:' + json.dumps(r))",
     ].join('\n');
 
+    const started = Date.now();
     const result: ExecuteCodeResult = await executeCode(
-      { language: 'python', code },
+      // 30 s own timeout (< the 60 s test budget): on a stall the interpreter
+      // is killed and the failure carries `execute_code timed out`, instead of
+      // a vitest timeout that leaves python polling and its run dir locked.
+      { language: 'python', code, timeoutMs: 30_000 },
       { rootDir: tempWorkspace, createId: nextId, rpcInvoke: invoke },
     );
+    const elapsed = Date.now() - started;
+    if (elapsed > 5_000) {
+      console.error(`[execute-code-rpc] slow python round-trip: ${elapsed}ms on ${process.platform}/node ${process.version}; stderr: ${result.stderr.slice(-500)}`);
+    }
 
-    expect(result.ok, result.error).toBe(true);
+    expect(result.ok, `${result.error}\n${result.stderr}`).toBe(true);
     const rpc = parseRpcLine(result.stdout);
     expect(rpc.ok).toBe(true);
     expect(rpc.output).toContain(secret);
-  });
+    // Real interpreter spawn + file-polling RPC: Windows CI runners jitter
+    // 1.2–3.5 s with occasional I/O stalls (20 s+ on run 32590054137 after
+    // three green runs) — same 60 s budget as the other real-I/O suites.
+  }, 60_000);
 });
 
 // ──────────────────────────────────────────────────────────────────
@@ -313,7 +325,8 @@ describe('CODEBUDDY_EXECUTE_CODE_RPC_TOOLS integration', () => {
   afterEach(async () => {
     delete process.env.CODEBUDDY_EXECUTE_CODE_TOOL_RPC;
     delete process.env.CODEBUDDY_EXECUTE_CODE_RPC_TOOLS;
-    await fs.rm(tempWorkspace, { recursive: true, force: true });
+    // Retry: a script killed on timeout may still hold its run dir on Windows.
+    await fs.rm(tempWorkspace, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('extraTools are unioned with the base allowlist', () => {


### PR DESCRIPTION
## Diagnostic (run 32590054137, job 22.x windows-latest)
Les 3 cas sont des **timeouts vitest (20 s)**, pas des assertions : `migration-e2e` « keeps FTS triggers functional » (23,2 s) et « upgrades a v2 install » (21,8 s), `execute-code-tool-rpc` « python round-trip » (20,0 s) + un EBUSY rmdir laissé par le python encore en polling.

**Ce n'est pas une régression Node 22** — mesuré sur les logs des 4 runs Windows :
| Run | Job | keeps FTS | upgrades v2 | python round-trip |
|---|---|---|---|---|
| 32581699885 (main) | 22.x | 4,4 s ✓ | 3,1 s ✓ | 3,5 s ✓ |
| 32587500158 (PR 89) | 22.x | 3,5 s ✓ | 3,4 s ✓ | 2,1 s ✓ |
| 32588902764 (PR 90) | 22.x | 0,8 s ✓ | 0,8 s ✓ | 1,7 s ✓ |
| 32590054137 (PR 91) | 22.x | **23,2 s ✗** | **21,8 s ✗** | **20,0 s ✗** |
| 32590054137 (PR 91) | 20.x | 2,4 s ✓ | 3,2 s ✓ | 1,2 s ✓ |

Gigue ×5 d'un run à l'autre sur les mêmes tests, et `SCHEMA_VERSION = 3` (trois migrations minuscules) : un upgrade à 22 s est un **stall I/O du runner** (fsync par commit en journal rollback, AV sur fichiers neufs), pas du travail. Deux tests DB adjacents + le round-trip python (spawn + RPC par fichiers) sont tombés dans la même rafale. Pas de différence de build better-sqlite3 (test 1 et 4 du même fichier : 2,7 s / 3,6 s, identiques à 20.x).

## Correctif (tests uniquement — rien à corriger dans le code)
- `tests/database/migration-e2e.test.ts` : `vi.setConfig({ testTimeout: 60_000 })` comme les autres suites real-I/O (`web-test-*-real`) ; chaque `initialize()` > 5 s est journalisé avec plateforme/node pour rendre un stall attribuable.
- `tests/tools/execute-code-tool-rpc.test.ts` : budget 60 s sur le round-trip python, `timeoutMs: 30_000` passé à `executeCode` (tue l'interpréteur et renvoie `execute_code timed out` au lieu d'un timeout vitest qui laisse python en polling et son run dir verrouillé → l'EBUSY), log des round-trips lents avec stderr, `rm` de teardown avec retries.

## Vérification
Linux : les 2 fichiers verts (27 tests) ; `tsc --noEmit` ✅ ; eslint ✅ (0 erreur). Réserve : non exécutable depuis Linux ; preuve = jobs windows-latest de la PR (et, sur un futur stall, la ligne `[migration-e2e] slow …` / `[execute-code-rpc] slow …` dira où le temps part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)