### PR TITLE
fix(ci): windows — budget de test 60 s (stalls I/O) + ocr-tool

### DIFF
--- a/src/tools/ocr-tool.ts
+++ b/src/tools/ocr-tool.ts
@@ -36,11 +36,26 @@ export interface OCROptions {
  * Uses Tesseract OCR as the backend (must be installed on system)
  * Falls back to basic image analysis if Tesseract is not available
  */
+export interface OCRToolOptions {
+  /**
+   * Host platform driving the engine cascade (default `process.platform`).
+   * Injected so tests of the Tesseract CLI path can skip engine 1 — the
+   * Windows-native PowerShell OCR shells out for real (dynamic
+   * `import('child_process')` escapes the static mock) and would race them.
+   */
+  platform?: NodeJS.Platform;
+}
+
 export class OCRTool {
   private readonly supportedFormats = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tiff', '.tif', '.webp'];
   private readonly maxFileSizeMB = 50;
   private tesseractAvailable: boolean | null = null;
   private vfs = UnifiedVfsRouter.Instance;
+  private readonly platform: NodeJS.Platform;
+
+  constructor(options: OCRToolOptions = {}) {
+    this.platform = options.platform ?? process.platform;
+  }
 
   /**
    * Perform OCR on an image file
@@ -75,7 +90,7 @@ export class OCRTool {
 
       // Cascade order:
       // 1. Try Windows Runtime OCR if on Windows
-      if (process.platform === 'win32') {
+      if (this.platform === 'win32') {
         const winResult = await this.runWindowsNativeOCR(resolvedPath);
         if (winResult.success) {
           return winResult;

--- a/tests/tools/ocr-tool.test.ts
+++ b/tests/tools/ocr-tool.test.ts
@@ -15,12 +15,12 @@ jest.mock('../../src/services/vfs/unified-vfs-router.js', () => ({
   }
 }));
 
-// Mock child_process. We intentionally do NOT provide `exec`: the Windows-native
-// OCR engine (engine 1 of the cascade) does `const { exec } = await
-// import('child_process')` then `promisify(exec)`. Leaving `exec` undefined makes
-// `promisify(undefined)` throw synchronously, so engine 1 fails fast and the
-// cascade falls through. (Providing a no-op `exec` mock would instead create a
-// promisified function that never resolves and hangs the test.)
+// Mock child_process (static `spawn`/`execSync` imports). The Windows-native
+// OCR engine (engine 1 of the cascade) does a DYNAMIC `await import('child_process')`
+// that this mock does not reliably intercept — on a Windows host it shelled out
+// to a real PowerShell OCR (up to 15 s) and raced the `setImmediate`-timed
+// emissions below. The tool is therefore constructed with an explicit
+// non-Windows platform so the cascade starts at engine 2 on every host.
 const mockSpawn = jest.fn();
 const mockExecSync = jest.fn();
 jest.mock('child_process', () => ({
@@ -52,7 +52,7 @@ describe('OCRTool', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    tool = new OCRTool();
+    tool = new OCRTool({ platform: 'linux' });
     (tool as any).tesseractAvailable = null;
     
     // Default execSync to return empty string instead of buffer to avoid split errors

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,14 +84,19 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
-    testTimeout: 20000,
+    // windows-latest runners show I/O stall bursts: on 2026-08-22 three
+    // different real-I/O suites (migration-e2e, execute-code RPC, ocr-tool)
+    // each crossed 20 s once on a Windows job while finishing in < 5 s on
+    // every other run. Give Windows hosts a 60 s budget; Linux/macOS keep the
+    // historical 20 s / 30 s (a real hang still fails, just later).
+    testTimeout: process.platform === 'win32' ? 60000 : 20000,
     // Match the generous test timeout for setup/teardown hooks. Several suites do
     // heavy dynamic `import()` inside `beforeEach`; under the CPU/RAM pressure of a
     // full parallel run on constrained CI runners those imports occasionally cross
     // the Vitest default 10s hook timeout and fail spuriously (the same test passes
     // in ~3s in isolation). 30s removes the false timeout without masking a real
     // hang. See CI flakiness on macos-latest (3 vCPU / 7 GB).
-    hookTimeout: 30000,
+    hookTimeout: process.platform === 'win32' ? 60000 : 30000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Contexte
Troisième suite real-I/O en trois runs Windows à dépasser une fois les 20 s (migration-e2e, execute-code RPC, puis `ocr-tool` sur le run de #93 en 22.x) alors qu'elle tient < 5 s partout ailleurs : stalls I/O des runners windows-latest. On arrête le whack-a-mole.

## Changements
1. **`vitest.config.ts`** : `testTimeout` / `hookTimeout` à **60 s uniquement quand `process.platform === 'win32'`** (commentaire daté 22/08 ; Linux/macOS gardent 20 s / 30 s — un vrai blocage échoue toujours, plus tard).
2. **Budgets locaux** (`vi.setConfig`) vérifiés : suites real (60–120 s) cohérentes ; `app-server-real` (30 s) et `checkpoint-versioning` (10 s) gardent leur choix explicite (plus court que le global win32, volontairement).
3. **`ocr-tool`** — les 2 timeouts étaient une **course**, pas seulement un stall : l'engine 1 de la cascade (OCR natif Windows) fait un `await import('child_process')` **dynamique** que le mock statique n'intercepte pas → sur un hôte Windows il lance un vrai PowerShell OCR (timeout 15 s) et les émissions stdout cadencées par `setImmediate` sont perdues (batchOCR : 1 spawn en 1 s ; extractRegion : blocage). **Code** : `OCRTool` accepte `{ platform }` (défaut `process.platform`, comme l'injection de plateforme de #87) ; **test** : `new OCRTool({ platform: 'linux' })` → la cascade démarre à l'engine 2 sur tout hôte ; commentaire du mock corrigé.

## Vérification
Linux : ocr-tool + misc-tools-part2 verts ; `tsc --noEmit` ✅ ; eslint ✅ (0 erreur). Réserve : non exécutable depuis Linux ; preuve = jobs windows-latest de la PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)