### PR TITLE
fix(ci): windows — suite en 3 shards consécutifs (worker exited unexpectedly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,27 @@ jobs:
       run: npm run lint
 
     - name: Run tests
+      if: runner.os != 'Windows'
       run: npm test
+
+    # Windows: run the suite as three consecutive shards (fresh vitest parent +
+    # fresh forks each time). On windows-latest the Node 20 job kept dying with
+    # "[vitest-pool]: Worker forks emitted error … Worker exited unexpectedly"
+    # (0 red tests, 1 file unreported — always the same file, the one the fork
+    # was on ~#377 of the size-ordered queue): a fork that has already run
+    # hundreds of files accumulates off-heap memory that --max-old-space-size
+    # cannot bound, and the OS kills it silently. Sharding caps how many files
+    # any single fork lives through (~535 instead of ~800) without changing
+    # what runs; Linux/macOS keep the single invocation.
+    - name: Run tests (shard 1/3)
+      if: runner.os == 'Windows'
+      run: npm test -- --shard=1/3
+    - name: Run tests (shard 2/3)
+      if: runner.os == 'Windows'
+      run: npm test -- --shard=2/3
+    - name: Run tests (shard 3/3)
+      if: runner.os == 'Windows'
+      run: npm test -- --shard=3/3
 
     - name: Build project
       run: npm run build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -135,7 +135,9 @@ export default defineConfig({
     // never reported: its fork died mid-run, outside any test. 4 GB per fork
     // keeps two forks inside the runner's RAM and turns a runaway heap into a
     // visible V8 "heap out of memory" instead of a silent OS kill.
-    // Linux/macOS keep 8 GB.
+    // Linux/macOS keep 8 GB. (The 4 GB cap alone was not enough — the fork still
+    // died with no V8 FATAL, i.e. off-heap growth; see the sharded Windows test
+    // steps in .github/workflows/ci.yml.)
     execArgv: [`--max-old-space-size=${process.platform === 'win32' ? 4096 : 8192}`],
     // Bound worker concurrency on CI only. The default is one worker per CPU, and
     // each fork carries an 8 GB heap ceiling — on GitHub's constrained runners


### PR DESCRIPTION
## Diagnostic (runs 20.x de #95 et #97 ×2)
`[vitest-pool]: Worker forks emitted error … Worker exited unexpectedly`, 0 test rouge, **1 fichier sur 1605 jamais rendu — toujours le même : `tests/unit/hybrid-search-semantic.test.ts`** (position #377 de la file triée par taille, pur, vert partout ailleurs). Victime déterministe à un point fixe de la séquence du fork, aucun `FATAL` V8 dans le log (le plafond 4 Go de #96 n'a donc jamais été atteint) ⇒ un fork qui a déjà exécuté des centaines de fichiers accumule de la mémoire **hors heap** (Buffers/natif, non bornée par `--max-old-space-size`) jusqu'au kill silencieux de l'OS ; l'allocateur de Node 22 y survit, pas Node 20. Le codemod de #95 a changé les tailles de fichiers donc l'ordre de la file : c'est pourquoi ça apparaît depuis. Le fichier qui précède immédiatement dans l'ordre est `tests/search/usearch-index.test.ts` (le seul voisin à dépendance native, mais non installé sur windows-latest ⇒ repli JS, donc pas retenu).

## Choix
- **Pas `maxWorkers: 1`** : un fork unique traverserait les 1605 fichiers (plus d'accumulation, même kill silencieux, et tout le reste du run perdu).
- **Pas 3 Go** : le plafond n'est jamais atteint (pas de FATAL) — la croissance est hors heap.
- **Retenu : 3 shards consécutifs sur Windows** (`.github/workflows/ci.yml` : `npm test -- --shard=1/3`, `2/3`, `3/3` en trois steps, `if: runner.os == 'Windows'`) — chaque step = nouveau parent vitest + nouveaux forks, aucun fork ne vit plus de ~535 fichiers (découpage `BaseSequencer.shard` par hash de fichier, ≈535 par shard ; `vitest list` ignore `--shard`, la répartition réelle se lit dans les logs des 3 steps) ; mêmes fichiers, mêmes 2 forks CI, Linux/macOS inchangés (une seule invocation). Surcoût ≈ 2 démarrages (~1 min). `vitest.config.ts` : commentaire mis à jour (heap 4 Go win32 conservé).

## Vérification
`tsc --noEmit` ✅ ; eslint ✅ ; le flag `--shard` est accepté par `vitest run` (vitest 4.1.9). Réserve : non exécutable depuis Linux ; preuve = jobs windows-latest de la PR (si un fork meurt encore, la victime apparaîtra dans un shard précis et la piste « accumulation » sera à écarter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)