### PR TITLE
fix(ci): windows — forks stables (worker exited unexpectedly)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -127,7 +127,16 @@ export default defineConfig({
       ...(RUN_REAL_TESTS ? [] : ['**/*real*.test.ts']),
     ],
     pool: 'forks',
-    execArgv: ['--max-old-space-size=8192'],
+    // Per-fork V8 heap ceiling. On windows-latest (7 GB RAM, 2 CI forks) the
+    // 8 GB ceiling over-subscribes physical memory: the Node 20 Windows job of
+    // the PR #95 run ended with "[vitest-pool]: Worker forks emitted error /
+    // Worker exited unexpectedly" — 1596 files passed, 0 failed, one file
+    // (tests/unit/hybrid-search-semantic, pure, 2.2 s in the 8 earlier runs)
+    // never reported: its fork died mid-run, outside any test. 4 GB per fork
+    // keeps two forks inside the runner's RAM and turns a runaway heap into a
+    // visible V8 "heap out of memory" instead of a silent OS kill.
+    // Linux/macOS keep 8 GB.
+    execArgv: [`--max-old-space-size=${process.platform === 'win32' ? 4096 : 8192}`],
     // Bound worker concurrency on CI only. The default is one worker per CPU, and
     // each fork carries an 8 GB heap ceiling — on GitHub's constrained runners
     // (esp. macos-latest: 3 vCPU / 7 GB) that over-subscribes RAM, causing swap


### PR DESCRIPTION
## Diagnostic (run de #95, job Windows 20.x)
`Unhandled Error: [vitest-pool]: Worker forks emitted error … Caused by: Worker exited unexpectedly`, avec **1596 fichiers passés, 0 FAIL**. Dans vitest 4 cette erreur n'est levée que si un fichier est encore assigné au fork qui meurt : **1596 passés + 7 skipped = 1603 sur 1604 collectés** → un fichier n'a jamais rendu son résultat : `tests/unit/hybrid-search-semantic.test.ts` (seul absent du log ; BM25 pur + embeddings mockés, 26 tests, **2,2 s dans les 8 runs Windows précédents**). Le fork est donc mort en plein vol pour une raison extérieure au test : deux forks CI (`maxWorkers: 2`) avec chacun un plafond V8 de **8 Go sur un runner de 7 Go**. Aucun `FATAL ERROR … heap` dans le log (un refus de commit mémoire côté Windows tue sans message). Pas de `taskkill /t` sur l'arbre parent : celui du shadow-workspace (#90) vise le seul pid du cmd.exe enfant — vérifié. Pas de crash natif attribuable (le fichier fautif n'en charge aucun).

## Correctif
`vitest.config.ts` : `execArgv: ['--max-old-space-size=4096']` **uniquement quand `process.platform === 'win32'`** (Linux/macOS gardent 8192) ; `maxWorkers: 2` sur CI inchangé. Deux forks tiennent dans la RAM du runner, et une fuite de heap devient un `heap out of memory` visible au lieu d'un kill silencieux. (`memoryLimit`/recyclage de fork n'existe que pour `vmForks`/`vmThreads` dans vitest 4.1 — pas applicable au pool `forks`.)

## Vérification
Linux : config chargée, `hybrid-search-semantic` vert ; `tsc --noEmit` ✅ ; eslint ✅. Réserve : non exécutable depuis Linux ; preuve = jobs windows-latest de la PR (si un fork meurt encore, le log montrera désormais le FATAL V8 plutôt qu'une mort silencieuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)