### PR TITLE
fix(ci): windows — acp-agentic-turn teardown (ENOTEMPTY)

### DIFF
--- a/src/protocols/acp/acp-stdio-server.ts
+++ b/src/protocols/acp/acp-stdio-server.ts
@@ -151,6 +151,8 @@ export class AcpStdioServer {
   private readonly pendingClientRequests = new Map<string, PendingClientRequest>();
   private readonly store: AcpSessionStore;
   private storeLoaded = false;
+  /** In-flight fire-and-forget persistSession() writes (see whenIdle()). */
+  private readonly pendingPersists = new Set<Promise<void>>();
   private clientCapabilities: AcpClientCapabilities = {};
   private nextClientRequestId = 0;
   private buffer = '';
@@ -230,23 +232,37 @@ export class AcpStdioServer {
    * Fire-and-forget persistence (`void this.persistSession(...)`): a failed
    * write must be logged, never surface as an unhandled rejection.
    */
-  private async persistSession(sessionId: string): Promise<void> {
+  private persistSession(sessionId: string): Promise<void> {
     const s = this.sessions.get(sessionId);
-    if (!s) return;
-    try {
-      await this.store.save({
-        sessionId,
-        cwd: s.cwd,
-        history: s.history,
-        mcpServers: s.mcpServers,
-        title: s.title,
-        updatedAt: s.updatedAt,
-      });
-    } catch (err) {
+    if (!s) return Promise.resolve();
+    const snapshot = {
+      sessionId,
+      cwd: s.cwd,
+      history: s.history,
+      mcpServers: s.mcpServers,
+      title: s.title,
+      updatedAt: s.updatedAt,
+    };
+    const write = this.store.save(snapshot).catch((err: unknown) => {
       logger.warn?.('[acp] failed to persist session', {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
+    });
+    this.pendingPersists.add(write);
+    void write.finally(() => this.pendingPersists.delete(write));
+    return write;
+  }
+
+  /**
+   * Resolves once every in-flight session write has settled (successfully or
+   * not). Callers that stop the server and then remove its store directory
+   * (tests, a tear-down) await this first: on Windows a write still holding
+   * `<id>.json.tmp` open makes the directory removal fail with ENOTEMPTY.
+   */
+  async whenIdle(): Promise<void> {
+    while (this.pendingPersists.size > 0) {
+      await Promise.allSettled([...this.pendingPersists]);
     }
   }
 

--- a/tests/protocols/acp/acp-agentic-turn.test.ts
+++ b/tests/protocols/acp/acp-agentic-turn.test.ts
@@ -166,9 +166,18 @@ const FS_WRITE_CAPS: AcpClientCapabilities = { fs: { readTextFile: true, writeTe
 describe('ACP agentic tool-using turn (real server + simulated editor)', () => {
   let editor: SimulatedEditor;
 
-  afterEach(() => {
-    editor?.server.stop();
-    if (editor) rmSync(editor.storeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  afterEach(async () => {
+    if (!editor) return;
+    // Stop, then wait for the fire-and-forget session writes to settle BEFORE
+    // removing the private store: on Windows an in-flight `<id>.json.tmp`
+    // makes `rm` fail with ENOTEMPTY. Cleanup is best effort — never a test failure.
+    editor.server.stop();
+    await editor.server.whenIdle();
+    try {
+      rmSync(editor.storeDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch (err) {
+      console.error('[acp-agentic-turn] store cleanup skipped:', err instanceof Error ? err.message : String(err));
+    }
   });
 
   it('runs a real tool round-trip: tool_call → permission → fs/read → tool_call_update → end_turn', async () => {


### PR DESCRIPTION
## Diagnostic
Job Windows 20.x du run de la PR #92 : `tests/protocols/acp/acp-agentic-turn.test.ts` (4 cas) — `ENOTEMPTY: directory not empty, rmdir C:\…\Temp\acp-agentic-turn-…`. Le store temporaire privé introduit en #91 est supprimé dans `afterEach` alors que des `persistSession()` fire-and-forget (écriture atomique `<id>.json.tmp` + retry EPERM jusqu'à 200 ms) sont encore en vol → un `.tmp` ouvert empêche le `rmdir` sous Windows.

## Correctif
- **Code** : `AcpStdioServer` suit ses `persistSession()` en vol (`pendingPersists`) et expose `whenIdle()` (résolu quand toutes les écritures en attente sont réglées, succès ou échec).
- **Test** : le teardown fait `server.stop()` → `await server.whenIdle()` → `rmSync(store, { recursive, force, maxRetries: 10, retryDelay: 100 })` dans un try/catch qui journalise — le nettoyage ne peut plus faire échouer un test.

## Vérification
Linux : `tests/protocols` verts ; `tsc --noEmit` ✅ ; eslint ✅ (0 erreur). Réserve : non exécutable depuis Linux ; preuve = jobs windows-latest de la PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)