### PR TITLE
feat(providers): enrôler OmniRoute dans le registre actif

### DIFF
--- a/docs/providers/omniroute-free-catalog.md
+++ b/docs/providers/omniroute-free-catalog.md
@@ -2,6 +2,8 @@
 
 > Généré par `python3 scripts/providers/import-omniroute-free-catalog.py --curated` (source : paquet npm global `omniroute` 3.8.49, MIT). Les 24 entrées « curées » sont dans `src/providers/provider-catalog.ts` (priorité 300, actives seulement si `<ID>_API_KEY` est posé). OmniRoute lui-même est aussi un provider (`omniroute`, gateway local `http://localhost:20128/v1`, profil `buddy --profile omniroute`). **Paliers gratuits = à vérifier live avant de s'y fier ; re-lancer le script pour rafraîchir.**
 
+> **Registre actif / flotte (23/08/2026).** Le gateway est enrôlé comme un runtime local : la `capability-registry` sonde `GET {OMNIROUTE_BASE_URL}/v1/models` (défaut `http://127.0.0.1:20128`, timeout 800 ms, silencieux si absent — bearer `OMNIROUTE_API_KEY` si posé). S'il répond, `buildActiveLlmRegistry` l'active (`auto/best-free` ou `OMNIROUTE_MODEL`, coût 0, **`isLocal: false` / egress `cloud`** : le proxy tourne sur la machine mais l'inférence part chez les fournisseurs — exclu de `localOnly`), et le pool du council (`CODEBUDDY_COUNCIL_POOL=full`) l'étend aux combos `auto/*` puis aux ids servis (plafonnés comme un runtime). Gateway absent ⇒ rien ne change.
+
 
 | id | nom | baseURL | palier gratuit | modèles (extrait) | clé |
 |---|---|---|---|---|---|

--- a/src/fleet/capability-registry.ts
+++ b/src/fleet/capability-registry.ts
@@ -15,6 +15,8 @@
  *   4. Local Ollama daemon — best-effort `GET http://127.0.0.1:11434/api/tags`
  *      (fails silently when Ollama isn't running)
  *   5. Local LM Studio — best-effort `GET http://127.0.0.1:1234/v1/models`
+ *   6. Local OmniRoute gateway — best-effort `GET {OMNIROUTE_BASE_URL}/v1/models`
+ *      (loopback proxy to 90+ cloud free tiers → advertised with `cloud` egress)
  *
  * The registry is **opportunistic** — it only advertises providers
  * that are actually reachable at boot time. A 5-min refresh keeps
@@ -136,6 +138,10 @@ async function buildCapabilitySnapshot(): Promise<PeerCapability> {
   // Layer 5 — local Lemonade Server (OpenAI-compatible, Ryzen NPU/GPU/CPU).
   const lemonadeModels = await probeLemonade();
   models.push(...lemonadeModels);
+
+  // Layer 6 — local OmniRoute gateway (OpenAI-compatible, $0, cloud egress).
+  const omnirouteModels = await probeOmniRoute();
+  models.push(...omnirouteModels);
 
   const egress: PeerCapability['egress'] = models.some((model) => model.egress === 'cloud')
     ? 'cloud' // any cloud key present → peer is a cloud-egress peer
@@ -593,6 +599,58 @@ async function probeLemonade(): Promise<FleetModelDescriptor[]> {
       }));
   } catch (error) {
     logger.debug?.('[capability-registry] Lemonade probe skipped', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+/** Default OmniRoute endpoint (`omniroute serve`), mirrors the provider catalog. */
+const DEFAULT_OMNIROUTE_BASE_URL = 'http://127.0.0.1:20128';
+const OMNIROUTE_PROBE_TIMEOUT_MS = 800;
+
+/**
+ * Turn an OmniRoute base URL (HOST:PORT, with or without `/v1`) into its
+ * `/v1/models` endpoint. Exported for the unit tests.
+ */
+export function omnirouteModelsUrl(baseURL: string | undefined): string {
+  let host = (baseURL ?? '').trim() || DEFAULT_OMNIROUTE_BASE_URL;
+  if (!/^https?:\/\//i.test(host)) host = `http://${host}`;
+  host = host.replace(/\/+$/, '').replace(/\/v1$/i, '');
+  return `${host}/v1/models`;
+}
+
+/**
+ * Probe a local OmniRoute gateway. OmniRoute is a loopback OpenAI-compatible
+ * proxy that fans out to 90+ cloud free tiers, so its models are advertised
+ * with `cloud` egress (the process is local, the inference is not) at $0.
+ * Best-effort: short timeout, never throws — an absent gateway costs nothing.
+ */
+async function probeOmniRoute(): Promise<FleetModelDescriptor[]> {
+  const url = omnirouteModelsUrl(process.env.OMNIROUTE_BASE_URL);
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), OMNIROUTE_PROBE_TIMEOUT_MS);
+    const apiKey = process.env.OMNIROUTE_API_KEY?.trim();
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const data = (await res.json()) as { data?: Array<{ id?: unknown }> };
+    if (!Array.isArray(data.data)) return [];
+    return data.data
+      .filter((model): model is { id: string } => typeof model.id === 'string' && model.id.length > 0)
+      .map((model): FleetModelDescriptor => ({
+        id: model.id,
+        contextWindow: 32_768,
+        strengths: deriveStrengths(model.id, 'omniroute'),
+        provider: 'omniroute',
+        egress: 'cloud',
+      }));
+  } catch (error) {
+    logger.debug?.('[capability-registry] OmniRoute probe skipped', {
       error: error instanceof Error ? error.message : String(error),
     });
     return [];

--- a/src/fleet/model-inventory.ts
+++ b/src/fleet/model-inventory.ts
@@ -240,6 +240,8 @@ function providerExecutionLocation(provider: FleetProvider): ModelExecutionLocat
   if (provider === 'chatgpt-oauth' || provider === 'anthropic' || provider === 'openai' || provider === 'gemini' || provider === 'grok' || provider === 'mistral') {
     return 'cloud';
   }
+  // OmniRoute listens on loopback but routes inference to cloud free tiers.
+  if (provider === 'omniroute') return 'cloud';
   return 'local';
 }
 

--- a/src/fleet/types.ts
+++ b/src/fleet/types.ts
@@ -20,6 +20,7 @@ export type FleetProvider =
   | 'agy-cli'      // wraps Google Antigravity (cloud subscription)
   | 'ollama'
   | 'lemonade'     // local Ryzen NPU/GPU/CPU OpenAI-compatible server
+  | 'omniroute'    // local OpenAI-compatible gateway to 90+ free tiers (inference egress = cloud)
   | 'openrouter'
   | 'lm-studio'
   | 'chatgpt-oauth'

--- a/src/providers/active-llm-model-pool.ts
+++ b/src/providers/active-llm-model-pool.ts
@@ -87,7 +87,8 @@ async function probeSelectableModels(): Promise<Array<{ id: string; provider: st
         m.provider === 'ollama' ||
         m.provider === 'lm-studio' ||
         m.provider === 'lemonade' ||
-        m.provider === 'agy-cli',
+        m.provider === 'agy-cli' ||
+        m.provider === 'omniroute',
       )
       .map((m) => ({ id: m.id, provider: normalizeLocalProvider(m.provider) }));
   } catch {
@@ -117,7 +118,9 @@ export async function listActiveLlmModelPool(
   const seenCloud = new Set<string>();
   const seenLocalNames = new Set<string>();
   const maxLocal = Math.max(1, opts.maxLocalPerProvider ?? DEFAULT_MAX_LOCAL_PER_PROVIDER);
-  const discoveredModels = base.some((c) => c.isLocal || c.provider === 'agy-cli')
+  const discoveredModels = base.some(
+    (c) => c.isLocal || c.provider === 'agy-cli' || c.provider === 'omniroute',
+  )
     ? await probeSelectableModels()
     : [];
 
@@ -126,7 +129,17 @@ export async function listActiveLlmModelPool(
     // The registry's resolved default (env override included) always seats first.
     const catalogModels = active.provider === 'agy-cli'
       ? discoveredModels.filter((m) => m.provider === 'agy-cli').map((m) => m.id)
-      : (findRuntimeProvider(active.provider)?.models ?? []);
+      : active.provider === 'omniroute'
+        // OmniRoute: the curated `auto/*` routing combos first, then the ids the
+        // gateway actually serves (capped like a probed runtime — it can list 100+).
+        ? [
+          ...(findRuntimeProvider('omniroute')?.models ?? []),
+          ...discoveredModels
+            .filter((m) => m.provider === 'omniroute')
+            .map((m) => m.id)
+            .slice(0, maxLocal),
+        ]
+        : (findRuntimeProvider(active.provider)?.models ?? []);
     for (const model of [defaultEntry.model, ...catalogModels]) {
       const key = `${active.provider}:${model}`.toLowerCase();
       if (seenCloud.has(key)) continue;

--- a/src/providers/active-llm-registry.ts
+++ b/src/providers/active-llm-registry.ts
@@ -67,6 +67,7 @@ const APPROX_COST_USD_PER_MTOK: Record<string, number> = {
   ollama: 0,
   lemonade: 0,
   lmstudio: 0,
+  omniroute: 0,
   'gemini-cli': 0,
   grok: 0.5,
   gemini: 0.3,
@@ -81,6 +82,22 @@ function canonicalProviderId(provider: string | undefined | null): string | unde
   return findRuntimeProvider(provider)?.id ?? provider.trim().toLowerCase();
 }
 
+/**
+ * Catalog providers that are only ACTIVE when their endpoint/CLI actually
+ * answered the capability probe (a stale env var or default port must never
+ * occupy a failover slot or a council seat): the on-box runtimes, the
+ * Antigravity CLI and the OmniRoute gateway.
+ */
+const PROBED_RUNTIME_PROVIDERS = new Set(['ollama', 'lmstudio', 'lemonade', 'agy-cli', 'omniroute']);
+
+/**
+ * Local gateways: `authMode: 'local'` in the catalog (loopback endpoint, no
+ * key) but the inference leaves the machine — OmniRoute proxies to cloud free
+ * tiers. They are probed like runtimes yet reported as NOT local so the
+ * privacy escape hatches (`localOnly`) never route through them.
+ */
+const LOCAL_GATEWAY_PROVIDERS = new Set(['omniroute']);
+
 /** Local runtimes that actually responded to a probe → their first real
  * installed model (reuses the fleet capability registry's Ollama/LM Studio
  * HTTP probes; `probeOllama` sets `id` to the actual model name). */
@@ -91,10 +108,7 @@ async function getReachableRuntimeModels(force?: boolean): Promise<Map<string, s
     const caps = await getLocalCapabilities({ force });
     for (const m of caps.models) {
       const id = canonicalProviderId(m.provider);
-      if (
-        (id === 'ollama' || id === 'lmstudio' || id === 'lemonade' || id === 'agy-cli') &&
-        !map.has(id)
-      ) {
+      if (id && PROBED_RUNTIME_PROVIDERS.has(id) && !map.has(id)) {
         map.set(id, m.id);
       }
     }
@@ -137,7 +151,9 @@ function toActiveLlm(
   resolved: ResolvedRuntimeProvider,
   entry: RuntimeProviderCatalogEntry | undefined,
 ): ActiveLlm {
-  const isLocal = (entry?.authMode ?? resolved.authMode) === 'local';
+  const isLocal =
+    (entry?.authMode ?? resolved.authMode) === 'local' &&
+    !LOCAL_GATEWAY_PROVIDERS.has(resolved.provider);
   const resolvedModel = resolved.defaultModel;
   const isFreeOpenRouterModel =
     resolved.provider === 'openrouter' &&
@@ -220,7 +236,8 @@ export async function buildActiveLlmRegistry(
       resolved = { ...resolved, defaultModel: realModel };
     }
 
-    const isLocal = (entry.authMode ?? resolved.authMode) === 'local';
+    const isGateway = LOCAL_GATEWAY_PROVIDERS.has(entry.id);
+    const isLocal = (entry.authMode ?? resolved.authMode) === 'local' && !isGateway;
     if (opts.localOnly && !isLocal) continue;
     // The catalog reports a local provider as "configured" even when it isn't
     // running — only keep locals we actually probed as reachable, and use their
@@ -230,6 +247,11 @@ export async function buildActiveLlmRegistry(
       if (!realModel) continue;
       resolved = { ...resolved, defaultModel: realModel };
     }
+    // A local gateway (OmniRoute) is active only when its `/v1/models` answered;
+    // its resolved model (env override or the catalog's `auto/best-free` combo)
+    // is kept — the gateway routes any of its ids, unlike a runtime whose
+    // catalog default may not be installed.
+    if (isGateway && !reachableRuntimeModels.has(entry.id)) continue;
 
     const key = `${canonicalProviderId(resolved.provider)}:${resolved.baseURL.replace(/\/+$/, '')}`;
     if (seen.has(key)) continue;

--- a/src/providers/model-egress.ts
+++ b/src/providers/model-egress.ts
@@ -1,11 +1,17 @@
 export type ModelEgress = 'local' | 'lan' | 'cloud';
 
+/**
+ * Providers whose PROCESS/endpoint is local but whose inference is not: the
+ * subscription CLIs (child process on the box, model in the cloud) and the
+ * OmniRoute gateway (loopback proxy that fans out to cloud free tiers).
+ */
 const CLOUD_SUBPROCESS_PROVIDERS = new Set([
   'agy-cli',
   'gemini-cli',
   'chatgpt',
   'chatgpt-oauth',
   'grok-oauth',
+  'omniroute',
 ]);
 
 function isPrivateIpv4(hostname: string): boolean {

--- a/tests/fleet/capability-registry.test.ts
+++ b/tests/fleet/capability-registry.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/utils/logger.js', () => ({
 
 import {
   getLocalCapabilities,
+  omnirouteModelsUrl,
   parseAgyModelsOutput,
   resetCapabilityCache,
 } from '../../src/fleet/capability-registry';
@@ -53,6 +54,8 @@ function clearProviderEnv() {
     'AGY_CLI_PATH',
     'LEMONADE_HOST',
     'LEMONADE_API_KEY',
+    'OMNIROUTE_BASE_URL',
+    'OMNIROUTE_API_KEY',
     'OPENROUTER_API_KEY',
   ]) {
     delete process.env[k];
@@ -311,6 +314,90 @@ describe('capability-registry — Lemonade probe', () => {
     const lemonade = cap.models.filter((model) => model.provider === 'lemonade');
     expect(lemonade.map((model) => model.id)).toContain('Qwen3.6-35B-A3B-MTP-GGUF');
     expect(cap.egress).toBe('local');
+  });
+});
+
+describe('capability-registry — OmniRoute gateway probe', () => {
+  it('enrols the gateway models when /v1/models answers, with cloud egress (inference leaves the box)', async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url) === 'http://127.0.0.1:20128/v1/models') {
+        return new Response(JSON.stringify({
+          data: [
+            { id: 'auto/best-free' },
+            { id: 'nvidia/nemotron-3-nano' },
+            { id: 42 }, // junk id → dropped
+          ],
+        }), { status: 200 });
+      }
+      throw new Error('econn');
+    }) as unknown as typeof fetch;
+
+    const cap = await getLocalCapabilities();
+    const omni = cap.models.filter((model) => model.provider === 'omniroute');
+    expect(omni.map((model) => model.id)).toEqual(['auto/best-free', 'nvidia/nemotron-3-nano']);
+    expect(omni.every((model) => model.egress === 'cloud')).toBe(true);
+    expect(cap.egress).toBe('cloud');
+  });
+
+  it('stays silent when the gateway is absent (connection refused)', async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error('ECONNREFUSED 127.0.0.1:20128');
+    }) as unknown as typeof fetch;
+
+    const cap = await getLocalCapabilities();
+    expect(cap.models.filter((model) => model.provider === 'omniroute')).toEqual([]);
+    expect(cap.egress).toBe('local');
+  });
+
+  it('stays silent on an HTTP error or a malformed body', async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes(':20128/v1/models')) {
+        return new Response('upstream exploded', { status: 502 });
+      }
+      throw new Error('econn');
+    }) as unknown as typeof fetch;
+    expect((await getLocalCapabilities({ force: true })).models.filter((m) => m.provider === 'omniroute')).toEqual([]);
+
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes(':20128/v1/models')) {
+        return new Response('not json', { status: 200 });
+      }
+      throw new Error('econn');
+    }) as unknown as typeof fetch;
+    expect((await getLocalCapabilities({ force: true })).models.filter((m) => m.provider === 'omniroute')).toEqual([]);
+
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes(':20128/v1/models')) {
+        return new Response(JSON.stringify({ models: ['wrong-shape'] }), { status: 200 });
+      }
+      throw new Error('econn');
+    }) as unknown as typeof fetch;
+    expect((await getLocalCapabilities({ force: true })).models.filter((m) => m.provider === 'omniroute')).toEqual([]);
+  });
+
+  it('honours OMNIROUTE_BASE_URL (HOST:PORT or /v1 form) and sends the bearer when OMNIROUTE_API_KEY is set', async () => {
+    process.env.OMNIROUTE_BASE_URL = 'omni.lan:20128/v1/';
+    process.env.OMNIROUTE_API_KEY = 'sk-omni';
+    const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url) === 'http://omni.lan:20128/v1/models') {
+        return new Response(JSON.stringify({ data: [{ id: 'auto/best-free' }] }), { status: 200 });
+      }
+      throw new Error('econn');
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const cap = await getLocalCapabilities();
+    expect(cap.models.filter((model) => model.provider === 'omniroute').map((m) => m.id)).toEqual(['auto/best-free']);
+    const call = fetchSpy.mock.calls.find((c) => String(c[0]).includes('omni.lan'));
+    expect(call).toBeDefined();
+    expect((call![1] as RequestInit | undefined)?.headers).toEqual({ Authorization: 'Bearer sk-omni' });
+  });
+
+  it('omnirouteModelsUrl normalises scheme, trailing slash and /v1', () => {
+    expect(omnirouteModelsUrl(undefined)).toBe('http://127.0.0.1:20128/v1/models');
+    expect(omnirouteModelsUrl('localhost:20128')).toBe('http://localhost:20128/v1/models');
+    expect(omnirouteModelsUrl('http://localhost:20128/v1')).toBe('http://localhost:20128/v1/models');
+    expect(omnirouteModelsUrl('https://gw.example/v1/')).toBe('https://gw.example/v1/models');
   });
 });
 

--- a/tests/providers/active-llm-model-pool.test.ts
+++ b/tests/providers/active-llm-model-pool.test.ts
@@ -131,6 +131,87 @@ describe('listActiveLlmModelPool — cloud expansion', () => {
   });
 });
 
+describe('listActiveLlmModelPool — OmniRoute gateway expansion', () => {
+  function omniroute(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return active({
+      provider: 'omniroute',
+      model: 'auto/best-free',
+      apiKey: 'omniroute',
+      baseURL: 'http://localhost:20128/v1',
+      costInputUsdPerMtok: 0,
+      isLocal: false, // loopback gateway, cloud inference
+      ...over,
+    });
+  }
+
+  it('seats the resolved default, then the curated auto/* combos, then the ids the gateway serves — all $0, cloud egress', async () => {
+    buildActiveLlmRegistry.mockResolvedValue({ all: [omniroute()] });
+    findRuntimeProvider.mockImplementation((id: string) =>
+      id === 'omniroute' ? { models: ['auto/best-free', 'auto/best-coding'] } : undefined,
+    );
+    getLocalCapabilities.mockResolvedValue({
+      models: [
+        { id: 'auto/best-free', provider: 'omniroute' }, // dup of the default → dropped
+        { id: 'nvidia/nemotron-3-nano', provider: 'omniroute' },
+        { id: 'qwen3:8b', provider: 'ollama' }, // not enrolled: ollama isn't active here
+      ],
+    });
+
+    const pool = await listActiveLlmModelPool({ env: {} });
+
+    expect(pool.map((p) => p.model)).toEqual([
+      'auto/best-free',
+      'auto/best-coding',
+      'nvidia/nemotron-3-nano',
+    ]);
+    for (const entry of pool) {
+      expect(entry.provider).toBe('omniroute');
+      expect(entry.apiKey).toBe('omniroute');
+      expect(entry.baseURL).toBe('http://localhost:20128/v1');
+      expect(entry.costInputUsdPerMtok).toBe(0);
+      expect(entry.egress).toBe('cloud');
+    }
+  });
+
+  it('caps the ids discovered from the gateway (it can list 100+), keeping the curated combos', async () => {
+    buildActiveLlmRegistry.mockResolvedValue({ all: [omniroute()] });
+    findRuntimeProvider.mockImplementation((id: string) =>
+      id === 'omniroute' ? { models: ['auto/best-free'] } : undefined,
+    );
+    getLocalCapabilities.mockResolvedValue({
+      models: Array.from({ length: 40 }, (_, i) => ({ id: `vendor/model-${i}`, provider: 'omniroute' })),
+    });
+
+    const pool = await listActiveLlmModelPool({ env: {}, maxLocalPerProvider: 3 });
+    expect(pool.map((p) => p.model)).toEqual([
+      'auto/best-free',
+      'vendor/model-0',
+      'vendor/model-1',
+      'vendor/model-2',
+    ]);
+  });
+
+  it('survives a failing gateway probe (default combo still seated)', async () => {
+    buildActiveLlmRegistry.mockResolvedValue({ all: [omniroute()] });
+    findRuntimeProvider.mockReturnValue(undefined);
+    getLocalCapabilities.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const pool = await listActiveLlmModelPool({ env: {} });
+    expect(pool).toEqual([
+      expect.objectContaining({ provider: 'omniroute', model: 'auto/best-free', costInputUsdPerMtok: 0 }),
+    ]);
+  });
+
+  it('legacy registry pool mode keeps one omniroute entry (no expansion, no probe)', async () => {
+    buildActiveLlmRegistry.mockResolvedValue({ all: [omniroute()] });
+    findRuntimeProvider.mockReturnValue({ models: ['auto/best-free', 'auto/best-coding'] });
+
+    const pool = await listActiveLlmModelPool({ env: { CODEBUDDY_COUNCIL_POOL: 'registry' } });
+    expect(pool.map((p) => p.model)).toEqual(['auto/best-free']);
+    expect(getLocalCapabilities).not.toHaveBeenCalled();
+  });
+});
+
 describe('listActiveLlmModelPool — local expansion', () => {
   it('expands installed Lemonade models as local zero-cost candidates', async () => {
     buildActiveLlmRegistry.mockResolvedValue({

--- a/tests/providers/active-llm-registry-omniroute.test.ts
+++ b/tests/providers/active-llm-registry-omniroute.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Active-LLM registry — OmniRoute gateway enrolment.
+ *
+ * OmniRoute (`authMode: 'local'` in the catalog, loopback proxy to 90+ cloud
+ * free tiers) must behave like a probed runtime: ACTIVE only when its
+ * `/v1/models` answered, NEVER when the gateway is absent — but reported as
+ * NOT local (cloud inference) so privacy escape hatches skip it.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const getLocalCapabilities = vi.fn();
+vi.mock('../../src/fleet/capability-registry.js', () => ({
+  getLocalCapabilities: (...args: unknown[]) => getLocalCapabilities(...args),
+}));
+
+vi.mock('../../src/providers/codex-oauth.js', () => ({
+  hasCodexCredentials: () => false,
+}));
+
+vi.mock('../../src/providers/xai-oauth.js', () => ({
+  hasXaiCredentials: () => false,
+  getValidXaiAccessToken: async () => null,
+}));
+
+import { buildActiveLlmRegistry } from '../../src/providers/active-llm-registry.js';
+
+beforeEach(() => {
+  getLocalCapabilities.mockReset();
+  getLocalCapabilities.mockResolvedValue({ models: [] });
+});
+
+describe('buildActiveLlmRegistry — OmniRoute gateway', () => {
+  it('enrols omniroute when the gateway answered the probe: $0, cloud (not local), catalog default combo', async () => {
+    getLocalCapabilities.mockResolvedValue({
+      models: [
+        { id: 'auto/best-free', provider: 'omniroute', egress: 'cloud' },
+        { id: 'nvidia/nemotron-3-nano', provider: 'omniroute', egress: 'cloud' },
+      ],
+    });
+
+    const reg = await buildActiveLlmRegistry({ env: {} });
+    const omni = reg.all.find((p) => p.provider === 'omniroute');
+    expect(omni).toBeDefined();
+    expect(omni!.model).toBe('auto/best-free');
+    expect(omni!.baseURL).toBe('http://localhost:20128/v1');
+    expect(omni!.apiKey).toBe('omniroute');
+    expect(omni!.costInputUsdPerMtok).toBe(0);
+    expect(omni!.isLocal).toBe(false);
+    expect(omni!.priority).toBe(23);
+  });
+
+  it('keeps the OMNIROUTE_MODEL / OMNIROUTE_BASE_URL overrides (the gateway routes any id it lists)', async () => {
+    getLocalCapabilities.mockResolvedValue({
+      models: [{ id: 'auto/best-free', provider: 'omniroute', egress: 'cloud' }],
+    });
+
+    const reg = await buildActiveLlmRegistry({
+      env: {
+        OMNIROUTE_MODEL: 'auto/best-coding',
+        OMNIROUTE_BASE_URL: 'omni.lan:20128',
+        OMNIROUTE_API_KEY: 'sk-omni',
+      },
+    });
+    const omni = reg.all.find((p) => p.provider === 'omniroute');
+    expect(omni).toMatchObject({
+      model: 'auto/best-coding',
+      baseURL: 'http://omni.lan:20128/v1',
+      apiKey: 'sk-omni',
+    });
+  });
+
+  it('does NOT enrol omniroute when the gateway is absent (probe returned nothing)', async () => {
+    getLocalCapabilities.mockResolvedValue({ models: [] });
+    const reg = await buildActiveLlmRegistry({ env: { OMNIROUTE_BASE_URL: 'http://localhost:20128/v1' } });
+    expect(reg.all.find((p) => p.provider === 'omniroute')).toBeUndefined();
+  });
+
+  it('does NOT enrol omniroute when the probe itself fails (never blocks the registry)', async () => {
+    getLocalCapabilities.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:20128'));
+    const reg = await buildActiveLlmRegistry({ env: {} });
+    expect(reg.all.find((p) => p.provider === 'omniroute')).toBeUndefined();
+  });
+
+  it('localOnly (privacy) excludes the gateway even when reachable — inference leaves the box', async () => {
+    getLocalCapabilities.mockResolvedValue({
+      models: [
+        { id: 'auto/best-free', provider: 'omniroute', egress: 'cloud' },
+        { id: 'qwen3:8b', provider: 'ollama', egress: 'local' },
+      ],
+    });
+
+    const reg = await buildActiveLlmRegistry({ env: {}, localOnly: true });
+    expect(reg.all.map((p) => p.provider)).toContain('ollama');
+    expect(reg.all.map((p) => p.provider)).not.toContain('omniroute');
+  });
+
+  it('resilience ordering: omniroute sits with the cloud providers, before the on-box runtimes', async () => {
+    getLocalCapabilities.mockResolvedValue({
+      models: [
+        { id: 'qwen3:8b', provider: 'ollama', egress: 'local' },
+        { id: 'auto/best-free', provider: 'omniroute', egress: 'cloud' },
+      ],
+    });
+
+    const reg = await buildActiveLlmRegistry({ env: { GROK_API_KEY: 'xai-k' } });
+    const order = reg.fallbacks.map((p) => p.provider);
+    expect(order.indexOf('omniroute')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('omniroute')).toBeLessThan(order.indexOf('ollama'));
+  });
+});

--- a/tests/providers/model-egress.test.ts
+++ b/tests/providers/model-egress.test.ts
@@ -11,6 +11,11 @@ describe('model egress classification', () => {
     expect(classifyProviderModelEgress('agy-cli', 'local://agy-cli', true)).toBe('cloud');
   });
 
+  it('treats the OmniRoute gateway as cloud egress even on loopback (it proxies to cloud free tiers)', () => {
+    expect(classifyModelEgress('http://localhost:20128/v1', true)).toBe('local');
+    expect(classifyProviderModelEgress('omniroute', 'http://localhost:20128/v1', true)).toBe('cloud');
+  });
+
   it('keeps actual loopback inference local and remote APIs cloud', () => {
     expect(classifyProviderModelEgress('ollama', 'http://127.0.0.1:11434', true)).toBe('local');
     expect(classifyProviderModelEgress('grok', 'https://api.x.ai/v1', false)).toBe('cloud');


### PR DESCRIPTION
## Résumé
Le provider `omniroute` (gateway local OpenAI-compatible `http://localhost:20128/v1`, PR #82) était dans `provider-catalog.ts` mais jamais dans le **registre des LLM actifs** ni dans le **pool de modèles** du council/fleet. Cette PR l'enrôle comme un runtime local (Ollama / LM Studio / Lemonade), sans rien changer quand le gateway est absent.

- `src/fleet/capability-registry.ts` — sonde `probeOmniRoute` : `GET {OMNIROUTE_BASE_URL}/v1/models` (défaut `127.0.0.1:20128`, HOST:PORT / `/v1` tolérés, timeout 800 ms, bearer `OMNIROUTE_API_KEY` si posé), **fail-silent** (connexion refusée, HTTP ≠ 2xx, JSON malformé ⇒ `[]`). Modèles publiés avec egress `cloud` (le proxy est local, l'inférence part chez les fournisseurs).
- `src/providers/active-llm-registry.ts` — omniroute actif **seulement si la sonde a répondu** (`PROBED_RUNTIME_PROVIDERS`), coût 0 $, `isLocal: false` (`LOCAL_GATEWAY_PROVIDERS`) donc exclu de `localOnly` ; modèle = `OMNIROUTE_MODEL` ou `auto/best-free`.
- `src/providers/active-llm-model-pool.ts` — expansion (`CODEBUDDY_COUNCIL_POOL=full`) : combos `auto/*` du catalogue puis les ids servis par le gateway, plafonnés via `maxLocalPerProvider` (il peut en lister 100+).
- `src/providers/model-egress.ts` — `omniroute` classé `cloud` même sur loopback ; `FleetProvider` (`src/fleet/types.ts`) + `model-inventory.ts` alignés.
- `docs/providers/omniroute-free-catalog.md` — note « registre actif / flotte ».

## Tests
- `tests/fleet/capability-registry.test.ts` — présent / absent / erreur HTTP / JSON malformé / URL normalisée + bearer.
- `tests/providers/active-llm-registry-omniroute.test.ts` (nouveau) — enrôlé si sondé, pas enrôlé si absent ou si la sonde échoue, overrides env, `localOnly` l'exclut, ordre de failover.
- `tests/providers/active-llm-model-pool.test.ts` — expansion combos + ids, plafond, sonde en échec, mode `registry`.
- `tests/providers/model-egress.test.ts` — loopback → cloud pour omniroute.

`tsc --noEmit` ✅ · `eslint` (fichiers touchés) ✅ · vitest ciblé : 62/62 + 127 tests voisins verts (model-selector, model-inventory, provider-catalog, fleet smoke, council bench…).

Ne pas merger sans relecture (mission : PR seulement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)