### PR TITLE
feat(cli): cost, changelog, import (découpe de #70)

### DIFF
--- a/src/analytics/cost-report.ts
+++ b/src/analytics/cost-report.ts
@@ -1,0 +1,916 @@
+/**
+ * Pure cost-report aggregation for persisted Code Buddy sessions.
+ *
+ * Session persistence has had several shapes over time (camelCase, snake_case,
+ * per-message usage, per-turn usage, and session-level totals). This module
+ * deliberately accepts loose injected records and normalizes those shapes. It
+ * performs no filesystem/database access. Pricing is injected by the caller so
+ * the CLI can reuse the canonical model registry without coupling this module
+ * to its snapshot loader.
+ */
+
+export type CostGroupBy = 'model' | 'provider' | 'day';
+
+export interface CostPricing {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+export type CostPricingResolver = (model: string, provider: string) => CostPricing | undefined;
+
+export interface CostSessionEntry {
+  [key: string]: unknown;
+}
+
+export interface CostTokenTotals {
+  input: number;
+  output: number;
+  /** Tokens persisted without an input/output split. Never guessed. */
+  unattributed: number;
+}
+
+export interface CostBreakdown {
+  cost: number;
+  tokens: CostTokenTotals;
+  turns: number;
+  averageCostPerTurn: number;
+  /** Portion of `cost` reconstructed from tokens and injected model pricing. */
+  estimatedCost: number;
+  estimatedTurns: number;
+  /** Turns for which neither a stored cost nor a defensible estimate exists. */
+  unknownCostTurns: number;
+}
+
+export interface CostReport {
+  generatedAt: string;
+  since: string | null;
+  sessions: number;
+  turns: number;
+  totalCost: number;
+  averageCostPerTurn: number;
+  tokens: CostTokenTotals;
+  estimatedCost: number;
+  estimatedTurns: number;
+  unknownCostSessions: number;
+  unknownCostTurns: number;
+  byModel: Record<string, CostBreakdown>;
+  byProvider: Record<string, CostBreakdown>;
+  byDay: Record<string, CostBreakdown>;
+}
+
+export interface CostReportOptions {
+  /** Inclusive lower timestamp bound. Accepts a Date, `Nd`, or `YYYY-MM-DD`. */
+  since?: Date | string;
+  /** Clock injection for deterministic reports and relative `Nd` filters. */
+  now?: Date;
+  /** Canonical pricing resolver supplied by the I/O/orchestration layer. */
+  resolvePricing?: CostPricingResolver;
+}
+
+interface RawMeasurement {
+  inputTokens: number;
+  outputTokens: number;
+  unattributedTokens: number;
+  hasTokenInformation: boolean;
+  tokenSource: 'structured' | 'role';
+  storedCost?: number;
+  preEstimatedCost?: number;
+  model?: string;
+  provider?: string;
+  timestamp?: Date;
+  pricing?: CostPricing;
+}
+
+interface DraftTurn {
+  measurements: RawMeasurement[];
+  model: string;
+  provider: string;
+  timestamp?: Date;
+  turns: number;
+}
+
+interface NormalizedTurn {
+  sessionKey: string;
+  model: string;
+  provider: string;
+  day: string;
+  timestamp?: Date;
+  cost: number;
+  estimatedCost: number;
+  costEstimated: boolean;
+  costUnknown: boolean;
+  inputTokens: number;
+  outputTokens: number;
+  unattributedTokens: number;
+  turns: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const UNKNOWN_MODEL = 'unknown';
+const UNKNOWN_PROVIDER = 'unknown';
+const UNKNOWN_DAY = 'unknown';
+
+const INPUT_TOKEN_KEYS = [
+  'inputTokens',
+  'input_tokens',
+  'tokensIn',
+  'tokens_in',
+  'promptTokens',
+  'prompt_tokens',
+  'totalTokensIn',
+  'total_tokens_in',
+] as const;
+
+const OUTPUT_TOKEN_KEYS = [
+  'outputTokens',
+  'output_tokens',
+  'tokensOut',
+  'tokens_out',
+  'completionTokens',
+  'completion_tokens',
+  'totalTokensOut',
+  'total_tokens_out',
+] as const;
+
+const TOTAL_TOKEN_KEYS = ['totalTokens', 'total_tokens', 'tokenCount', 'token_count'] as const;
+
+const STORED_COST_KEYS = [
+  'costUsd',
+  'costUSD',
+  'cost_usd',
+  'totalCost',
+  'totalCostUsd',
+  'total_cost',
+  'total_cost_usd',
+  'sessionCost',
+  'session_cost',
+  'totalUsd',
+  'total_usd',
+  'cost',
+  'amountUsd',
+  'amount_usd',
+  'usd',
+] as const;
+
+const ESTIMATED_COST_KEYS = [
+  'estimatedCostUsd',
+  'estimated_cost_usd',
+  'estimatedCost',
+  'estimated_cost',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  const number = nonNegativeNumber(value);
+  return number !== undefined && Number.isSafeInteger(number) ? number : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function firstNumber(
+  records: readonly (Record<string, unknown> | undefined)[],
+  keys: readonly string[]
+): number | undefined {
+  for (const record of records) {
+    if (!record) continue;
+    for (const key of keys) {
+      const value = nonNegativeNumber(record[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+function firstString(
+  records: readonly (Record<string, unknown> | undefined)[],
+  keys: readonly string[]
+): string | undefined {
+  for (const record of records) {
+    if (!record) continue;
+    for (const key of keys) {
+      const value = nonEmptyString(record[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+function parseTimestamp(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : new Date(value.getTime());
+  }
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function firstTimestamp(
+  records: readonly (Record<string, unknown> | undefined)[]
+): Date | undefined {
+  for (const record of records) {
+    if (!record) continue;
+    for (const key of ['timestamp', 'ts', 'date', 'createdAt', 'created_at']) {
+      const timestamp = parseTimestamp(record[key]);
+      if (timestamp) return timestamp;
+    }
+  }
+  return undefined;
+}
+
+function pricingFromRecords(
+  records: readonly (Record<string, unknown> | undefined)[]
+): CostPricing | undefined {
+  for (const record of records) {
+    if (!record) continue;
+    const candidates = [
+      asRecord(record.pricing),
+      asRecord(record.modelPricing),
+      asRecord(record.model_pricing),
+    ];
+    for (const pricing of candidates) {
+      if (!pricing) continue;
+      const inputPerMillion = firstNumber(
+        [pricing],
+        ['inputPerMillion', 'inputPer1M', 'input_price_per_million', 'price_per_m_input', 'input']
+      );
+      const outputPerMillion = firstNumber(
+        [pricing],
+        [
+          'outputPerMillion',
+          'outputPer1M',
+          'output_price_per_million',
+          'price_per_m_output',
+          'output',
+        ]
+      );
+      if (inputPerMillion !== undefined && outputPerMillion !== undefined) {
+        return { inputPerMillion, outputPerMillion };
+      }
+    }
+  }
+  return undefined;
+}
+
+function roleOf(record: Record<string, unknown>): string | undefined {
+  return firstString([record], ['type', 'role'])?.toLowerCase();
+}
+
+function isUserRole(role: string | undefined): boolean {
+  return role === 'user' || role === 'human';
+}
+
+function isAssistantRole(role: string | undefined): boolean {
+  return role === 'assistant' || role === 'model' || role === 'reasoning';
+}
+
+function measurementFromRecord(
+  record: Record<string, unknown>,
+  role?: string
+): RawMeasurement | undefined {
+  const usage = asRecord(record.usage);
+  const tokenUsage = asRecord(record.tokenUsage) ?? asRecord(record.token_usage);
+  const metrics = asRecord(record.metrics);
+  const metadata = asRecord(record.metadata);
+  const metadataUsage = asRecord(metadata?.usage);
+  const tokensObject = asRecord(record.tokens);
+  const costObject = asRecord(record.cost);
+  const candidates = [
+    usage,
+    tokenUsage,
+    metrics,
+    tokensObject,
+    record,
+    metadataUsage,
+    metadata,
+    costObject,
+  ];
+
+  let inputTokens = firstNumber(candidates, INPUT_TOKEN_KEYS);
+  let outputTokens = firstNumber(candidates, OUTPUT_TOKEN_KEYS);
+  const totalTokens = firstNumber(candidates, TOTAL_TOKEN_KEYS);
+  const directRoleTokens = nonNegativeNumber(record.tokens) ?? nonNegativeNumber(record.tokenCount);
+  const hasDirectionalTokens = inputTokens !== undefined || outputTokens !== undefined;
+  let unattributedTokens = 0;
+  let tokenSource: RawMeasurement['tokenSource'] = 'structured';
+
+  if (hasDirectionalTokens) {
+    inputTokens ??= 0;
+    outputTokens ??= 0;
+    if (totalTokens !== undefined) {
+      unattributedTokens = Math.max(0, totalTokens - inputTokens - outputTokens);
+    }
+  } else if (directRoleTokens !== undefined && isUserRole(role)) {
+    inputTokens = directRoleTokens;
+    outputTokens = 0;
+    tokenSource = 'role';
+  } else if (directRoleTokens !== undefined && isAssistantRole(role)) {
+    inputTokens = 0;
+    outputTokens = directRoleTokens;
+    tokenSource = 'role';
+  } else {
+    inputTokens = 0;
+    outputTokens = 0;
+    unattributedTokens = totalTokens ?? directRoleTokens ?? 0;
+  }
+
+  let storedCost = firstNumber(candidates, STORED_COST_KEYS);
+  let preEstimatedCost = firstNumber(candidates, ESTIMATED_COST_KEYS);
+  const costSource = firstString(candidates, ['costSource', 'cost_source'])?.toLowerCase();
+  const explicitlyEstimated =
+    record.estimated === true ||
+    record.costEstimated === true ||
+    record.cost_estimated === true ||
+    costSource === 'estimated';
+  if (storedCost !== undefined && explicitlyEstimated) {
+    preEstimatedCost ??= storedCost;
+    storedCost = undefined;
+  }
+
+  const hasTokenInformation =
+    hasDirectionalTokens || directRoleTokens !== undefined || totalTokens !== undefined;
+  if (!hasTokenInformation && storedCost === undefined && preEstimatedCost === undefined) {
+    return undefined;
+  }
+
+  const model = firstString(
+    [record, usage, tokenUsage, metrics, metadataUsage, metadata],
+    ['model', 'modelId', 'model_id']
+  );
+  const provider = firstString(
+    [record, usage, tokenUsage, metrics, metadataUsage, metadata],
+    ['provider', 'providerId', 'provider_id']
+  );
+
+  return {
+    inputTokens,
+    outputTokens,
+    unattributedTokens,
+    hasTokenInformation,
+    tokenSource,
+    storedCost,
+    preEstimatedCost,
+    model,
+    provider,
+    timestamp: firstTimestamp([record, usage, tokenUsage, metrics, metadataUsage, metadata]),
+    pricing: pricingFromRecords(candidates),
+  };
+}
+
+function normalizeProviderName(provider: string): string {
+  const normalized = provider.trim().toLowerCase().replace(/_/g, '-');
+  const aliases: Record<string, string> = {
+    xai: 'grok',
+    google: 'gemini',
+    'google-ai': 'gemini',
+    'aws-bedrock': 'bedrock',
+    aws: 'bedrock',
+    'azure-openai': 'azure',
+    'github-copilot': 'copilot',
+    'lm-studio': 'lmstudio',
+    'chatgpt-oauth': 'chatgpt',
+    'openai-codex': 'chatgpt',
+  };
+  return aliases[normalized] ?? normalized;
+}
+
+/** Infer a user-facing provider when an old session only persisted the model. */
+export function inferCostProvider(model: string): string {
+  const lower = model.trim().toLowerCase();
+  if (!lower || lower === UNKNOWN_MODEL) return UNKNOWN_PROVIDER;
+  if (lower === 'openrouter/free' || lower.endsWith(':free')) return 'openrouter';
+
+  const qualified = lower.match(/^([a-z0-9_-]+)\//)?.[1];
+  if (
+    qualified &&
+    [
+      'openrouter',
+      'groq',
+      'together',
+      'fireworks',
+      'azure',
+      'bedrock',
+      'copilot',
+      'vllm',
+      'lmstudio',
+      'ollama',
+    ].includes(qualified)
+  ) {
+    return normalizeProviderName(qualified);
+  }
+
+  if (/^(anthropic\.|amazon\.|meta\.|mistral\.).*:v?\d/i.test(lower)) return 'bedrock';
+  if (lower.startsWith('grok-')) return 'grok';
+  if (/^(gpt-|o[1-9](?:-|$)|codex)/.test(lower)) return 'openai';
+  if (lower.startsWith('claude-')) return 'anthropic';
+  if (lower.startsWith('gemini-')) return 'gemini';
+  if (lower.startsWith('azure-')) return 'azure';
+  if (lower.startsWith('groq/')) return 'groq';
+  if (lower.startsWith('together/')) return 'together';
+  if (lower.startsWith('fireworks/')) return 'fireworks';
+  if (lower.startsWith('mistral') || lower.startsWith('mixtral') || lower.startsWith('devstral')) {
+    return 'mistral';
+  }
+  if (
+    lower.startsWith('ollama/') ||
+    /^(llama|qwen|gemma|phi|codellama|command-r|deepseek)/.test(lower)
+  ) {
+    return 'ollama';
+  }
+  if (lower.startsWith('lmstudio/') || lower === 'local-model') return 'lmstudio';
+  if (lower.startsWith('vllm/')) return 'vllm';
+  return UNKNOWN_PROVIDER;
+}
+
+function modelForSession(session: Record<string, unknown>): string {
+  const metadata = asRecord(session.metadata);
+  return firstString([session, metadata], ['model', 'modelId', 'model_id']) ?? UNKNOWN_MODEL;
+}
+
+function providerForSession(session: Record<string, unknown>, model: string): string {
+  const metadata = asRecord(session.metadata);
+  const provider = firstString([session, metadata], ['provider', 'providerId', 'provider_id']);
+  return provider ? normalizeProviderName(provider) : inferCostProvider(model);
+}
+
+function sessionTimestamp(session: Record<string, unknown>): Date | undefined {
+  const metadata = asRecord(session.metadata);
+  for (const record of [session, metadata]) {
+    if (!record) continue;
+    for (const key of [
+      'lastAccessedAt',
+      'last_accessed_at',
+      'updatedAt',
+      'updated_at',
+      'createdAt',
+      'created_at',
+      'timestamp',
+      'date',
+    ]) {
+      const parsed = parseTimestamp(record[key]);
+      if (parsed) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function explicitTurnCount(session: Record<string, unknown>): number | undefined {
+  const metadata = asRecord(session.metadata);
+  for (const record of [session, metadata]) {
+    if (!record) continue;
+    for (const key of ['turnCount', 'turn_count', 'totalTurns', 'total_turns']) {
+      const value = nonNegativeInteger(record[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+function recordsFromArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function measurementArray(session: Record<string, unknown>): Record<string, unknown>[] {
+  for (const key of ['turns', 'usageEntries', 'usage_entries', 'costEntries', 'cost_entries']) {
+    const entries = recordsFromArray(session[key]);
+    if (entries.length > 0) return entries;
+  }
+  const usageEntries = recordsFromArray(session.usage);
+  return usageEntries;
+}
+
+function draftFromEntry(
+  entry: Record<string, unknown>,
+  fallbackModel: string,
+  fallbackProvider: string,
+  fallbackTimestamp: Date | undefined
+): DraftTurn {
+  const measurement = measurementFromRecord(entry, roleOf(entry));
+  const model = measurement?.model ?? fallbackModel;
+  const provider = measurement?.provider
+    ? normalizeProviderName(measurement.provider)
+    : fallbackProvider === UNKNOWN_PROVIDER
+      ? inferCostProvider(model)
+      : fallbackProvider;
+  return {
+    measurements: measurement ? [measurement] : [],
+    model,
+    provider,
+    timestamp: measurement?.timestamp ?? firstTimestamp([entry]) ?? fallbackTimestamp,
+    turns: 1,
+  };
+}
+
+function messageDrafts(
+  session: Record<string, unknown>,
+  fallbackModel: string,
+  fallbackProvider: string,
+  fallbackTimestamp: Date | undefined
+): DraftTurn[] {
+  const messages = recordsFromArray(session.messages);
+  const turns: DraftTurn[] = [];
+  let current: DraftTurn | undefined;
+
+  const finishCurrent = (): void => {
+    if (current) turns.push(current);
+    current = undefined;
+  };
+
+  for (const message of messages) {
+    const role = roleOf(message);
+    const measurement = measurementFromRecord(message, role);
+    const timestamp = measurement?.timestamp ?? firstTimestamp([message]);
+
+    if (isUserRole(role)) {
+      finishCurrent();
+      const model = measurement?.model ?? fallbackModel;
+      current = {
+        measurements: measurement ? [measurement] : [],
+        model,
+        provider: measurement?.provider
+          ? normalizeProviderName(measurement.provider)
+          : fallbackProvider === UNKNOWN_PROVIDER
+            ? inferCostProvider(model)
+            : fallbackProvider,
+        timestamp: timestamp ?? fallbackTimestamp,
+        turns: 1,
+      };
+      continue;
+    }
+
+    if (current) {
+      if (measurement) {
+        current.measurements.push(measurement);
+        if (measurement.model) current.model = measurement.model;
+        if (measurement.provider) current.provider = normalizeProviderName(measurement.provider);
+      }
+      current.timestamp ??= timestamp ?? fallbackTimestamp;
+      continue;
+    }
+
+    // Legacy histories can contain standalone assistant usage entries. Count
+    // only entries that actually carry usage/cost, not decorative messages.
+    if (measurement) {
+      turns.push(draftFromEntry(message, fallbackModel, fallbackProvider, fallbackTimestamp));
+    }
+  }
+  finishCurrent();
+  return turns;
+}
+
+function sumDraftTokens(drafts: readonly DraftTurn[]): CostTokenTotals {
+  const totals: CostTokenTotals = { input: 0, output: 0, unattributed: 0 };
+  for (const draft of drafts) {
+    const measurements = tokenMeasurements(draft.measurements);
+    for (const measurement of measurements) {
+      totals.input += measurement.inputTokens;
+      totals.output += measurement.outputTokens;
+      totals.unattributed += measurement.unattributedTokens;
+    }
+  }
+  return totals;
+}
+
+function tokenMeasurements(measurements: readonly RawMeasurement[]): RawMeasurement[] {
+  const structured = measurements.filter(
+    (measurement) => measurement.hasTokenInformation && measurement.tokenSource === 'structured'
+  );
+  if (structured.length > 0) return structured;
+  return measurements.filter((measurement) => measurement.hasTokenInformation);
+}
+
+function sessionDrafts(session: Record<string, unknown>): DraftTurn[] {
+  const fallbackModel = modelForSession(session);
+  const fallbackProvider = providerForSession(session, fallbackModel);
+  const fallbackTimestamp = sessionTimestamp(session);
+  const entries = measurementArray(session);
+  const details =
+    entries.length > 0
+      ? entries.map((entry) =>
+          draftFromEntry(entry, fallbackModel, fallbackProvider, fallbackTimestamp)
+        )
+      : messageDrafts(session, fallbackModel, fallbackProvider, fallbackTimestamp);
+
+  const rootMeasurement = measurementFromRecord(session);
+  const rootHasStoredCost =
+    rootMeasurement?.storedCost !== undefined || rootMeasurement?.preEstimatedCost !== undefined;
+  const detailsHaveStoredCost = details.some((draft) =>
+    draft.measurements.some(
+      (measurement) =>
+        measurement.storedCost !== undefined || measurement.preEstimatedCost !== undefined
+    )
+  );
+  const detailsHaveMeasurement = details.some((draft) => draft.measurements.length > 0);
+  const configuredTurns = explicitTurnCount(session);
+  const detailedTurns = details.reduce((sum, draft) => sum + draft.turns, 0);
+  const rootHasActivity = Boolean(
+    rootMeasurement &&
+    ((rootMeasurement.storedCost ?? rootMeasurement.preEstimatedCost ?? 0) > 0 ||
+      rootMeasurement.inputTokens +
+        rootMeasurement.outputTokens +
+        rootMeasurement.unattributedTokens >
+        0)
+  );
+  const inferredTurns =
+    configuredTurns ?? (detailedTurns > 0 ? detailedTurns : rootHasActivity ? 1 : 0);
+
+  // A stored session total is authoritative when no finer-grained stored cost
+  // exists. This prevents totals and message estimates from being double-counted.
+  if (rootMeasurement && rootHasStoredCost && !detailsHaveStoredCost) {
+    const detailedTokens = sumDraftTokens(details);
+    if (!rootMeasurement.hasTokenInformation && detailsHaveMeasurement) {
+      rootMeasurement.inputTokens = detailedTokens.input;
+      rootMeasurement.outputTokens = detailedTokens.output;
+      rootMeasurement.unattributedTokens = detailedTokens.unattributed;
+      rootMeasurement.hasTokenInformation =
+        detailedTokens.input + detailedTokens.output + detailedTokens.unattributed > 0;
+    }
+    return [
+      {
+        measurements: [rootMeasurement],
+        model: rootMeasurement.model ?? fallbackModel,
+        provider: rootMeasurement.provider
+          ? normalizeProviderName(rootMeasurement.provider)
+          : fallbackProvider,
+        timestamp: rootMeasurement.timestamp ?? fallbackTimestamp,
+        turns: inferredTurns,
+      },
+    ];
+  }
+
+  if (details.length > 0) {
+    if (detailsHaveMeasurement || !rootMeasurement) return details;
+  }
+
+  if (rootMeasurement) {
+    return [
+      {
+        measurements: [rootMeasurement],
+        model: rootMeasurement.model ?? fallbackModel,
+        provider: rootMeasurement.provider
+          ? normalizeProviderName(rootMeasurement.provider)
+          : fallbackProvider,
+        timestamp: rootMeasurement.timestamp ?? fallbackTimestamp,
+        turns: inferredTurns,
+      },
+    ];
+  }
+
+  if (details.length > 0) return details;
+
+  // Keep a genuinely empty saved session visible in the session count while
+  // avoiding an invented turn.
+  return [
+    {
+      measurements: [],
+      model: fallbackModel,
+      provider: fallbackProvider,
+      timestamp: fallbackTimestamp,
+      turns: configuredTurns ?? 0,
+    },
+  ];
+}
+
+function validPricing(pricing: CostPricing | undefined): pricing is CostPricing {
+  return Boolean(
+    pricing &&
+    nonNegativeNumber(pricing.inputPerMillion) !== undefined &&
+    nonNegativeNumber(pricing.outputPerMillion) !== undefined
+  );
+}
+
+function normalizeDraft(
+  draft: DraftTurn,
+  sessionKey: string,
+  resolvePricing: CostPricingResolver | undefined
+): NormalizedTurn {
+  const measurements = tokenMeasurements(draft.measurements);
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let unattributedTokens = 0;
+  for (const measurement of measurements) {
+    inputTokens += measurement.inputTokens;
+    outputTokens += measurement.outputTokens;
+    unattributedTokens += measurement.unattributedTokens;
+  }
+
+  const storedCosts = draft.measurements
+    .map((measurement) => measurement.storedCost)
+    .filter((cost): cost is number => cost !== undefined);
+  const preEstimatedCosts = draft.measurements
+    .map((measurement) => measurement.preEstimatedCost)
+    .filter((cost): cost is number => cost !== undefined);
+  const hasPersistedCost = storedCosts.length + preEstimatedCosts.length > 0;
+  let cost = storedCosts.reduce((sum, value) => sum + value, 0);
+  let estimatedCost = preEstimatedCosts.reduce((sum, value) => sum + value, 0);
+  let costEstimated = preEstimatedCosts.length > 0;
+  let costUnknown = false;
+
+  if (hasPersistedCost) {
+    cost += estimatedCost;
+  } else {
+    const embeddedPricing = draft.measurements.find((measurement) =>
+      validPricing(measurement.pricing)
+    )?.pricing;
+    let pricing = embeddedPricing;
+    if (!pricing && resolvePricing) {
+      try {
+        pricing = resolvePricing(draft.model, draft.provider);
+      } catch {
+        pricing = undefined;
+      }
+    }
+    const hasDirectionalTokens = measurements.some(
+      (measurement) =>
+        measurement.hasTokenInformation &&
+        (measurement.inputTokens > 0 ||
+          measurement.outputTokens > 0 ||
+          measurement.unattributedTokens === 0)
+    );
+    if (validPricing(pricing) && hasDirectionalTokens) {
+      estimatedCost =
+        (inputTokens * pricing.inputPerMillion + outputTokens * pricing.outputPerMillion) /
+        1_000_000;
+      cost = estimatedCost;
+      costEstimated = true;
+      costUnknown = unattributedTokens > 0;
+    } else {
+      costUnknown = true;
+    }
+  }
+
+  const timestamp = draft.timestamp;
+  return {
+    sessionKey,
+    model: draft.model || UNKNOWN_MODEL,
+    provider:
+      draft.provider && draft.provider !== UNKNOWN_PROVIDER
+        ? normalizeProviderName(draft.provider)
+        : inferCostProvider(draft.model),
+    day: timestamp ? timestamp.toISOString().slice(0, 10) : UNKNOWN_DAY,
+    timestamp,
+    cost,
+    estimatedCost,
+    costEstimated,
+    costUnknown,
+    inputTokens,
+    outputTokens,
+    unattributedTokens,
+    turns: draft.turns,
+  };
+}
+
+/**
+ * Parse `--since` syntax. `Nd` is a rolling duration; a calendar date starts
+ * at midnight UTC so JSON and tests do not depend on the host timezone.
+ */
+export function parseCostSince(value: string | Date, now: Date = new Date()): Date {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) throw new Error('Date `--since` invalide.');
+    return new Date(value.getTime());
+  }
+
+  const trimmed = value.trim();
+  const relative = /^(\d+)d$/i.exec(trimmed);
+  if (relative) {
+    const days = Number(relative[1]);
+    if (!Number.isSafeInteger(days) || days < 1) {
+      throw new Error('`--since` doit être une durée positive comme `7d`.');
+    }
+    return new Date(now.getTime() - days * DAY_MS);
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const parsed = new Date(`${trimmed}T00:00:00.000Z`);
+    if (!Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === trimmed) {
+      return parsed;
+    }
+  }
+  throw new Error('`--since` doit être une durée comme `7d` ou une date `YYYY-MM-DD`.');
+}
+
+function emptyBreakdown(): CostBreakdown {
+  return {
+    cost: 0,
+    tokens: { input: 0, output: 0, unattributed: 0 },
+    turns: 0,
+    averageCostPerTurn: 0,
+    estimatedCost: 0,
+    estimatedTurns: 0,
+    unknownCostTurns: 0,
+  };
+}
+
+function addToBreakdown(
+  target: Record<string, CostBreakdown>,
+  key: string,
+  turn: NormalizedTurn
+): void {
+  const breakdown = target[key] ?? emptyBreakdown();
+  breakdown.cost += turn.cost;
+  breakdown.tokens.input += turn.inputTokens;
+  breakdown.tokens.output += turn.outputTokens;
+  breakdown.tokens.unattributed += turn.unattributedTokens;
+  breakdown.turns += turn.turns;
+  breakdown.estimatedCost += turn.estimatedCost;
+  if (turn.costEstimated) breakdown.estimatedTurns += turn.turns;
+  if (turn.costUnknown) breakdown.unknownCostTurns += turn.turns;
+  target[key] = breakdown;
+}
+
+function finalizeBreakdown(
+  input: Record<string, CostBreakdown>,
+  group: CostGroupBy
+): Record<string, CostBreakdown> {
+  const entries = Object.entries(input);
+  entries.sort(([leftKey, left], [rightKey, right]) => {
+    if (group === 'day') return leftKey.localeCompare(rightKey);
+    return right.cost - left.cost || leftKey.localeCompare(rightKey);
+  });
+  for (const [, value] of entries) {
+    value.averageCostPerTurn = value.turns > 0 ? value.cost / value.turns : 0;
+  }
+  return Object.fromEntries(entries);
+}
+
+/** Aggregate injected saved-session records into all requested dimensions. */
+export function aggregateCostReport(
+  entries: readonly CostSessionEntry[],
+  options: CostReportOptions = {}
+): CostReport {
+  const now = options.now ? new Date(options.now.getTime()) : new Date();
+  if (Number.isNaN(now.getTime())) throw new Error('Horloge de rapport invalide.');
+  const since = options.since ? parseCostSince(options.since, now) : undefined;
+  const normalized: NormalizedTurn[] = [];
+
+  entries.forEach((entry, index) => {
+    if (!isRecord(entry)) return;
+    const id = firstString([entry], ['id', 'sessionId', 'session_id']) ?? `session-${index + 1}`;
+    const sessionKey = `${id}#${index}`;
+    for (const draft of sessionDrafts(entry)) {
+      const turn = normalizeDraft(draft, sessionKey, options.resolvePricing);
+      if (since && (!turn.timestamp || turn.timestamp.getTime() < since.getTime())) continue;
+      normalized.push(turn);
+    }
+  });
+
+  const byModel: Record<string, CostBreakdown> = {};
+  const byProvider: Record<string, CostBreakdown> = {};
+  const byDay: Record<string, CostBreakdown> = {};
+  const includedSessions = new Set<string>();
+  const unknownSessions = new Set<string>();
+  const tokens: CostTokenTotals = { input: 0, output: 0, unattributed: 0 };
+  let turns = 0;
+  let totalCost = 0;
+  let estimatedCost = 0;
+  let estimatedTurns = 0;
+  let unknownCostTurns = 0;
+
+  for (const turn of normalized) {
+    includedSessions.add(turn.sessionKey);
+    if (turn.costUnknown) unknownSessions.add(turn.sessionKey);
+    turns += turn.turns;
+    totalCost += turn.cost;
+    estimatedCost += turn.estimatedCost;
+    if (turn.costEstimated) estimatedTurns += turn.turns;
+    if (turn.costUnknown) unknownCostTurns += turn.turns;
+    tokens.input += turn.inputTokens;
+    tokens.output += turn.outputTokens;
+    tokens.unattributed += turn.unattributedTokens;
+    addToBreakdown(byModel, turn.model, turn);
+    addToBreakdown(byProvider, turn.provider, turn);
+    addToBreakdown(byDay, turn.day, turn);
+  }
+
+  return {
+    generatedAt: now.toISOString(),
+    since: since?.toISOString() ?? null,
+    sessions: includedSessions.size,
+    turns,
+    totalCost,
+    averageCostPerTurn: turns > 0 ? totalCost / turns : 0,
+    tokens,
+    estimatedCost,
+    estimatedTurns,
+    unknownCostSessions: unknownSessions.size,
+    unknownCostTurns,
+    byModel: finalizeBreakdown(byModel, 'model'),
+    byProvider: finalizeBreakdown(byProvider, 'provider'),
+    byDay: finalizeBreakdown(byDay, 'day'),
+  };
+}
+
+/** Backward-friendly descriptive alias for consumers that prefer `build*`. */
+export const buildCostReport = aggregateCostReport;

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,0 +1,306 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Command } from 'commander';
+import {
+  groupChangelogCommits,
+  renderChangelogMarkdown,
+  type ChangelogCommit,
+} from '../git/changelog.js';
+import { logger } from '../utils/logger.js';
+
+const GIT_LOG_FORMAT = '--format=%H%x00%s%x00%b';
+const GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+export type ChangelogGitRunner = (args: readonly string[], cwd: string) => Promise<string>;
+
+export interface ChangelogCommandDependencies {
+  cwd?: string;
+  runGit?: ChangelogGitRunner;
+  stdout?: (content: string) => void;
+}
+
+export interface ChangelogCollectionOptions {
+  since?: string;
+  to?: string;
+}
+
+export type ChangelogRangeMode = 'all' | 'date' | 'ref' | 'tag';
+
+export interface ChangelogRange {
+  since: string | null;
+  to: string;
+  mode: ChangelogRangeMode;
+}
+
+export interface CollectedChangelogCommits {
+  commits: ChangelogCommit[];
+  range: ChangelogRange;
+}
+
+interface ChangelogCliOptions extends ChangelogCollectionOptions {
+  json: boolean;
+  out?: string;
+}
+
+class GitCommandError extends Error {
+  readonly code: string | number | undefined;
+
+  constructor(error: Error & { code?: string | number | null }, stderr: string) {
+    super(stderr.trim() || error.message);
+    this.name = 'GitCommandError';
+    this.code = error.code ?? undefined;
+  }
+}
+
+const defaultGitRunner: ChangelogGitRunner = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      [...args],
+      {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: GIT_MAX_BUFFER_BYTES,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new GitCommandError(error, stderr));
+          return;
+        }
+        resolve(stdout);
+      }
+    );
+  });
+
+function normalizeOption(value: string | undefined, fallback: string, label: string): string {
+  const normalized = value?.trim() ?? fallback;
+  if (!normalized) throw new Error(`${label} ne peut pas être vide.`);
+  return normalized;
+}
+
+function validateDate(value: string): void {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Date invalide pour --since : ${value}`);
+  }
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function parseGitLog(output: string): ChangelogCommit[] {
+  if (!output) return [];
+  const fields = output.split('\0');
+  if (fields.at(-1) === '') fields.pop();
+  if (fields.length % 3 !== 0) {
+    throw new Error('La sortie de `git log` est incomplète ou illisible.');
+  }
+
+  const commits: ChangelogCommit[] = [];
+  for (let index = 0; index < fields.length; index += 3) {
+    const hash = fields[index];
+    const subject = fields[index + 1];
+    const body = fields[index + 2];
+    if (hash === undefined || subject === undefined || body === undefined) {
+      throw new Error('La sortie de `git log` est incomplète ou illisible.');
+    }
+    commits.push({ hash, subject, body });
+  }
+  return commits;
+}
+
+async function ensureGitRepository(cwd: string, runGit: ChangelogGitRunner): Promise<void> {
+  try {
+    const gitDirectory = await runGit(['rev-parse', '--git-dir'], cwd);
+    if (!gitDirectory.trim()) throw new Error('Répertoire Git introuvable.');
+  } catch (error) {
+    if (error instanceof GitCommandError && error.code === 'ENOENT') {
+      throw new Error('Git est introuvable ou inaccessible sur cette machine.');
+    }
+    throw new Error(`Ce dossier n’est pas un dépôt Git : ${cwd}`);
+  }
+}
+
+async function tryResolveCommit(
+  reference: string,
+  cwd: string,
+  runGit: ChangelogGitRunner
+): Promise<string | undefined> {
+  try {
+    const resolved = await runGit(
+      ['rev-parse', '--verify', '--quiet', '--end-of-options', `${reference}^{commit}`],
+      cwd
+    );
+    return resolved.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function repositoryHasCommits(cwd: string, runGit: ChangelogGitRunner): Promise<boolean> {
+  const output = await runGit(['rev-list', '--max-count=1', '--all'], cwd);
+  return output.trim().length > 0;
+}
+
+async function latestReachableTag(
+  toHash: string,
+  cwd: string,
+  runGit: ChangelogGitRunner
+): Promise<string | undefined> {
+  try {
+    const tag = await runGit(['describe', '--tags', '--abbrev=0', toHash], cwd);
+    return tag.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Collect the selected Git history without mutating the repository. */
+export async function collectChangelogCommits(
+  options: ChangelogCollectionOptions = {},
+  dependencies: Pick<ChangelogCommandDependencies, 'cwd' | 'runGit'> = {}
+): Promise<CollectedChangelogCommits> {
+  const cwd = path.resolve(dependencies.cwd ?? process.cwd());
+  const runGit = dependencies.runGit ?? defaultGitRunner;
+  const to = normalizeOption(options.to, 'HEAD', '--to');
+
+  await ensureGitRepository(cwd, runGit);
+
+  const toHash = await tryResolveCommit(to, cwd, runGit);
+  if (!toHash) {
+    if (to === 'HEAD' && !(await repositoryHasCommits(cwd, runGit))) {
+      return { commits: [], range: { since: null, to, mode: 'all' } };
+    }
+    throw new Error(`Référence Git invalide pour --to : ${to}`);
+  }
+
+  const requestedSince = options.since?.trim();
+  if (options.since !== undefined && !requestedSince) {
+    throw new Error('--since ne peut pas être vide.');
+  }
+
+  let range: ChangelogRange;
+  let revision = toHash;
+  let dateArgument: string | undefined;
+
+  if (requestedSince && isIsoDate(requestedSince)) {
+    validateDate(requestedSince);
+    dateArgument = `--since=${requestedSince}`;
+    range = { since: requestedSince, to, mode: 'date' };
+  } else if (requestedSince) {
+    const sinceHash = await tryResolveCommit(requestedSince, cwd, runGit);
+    if (!sinceHash) throw new Error(`Référence Git invalide pour --since : ${requestedSince}`);
+    revision = `${sinceHash}..${toHash}`;
+    range = { since: requestedSince, to, mode: 'ref' };
+  } else {
+    const tag = await latestReachableTag(toHash, cwd, runGit);
+    if (tag) {
+      const sinceHash = await tryResolveCommit(tag, cwd, runGit);
+      if (!sinceHash) throw new Error(`Impossible de résoudre le dernier tag Git : ${tag}`);
+      revision = `${sinceHash}..${toHash}`;
+      range = { since: tag, to, mode: 'tag' };
+    } else {
+      range = { since: null, to, mode: 'all' };
+    }
+  }
+
+  const logArgs = ['log', '-z', '--no-color', GIT_LOG_FORMAT];
+  if (dateArgument) logArgs.push(dateArgument);
+  logArgs.push(revision, '--');
+  const output = await runGit(logArgs, cwd);
+
+  return {
+    commits: parseGitLog(output),
+    range,
+  };
+}
+
+function noCommitsMessage(range: ChangelogRange): string {
+  if (range.mode === 'all') {
+    return `Aucun commit trouvé dans l’historique Git jusqu’à ${range.to}.`;
+  }
+  return `Aucun commit trouvé sur la plage ${range.since} → ${range.to}.`;
+}
+
+async function readExistingFile(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+    throw error;
+  }
+}
+
+async function prependOutput(filePath: string, markdown: string): Promise<void> {
+  const existing = await readExistingFile(filePath);
+  const content = existing ? `${markdown.trimEnd()}\n\n${existing}` : markdown;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+function writeStdout(content: string, writer?: (content: string) => void): void {
+  (writer ?? ((value) => process.stdout.write(value)))(`${content.trimEnd()}\n`);
+}
+
+export function createChangelogCommand(dependencies: ChangelogCommandDependencies = {}): Command {
+  const command = new Command('changelog')
+    .description('Générer des release notes depuis les Conventional Commits')
+    .option('--since <tag|YYYY-MM-DD|ref>', 'Début exclu de la plage, ou date YYYY-MM-DD')
+    .option('--to <ref>', 'Fin incluse de la plage Git', 'HEAD')
+    .option('--out <CHANGELOG.md>', 'Préfixer les release notes dans ce fichier Markdown')
+    .option('--json', 'Émettre la structure groupée en JSON sur stdout', false);
+
+  command.action(async (options: ChangelogCliOptions) => {
+    try {
+      if (options.json && options.out) {
+        throw new Error('`--json` et `--out` ne peuvent pas être utilisés ensemble.');
+      }
+
+      const collection = await collectChangelogCommits(options, dependencies);
+      const changelog = groupChangelogCommits(collection.commits);
+      const message = changelog.totalCommits === 0 ? noCommitsMessage(collection.range) : undefined;
+
+      if (options.json) {
+        writeStdout(
+          JSON.stringify(
+            {
+              range: collection.range,
+              ...changelog,
+              ...(message ? { message } : {}),
+            },
+            null,
+            2
+          ),
+          dependencies.stdout
+        );
+        return;
+      }
+
+      if (message) {
+        writeStdout(message, dependencies.stdout);
+        return;
+      }
+
+      const markdown = renderChangelogMarkdown(changelog);
+      if (!options.out) {
+        writeStdout(markdown, dependencies.stdout);
+        return;
+      }
+
+      const cwd = path.resolve(dependencies.cwd ?? process.cwd());
+      const outputPath = path.resolve(cwd, options.out);
+      await prependOutput(outputPath, markdown);
+      logger.info(`Changelog mis à jour : ${outputPath}`);
+    } catch (error) {
+      command.error(error instanceof Error ? error.message : String(error), {
+        code: 'buddy.changelog',
+        exitCode: 1,
+      });
+    }
+  });
+
+  return command;
+}

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -1,0 +1,392 @@
+/** `buddy cost` — read-only cost dashboard over persisted session JSON. */
+
+import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Command, InvalidArgumentError } from 'commander';
+import {
+  aggregateCostReport,
+  parseCostSince,
+  type CostBreakdown,
+  type CostGroupBy,
+  type CostPricing,
+  type CostPricingResolver,
+  type CostReport,
+  type CostSessionEntry,
+} from '../analytics/cost-report.js';
+import { getModelPricing } from '../config/model-pricing.js';
+import { logger } from '../utils/logger.js';
+
+export interface CostCommandOptions {
+  last?: boolean;
+  session?: string;
+  since?: string;
+  by: CostGroupBy;
+  json?: boolean;
+}
+
+export interface SavedCostSessions {
+  sessions: CostSessionEntry[];
+  warnings: string[];
+}
+
+export interface CostCommandDependencies {
+  sessionsDirectory?: string;
+  loadSessions?: () => Promise<SavedCostSessions | readonly CostSessionEntry[]>;
+  now?: () => Date;
+  resolvePricing?: CostPricingResolver;
+  stdout?: (message: string) => void;
+}
+
+const UNMETERED_PROVIDERS = new Set([
+  'agy-cli',
+  'chatgpt',
+  'chatgpt-oauth',
+  'copilot',
+  'gemini-cli',
+  'lemonade',
+  'lmstudio',
+  'ollama',
+  'vllm',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return isRecord(error) && error.code === code;
+}
+
+function sessionId(entry: CostSessionEntry): string | undefined {
+  for (const key of ['id', 'sessionId', 'session_id']) {
+    const value = entry[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function sessionCandidates(value: unknown): CostSessionEntry[] {
+  if (Array.isArray(value)) return value.filter(isRecord);
+  if (!isRecord(value)) return [];
+
+  const nested = value.sessions;
+  if (Array.isArray(nested)) return nested.filter(isRecord);
+  if (isRecord(nested)) return Object.values(nested).filter(isRecord);
+
+  return sessionId(value) ? [value] : [];
+}
+
+/** Read all recognized JSON session shapes without creating or changing files. */
+export async function readSavedCostSessions(directory: string): Promise<SavedCostSessions> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return { sessions: [], warnings: [] };
+    return {
+      sessions: [],
+      warnings: [
+        `Impossible de lire le dossier des sessions : ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ],
+    };
+  }
+
+  const sessions = new Map<string, { entry: CostSessionEntry; priority: number }>();
+  const warnings: string[] = [];
+  const jsonFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of jsonFiles) {
+    const filePath = path.join(directory, entry.name);
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(filePath, 'utf8'));
+      const candidates = sessionCandidates(parsed);
+      const isLegacyContainer = isRecord(parsed) && 'sessions' in parsed;
+      if (candidates.length === 0) {
+        // `sessions.json` can legitimately be an empty legacy container.
+        if (!(isRecord(parsed) && ('sessions' in parsed || 'messages' in parsed))) {
+          warnings.push(`Format de session ignoré : ${entry.name}`);
+        }
+        continue;
+      }
+      candidates.forEach((candidate, index) => {
+        const id = sessionId(candidate) ?? `${entry.name}#${index}`;
+        // A dedicated per-session file is authoritative over a legacy
+        // container regardless of filename ordering.
+        const priority = isLegacyContainer ? 0 : 1;
+        const existing = sessions.get(id);
+        if (!existing || priority >= existing.priority) {
+          sessions.set(id, { entry: candidate, priority });
+        }
+      });
+    } catch (error) {
+      warnings.push(
+        `Session illisible ignorée (${entry.name}) : ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return { sessions: [...sessions.values()].map(({ entry }) => entry), warnings };
+}
+
+function parseGroupBy(value: string): CostGroupBy {
+  if (value === 'model' || value === 'provider' || value === 'day') return value;
+  throw new InvalidArgumentError('`--by` doit valoir `model`, `provider` ou `day`.');
+}
+
+function validateSince(value: string): string {
+  try {
+    parseCostSince(value);
+    return value;
+  } catch (error) {
+    throw new InvalidArgumentError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function timestampNumber(value: unknown): number | undefined {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? undefined : time;
+  }
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? undefined : time;
+}
+
+function latestSessionTimestamp(entry: CostSessionEntry): number {
+  const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
+  for (const record of [entry, metadata]) {
+    if (!record) continue;
+    for (const key of [
+      'lastAccessedAt',
+      'last_accessed_at',
+      'updatedAt',
+      'updated_at',
+      'createdAt',
+      'created_at',
+    ]) {
+      const value = timestampNumber(record[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return Number.NEGATIVE_INFINITY;
+}
+
+function selectSessions(
+  sessions: readonly CostSessionEntry[],
+  options: CostCommandOptions
+): CostSessionEntry[] {
+  if (options.last && options.session) {
+    throw new Error('`--last` et `--session` sont incompatibles.');
+  }
+  if (options.session) {
+    const requested = options.session.trim();
+    const match = sessions.find((entry) => sessionId(entry) === requested);
+    if (!match) throw new Error(`Session introuvable : ${requested}`);
+    return [match];
+  }
+  if (options.last) {
+    const latest = [...sessions].sort(
+      (left, right) => latestSessionTimestamp(right) - latestSessionTimestamp(left)
+    )[0];
+    return latest ? [latest] : [];
+  }
+  return [...sessions];
+}
+
+/** Reuse the canonical model registry and preserve known flat-fee/local routes. */
+export function resolveCostPricing(model: string, provider: string): CostPricing {
+  const normalizedProvider = provider.toLowerCase();
+  const normalizedModel = model.toLowerCase();
+  if (
+    UNMETERED_PROVIDERS.has(normalizedProvider) ||
+    normalizedModel === 'openrouter/free' ||
+    normalizedModel.endsWith(':free')
+  ) {
+    return { inputPerMillion: 0, outputPerMillion: 0 };
+  }
+  return getModelPricing(model);
+}
+
+function formatUsd(value: number): string {
+  if (value === 0) return '$0.0000';
+  if (Math.abs(value) < 0.0001) return `$${value.toFixed(6)}`;
+  if (Math.abs(value) < 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+}
+
+function plural(count: number, singular: string, pluralForm: string): string {
+  return `${formatInteger(count)} ${count === 1 ? singular : pluralForm}`;
+}
+
+function qualityLabel(breakdown: CostBreakdown): string {
+  const labels: string[] = [];
+  if (breakdown.estimatedTurns > 0)
+    labels.push(`${formatInteger(breakdown.estimatedTurns)} estimé(s)`);
+  if (breakdown.unknownCostTurns > 0) {
+    labels.push(`${formatInteger(breakdown.unknownCostTurns)} inconnu(s)`);
+  }
+  return labels.length > 0 ? labels.join(', ') : 'stocké';
+}
+
+function renderTable(headers: readonly string[], rows: readonly (readonly string[])[]): string {
+  const widths = headers.map((header, column) =>
+    Math.max(header.length, ...rows.map((row) => row[column]?.length ?? 0))
+  );
+  const numericColumns = new Set([1, 2, 3, 4, 5]);
+  const renderRow = (row: readonly string[]): string =>
+    row
+      .map((cell, column) =>
+        numericColumns.has(column)
+          ? cell.padStart(widths[column] ?? cell.length)
+          : cell.padEnd(widths[column] ?? cell.length)
+      )
+      .join('  ')
+      .trimEnd();
+  return [
+    renderRow(headers),
+    widths.map((width) => '-'.repeat(width)).join('  '),
+    ...rows.map(renderRow),
+  ].join('\n');
+}
+
+function selectedBreakdown(
+  report: CostReport,
+  groupBy: CostGroupBy
+): Record<string, CostBreakdown> {
+  if (groupBy === 'provider') return report.byProvider;
+  if (groupBy === 'day') return report.byDay;
+  return report.byModel;
+}
+
+/** Render the default aligned, human-readable dashboard. */
+export function formatCostReport(report: CostReport, groupBy: CostGroupBy = 'model'): string {
+  if (report.sessions === 0) {
+    return 'Aucune session sauvegardée ne correspond aux filtres.';
+  }
+
+  const lines = [
+    'Code Buddy — tableau de bord des dépenses',
+    '='.repeat(42),
+    `Période       : ${report.since ? `depuis ${report.since}` : 'toutes les sessions'}`,
+    `Sessions      : ${formatInteger(report.sessions)}`,
+    `Tours         : ${formatInteger(report.turns)}`,
+    `Coût total    : ${formatUsd(report.totalCost)}`,
+    `Tokens        : ${formatInteger(report.tokens.input)} in / ${formatInteger(report.tokens.output)} out`,
+    `Coût moyen    : ${formatUsd(report.averageCostPerTurn)} / tour`,
+  ];
+
+  if (report.tokens.unattributed > 0) {
+    lines.push(`Tokens non ventilés : ${formatInteger(report.tokens.unattributed)}`);
+  }
+  if (report.estimatedTurns > 0) {
+    lines.push(
+      `Coût estimé  : ${formatUsd(report.estimatedCost)} (${plural(
+        report.estimatedTurns,
+        'tour',
+        'tours'
+      )})`
+    );
+  }
+  if (report.unknownCostSessions > 0) {
+    lines.push(
+      `Coût inconnu : ${plural(report.unknownCostTurns, 'tour', 'tours')} dans ${plural(
+        report.unknownCostSessions,
+        'session',
+        'sessions'
+      )}`
+    );
+  }
+
+  const labels: Record<CostGroupBy, string> = {
+    model: 'Modèle',
+    provider: 'Provider',
+    day: 'Jour',
+  };
+  const breakdown = selectedBreakdown(report, groupBy);
+  const rows = Object.entries(breakdown).map(([key, value]) => [
+    key,
+    formatUsd(value.cost),
+    formatInteger(value.tokens.input),
+    formatInteger(value.tokens.output),
+    formatInteger(value.turns),
+    formatUsd(value.averageCostPerTurn),
+    qualityLabel(value),
+  ]);
+
+  if (rows.length > 0) {
+    lines.push(
+      '',
+      `Ventilation par ${groupBy === 'day' ? 'jour' : groupBy === 'provider' ? 'provider' : 'modèle'}`,
+      renderTable(
+        [labels[groupBy], 'Coût', 'Tokens in', 'Tokens out', 'Tours', 'Moy./tour', 'Qualité'],
+        rows
+      )
+    );
+  }
+  return lines.join('\n');
+}
+
+function normalizeLoadedSessions(
+  value: SavedCostSessions | readonly CostSessionEntry[]
+): SavedCostSessions {
+  return Array.isArray(value)
+    ? { sessions: [...value], warnings: [] }
+    : (value as SavedCostSessions);
+}
+
+export function createCostCommand(dependencies: CostCommandDependencies = {}): Command {
+  return new Command('cost')
+    .description('Afficher les dépenses agrégées depuis les sessions sauvegardées (read-only)')
+    .option('--last', 'Limiter le rapport à la session la plus récente', false)
+    .option('--session <id>', 'Limiter le rapport à un ID de session')
+    .option('--since <7d|YYYY-MM-DD>', 'Limiter les tours à une période', validateSince)
+    .option('--by <model|provider|day>', 'Ventilation du tableau', parseGroupBy, 'model')
+    .option('--json', 'Produire un JSON lisible par machine', false)
+    .action(async (options: CostCommandOptions) => {
+      const sessionsDirectory =
+        dependencies.sessionsDirectory ??
+        process.env.CODEBUDDY_SESSIONS_DIR ??
+        path.join(os.homedir(), '.codebuddy', 'sessions');
+      const loaded = normalizeLoadedSessions(
+        await (dependencies.loadSessions
+          ? dependencies.loadSessions()
+          : readSavedCostSessions(sessionsDirectory))
+      );
+      for (const warning of loaded.warnings) logger.warn(`[cost] ${warning}`);
+
+      const selected = selectSessions(loaded.sessions, options);
+      const now = dependencies.now?.() ?? new Date();
+      const report = aggregateCostReport(selected, {
+        now,
+        since: options.since,
+        resolvePricing: dependencies.resolvePricing ?? resolveCostPricing,
+      });
+      const write =
+        dependencies.stdout ?? ((message: string) => process.stdout.write(`${message}\n`));
+
+      if (options.json) {
+        const payload = {
+          ...report,
+          groupBy: options.by,
+          ...(report.sessions === 0
+            ? { message: 'Aucune session sauvegardée ne correspond aux filtres.' }
+            : {}),
+        };
+        write(JSON.stringify(payload, null, 2));
+        return;
+      }
+      write(formatCostReport(report, options.by));
+    });
+}

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,0 +1,672 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { Dirent } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Command } from 'commander';
+
+export interface ImportConfigOptions {
+  dryRun?: boolean;
+  from?: string;
+}
+
+export interface ImportConfigDependencies {
+  cwd?: string;
+  stdout?: (message: string) => void;
+}
+
+export type RuleImportStatus = 'imported' | 'already-imported';
+export type MCPImportStatus = 'imported' | 'existing' | 'duplicate';
+
+export interface RuleImportItem {
+  provider: string;
+  source: string;
+  status: RuleImportStatus;
+}
+
+export interface MCPImportItem {
+  name: string;
+  source: string;
+  status: MCPImportStatus;
+}
+
+export interface ConfigImportResult {
+  dryRun: boolean;
+  filesWritten: string[];
+  mcpServers: MCPImportItem[];
+  mcpServersImported: number;
+  ruleSources: RuleImportItem[];
+  ruleSourcesImported: number;
+  sourceRoot: string;
+  warnings: string[];
+}
+
+interface SafePathEntry {
+  kind: 'directory' | 'file';
+  realPath: string;
+}
+
+interface DiscoveredRuleSource {
+  content: string;
+  heading: string;
+  marker: string;
+  provider: string;
+  source: string;
+}
+
+interface DiscoveredMCPServer {
+  config: Record<string, unknown>;
+  name: string;
+  source: string;
+}
+
+interface DestinationMCPConfig {
+  config: Record<string, unknown>;
+  existingNames: Set<string>;
+  serverKey: 'mcpServers' | 'servers';
+  servers: Record<string, unknown>;
+}
+
+const MCP_SOURCE_PATHS = [
+  '.cursor/mcp.json',
+  '.vscode/mcp.json',
+  'claude_desktop_config.json',
+  '.mcp.json',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return isRecord(error) && error.code === code;
+}
+
+function isPathInside(parentPath: string, childPath: string): boolean {
+  const relative = path.relative(parentPath, childPath);
+  return (
+    relative === '' ||
+    (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+function toProjectPath(projectRoot: string, filePath: string): string {
+  return path.relative(projectRoot, filePath).split(path.sep).join('/');
+}
+
+function importMarker(source: string): string {
+  const digest = createHash('sha256').update(source).digest('hex').slice(0, 24);
+  return `<!-- codebuddy-import:${digest} -->`;
+}
+
+function hasImportedSource(existing: string, source: DiscoveredRuleSource): boolean {
+  if (existing.includes(source.marker)) return true;
+  return existing.split(/\r?\n/).some((line) => line.trimEnd() === source.heading);
+}
+
+function ruleBlock(source: DiscoveredRuleSource): string {
+  return [source.marker, source.heading, '', source.content.trimEnd()].join('\n');
+}
+
+function appendRuleBlocks(existing: string, sources: readonly DiscoveredRuleSource[]): string {
+  if (sources.length === 0) return existing;
+  const blocks = sources.map(ruleBlock).join('\n\n');
+  if (existing.length === 0) return `${blocks}\n`;
+  if (existing.endsWith('\n\n')) return `${existing}${blocks}\n`;
+  if (existing.endsWith('\n')) return `${existing}\n${blocks}\n`;
+  return `${existing}\n\n${blocks}\n`;
+}
+
+async function inspectSourcePath(
+  candidatePath: string,
+  projectRealRoot: string,
+  displayPath: string,
+  warnings: string[]
+): Promise<SafePathEntry | undefined> {
+  try {
+    await fs.lstat(candidatePath);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    warnings.push(
+      `Impossible d'inspecter ${displayPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
+
+  try {
+    const realPath = await fs.realpath(candidatePath);
+    if (!isPathInside(projectRealRoot, realPath)) {
+      warnings.push(`Source ignorée hors projet: ${displayPath}`);
+      return undefined;
+    }
+    const stat = await fs.stat(realPath);
+    if (stat.isFile()) return { kind: 'file', realPath };
+    if (stat.isDirectory()) return { kind: 'directory', realPath };
+    warnings.push(`Source ignorée (ni fichier ni dossier): ${displayPath}`);
+  } catch (error) {
+    warnings.push(
+      `Impossible de lire ${displayPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  return undefined;
+}
+
+async function readSafeTextFile(
+  projectRoot: string,
+  projectRealRoot: string,
+  candidatePath: string,
+  warnings: string[]
+): Promise<string | undefined> {
+  const displayPath = toProjectPath(projectRoot, candidatePath);
+  const entry = await inspectSourcePath(candidatePath, projectRealRoot, displayPath, warnings);
+  if (!entry || entry.kind !== 'file') return undefined;
+  try {
+    const content = await fs.readFile(entry.realPath, 'utf8');
+    if (content.includes('\0')) {
+      warnings.push(`Source binaire ignorée: ${displayPath}`);
+      return undefined;
+    }
+    return content;
+  } catch (error) {
+    warnings.push(
+      `Impossible de lire ${displayPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
+}
+
+async function discoverRuleFile(
+  provider: string,
+  candidatePath: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredRuleSource | undefined> {
+  const content = await readSafeTextFile(projectRoot, projectRealRoot, candidatePath, warnings);
+  if (content === undefined) return undefined;
+  const source = toProjectPath(projectRoot, candidatePath);
+  if (content.trim().length === 0) {
+    warnings.push(`Source de règles vide ignorée: ${source}`);
+    return undefined;
+  }
+  return {
+    content,
+    heading: `# Importé de ${provider} (${source})`,
+    marker: importMarker(source),
+    provider,
+    source,
+  };
+}
+
+async function listSafeDirectory(
+  directoryPath: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<Dirent<string>[] | undefined> {
+  const displayPath = toProjectPath(projectRoot, directoryPath);
+  const entry = await inspectSourcePath(directoryPath, projectRealRoot, displayPath, warnings);
+  if (!entry || entry.kind !== 'directory') return undefined;
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    warnings.push(
+      `Impossible de parcourir ${displayPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
+}
+
+async function discoverCursorRuleFiles(
+  sourceRoot: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredRuleSource[]> {
+  const rulesDirectory = path.join(sourceRoot, '.cursor', 'rules');
+  const entries = await listSafeDirectory(rulesDirectory, projectRoot, projectRealRoot, warnings);
+  if (!entries) return [];
+
+  const sources: DiscoveredRuleSource[] = [];
+  for (const entry of [...entries].sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.name.endsWith('.mdc')) continue;
+    const source = await discoverRuleFile(
+      'Cursor',
+      path.join(rulesDirectory, entry.name),
+      projectRoot,
+      projectRealRoot,
+      warnings
+    );
+    if (source) sources.push(source);
+  }
+  return sources;
+}
+
+async function discoverClineDirectoryFiles(
+  directoryPath: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredRuleSource[]> {
+  const entries = await listSafeDirectory(directoryPath, projectRoot, projectRealRoot, warnings);
+  if (!entries) return [];
+
+  const sources: DiscoveredRuleSource[] = [];
+  for (const entry of [...entries].sort((left, right) => left.name.localeCompare(right.name))) {
+    const candidatePath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      sources.push(
+        ...(await discoverClineDirectoryFiles(
+          candidatePath,
+          projectRoot,
+          projectRealRoot,
+          warnings
+        ))
+      );
+      continue;
+    }
+    if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+    const source = await discoverRuleFile(
+      'Cline',
+      candidatePath,
+      projectRoot,
+      projectRealRoot,
+      warnings
+    );
+    if (source) sources.push(source);
+  }
+  return sources;
+}
+
+async function discoverClineRules(
+  sourceRoot: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredRuleSource[]> {
+  const clinePath = path.join(sourceRoot, '.clinerules');
+  const displayPath = toProjectPath(projectRoot, clinePath);
+  const entry = await inspectSourcePath(clinePath, projectRealRoot, displayPath, warnings);
+  if (!entry) return [];
+  if (entry.kind === 'directory') {
+    return discoverClineDirectoryFiles(clinePath, projectRoot, projectRealRoot, warnings);
+  }
+  const source = await discoverRuleFile('Cline', clinePath, projectRoot, projectRealRoot, warnings);
+  return source ? [source] : [];
+}
+
+async function discoverRuleSources(
+  sourceRoot: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredRuleSource[]> {
+  const sources = await discoverCursorRuleFiles(sourceRoot, projectRoot, projectRealRoot, warnings);
+
+  const fixedSources: Array<[provider: string, relativePath: string]> = [
+    ['Cursor', '.cursorrules'],
+  ];
+  for (const [provider, relativePath] of fixedSources) {
+    const source = await discoverRuleFile(
+      provider,
+      path.join(sourceRoot, relativePath),
+      projectRoot,
+      projectRealRoot,
+      warnings
+    );
+    if (source) sources.push(source);
+  }
+
+  sources.push(...(await discoverClineRules(sourceRoot, projectRoot, projectRealRoot, warnings)));
+
+  const remainingSources: Array<[provider: string, relativePath: string]> = [
+    ['GitHub Copilot', '.github/copilot-instructions.md'],
+    ['Claude Code', 'CLAUDE.md'],
+  ];
+  for (const [provider, relativePath] of remainingSources) {
+    const source = await discoverRuleFile(
+      provider,
+      path.join(sourceRoot, relativePath),
+      projectRoot,
+      projectRealRoot,
+      warnings
+    );
+    if (source) sources.push(source);
+  }
+  return sources;
+}
+
+function parseJsonObject(content: string, source: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(
+      `JSON invalide dans ${source}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (!isRecord(parsed))
+    throw new Error(`Configuration JSON invalide dans ${source}: objet attendu.`);
+  return parsed;
+}
+
+async function discoverMCPServers(
+  sourceRoot: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  warnings: string[]
+): Promise<DiscoveredMCPServer[]> {
+  const discovered: DiscoveredMCPServer[] = [];
+  for (const relativePath of MCP_SOURCE_PATHS) {
+    const candidatePath = path.join(sourceRoot, relativePath);
+    const content = await readSafeTextFile(projectRoot, projectRealRoot, candidatePath, warnings);
+    if (content === undefined) continue;
+    const source = toProjectPath(projectRoot, candidatePath);
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = parseJsonObject(content, source);
+    } catch (error) {
+      warnings.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+
+    let foundServerMap = false;
+    for (const key of ['mcpServers', 'servers'] as const) {
+      const value = parsed[key];
+      if (value === undefined) continue;
+      if (!isRecord(value)) {
+        warnings.push(`Section ${key} invalide ignorée dans ${source}: objet attendu.`);
+        continue;
+      }
+      foundServerMap = true;
+      for (const [name, config] of Object.entries(value)) {
+        if (!isRecord(config)) {
+          warnings.push(`Serveur MCP invalide ignoré dans ${source}: ${name}`);
+          continue;
+        }
+        discovered.push({ config, name, source });
+      }
+    }
+    if (!foundServerMap) warnings.push(`Aucune section mcpServers/servers dans ${source}.`);
+  }
+  return discovered;
+}
+
+async function readDestinationText(
+  destinationPath: string,
+  projectRealRoot: string
+): Promise<string | undefined> {
+  let lstat;
+  try {
+    lstat = await fs.lstat(destinationPath);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+  if (lstat.isSymbolicLink()) {
+    throw new Error(`Destination symbolique refusée: ${destinationPath}`);
+  }
+  if (!lstat.isFile())
+    throw new Error(`Destination invalide (fichier attendu): ${destinationPath}`);
+  const realPath = await fs.realpath(destinationPath);
+  if (!isPathInside(projectRealRoot, realPath)) {
+    throw new Error(`Destination hors projet refusée: ${destinationPath}`);
+  }
+  return fs.readFile(realPath, 'utf8');
+}
+
+function destinationMCPConfig(content: string | undefined, source: string): DestinationMCPConfig {
+  const config = content === undefined ? {} : parseJsonObject(content, source);
+  const mcpServersValue = config.mcpServers;
+  const serversValue = config.servers;
+  if (mcpServersValue !== undefined && !isRecord(mcpServersValue)) {
+    throw new Error(
+      `Configuration existante invalide dans ${source}: mcpServers doit être un objet.`
+    );
+  }
+  if (serversValue !== undefined && !isRecord(serversValue)) {
+    throw new Error(`Configuration existante invalide dans ${source}: servers doit être un objet.`);
+  }
+
+  const mcpServers = isRecord(mcpServersValue) ? mcpServersValue : undefined;
+  const servers = isRecord(serversValue) ? serversValue : undefined;
+  const existingNames = new Set([...Object.keys(mcpServers ?? {}), ...Object.keys(servers ?? {})]);
+  if (mcpServers) return { config, existingNames, serverKey: 'mcpServers', servers: mcpServers };
+  if (servers) return { config, existingNames, serverKey: 'servers', servers };
+  return { config, existingNames, serverKey: 'mcpServers', servers: {} };
+}
+
+async function assertSafeDestination(
+  destinationPath: string,
+  projectRoot: string,
+  projectRealRoot: string
+): Promise<void> {
+  if (!isPathInside(projectRoot, path.resolve(destinationPath))) {
+    throw new Error(`Destination hors projet refusée: ${destinationPath}`);
+  }
+
+  let existingPath = destinationPath;
+  while (true) {
+    try {
+      const stat = await fs.lstat(existingPath);
+      if (existingPath === destinationPath && stat.isSymbolicLink()) {
+        throw new Error(`Destination symbolique refusée: ${destinationPath}`);
+      }
+      break;
+    } catch (error) {
+      if (!isErrno(error, 'ENOENT')) throw error;
+      const parent = path.dirname(existingPath);
+      if (parent === existingPath) throw new Error(`Aucun parent existant pour ${destinationPath}`);
+      existingPath = parent;
+    }
+  }
+
+  const realExistingPath = await fs.realpath(existingPath);
+  if (!isPathInside(projectRealRoot, realExistingPath)) {
+    throw new Error(`Destination hors projet refusée: ${destinationPath}`);
+  }
+}
+
+async function atomicWrite(
+  destinationPath: string,
+  content: string,
+  projectRoot: string,
+  projectRealRoot: string,
+  defaultMode: number
+): Promise<void> {
+  await assertSafeDestination(destinationPath, projectRoot, projectRealRoot);
+  const directory = path.dirname(destinationPath);
+  await fs.mkdir(directory, { recursive: true });
+  await assertSafeDestination(directory, projectRoot, projectRealRoot);
+  const mode = await fs
+    .stat(destinationPath)
+    .then((stat) => stat.mode & 0o777)
+    .catch((error: unknown) => {
+      if (isErrno(error, 'ENOENT')) return defaultMode;
+      throw error;
+    });
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(destinationPath)}.import-${process.pid}-${randomUUID()}.tmp`
+  );
+  try {
+    await fs.writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode });
+    await fs.rename(temporaryPath, destinationPath);
+  } catch (error) {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function resolveRoots(
+  cwd: string,
+  from: string | undefined
+): Promise<{ projectRealRoot: string; projectRoot: string; sourceRoot: string }> {
+  const projectRoot = path.resolve(cwd);
+  const projectStat = await fs.stat(projectRoot);
+  if (!projectStat.isDirectory()) throw new Error(`Projet invalide: ${projectRoot}`);
+  const projectRealRoot = await fs.realpath(projectRoot);
+  const sourceRoot = path.resolve(projectRoot, from ?? '.');
+  if (!isPathInside(projectRoot, sourceRoot)) {
+    throw new Error(`--from doit rester dans le projet courant: ${from}`);
+  }
+  const sourceRealRoot = await fs.realpath(sourceRoot).catch((error: unknown) => {
+    throw new Error(
+      `Dossier source introuvable: ${sourceRoot} (${error instanceof Error ? error.message : String(error)})`
+    );
+  });
+  if (!isPathInside(projectRealRoot, sourceRealRoot)) {
+    throw new Error(`--from pointe hors du projet courant: ${from}`);
+  }
+  const sourceStat = await fs.stat(sourceRealRoot);
+  if (!sourceStat.isDirectory()) throw new Error(`--from doit désigner un dossier: ${from}`);
+  return { projectRealRoot, projectRoot, sourceRoot };
+}
+
+export async function importProjectConfiguration(
+  options: ImportConfigOptions = {},
+  dependencies: ImportConfigDependencies = {}
+): Promise<ConfigImportResult> {
+  const dryRun = options.dryRun === true;
+  const roots = await resolveRoots(dependencies.cwd ?? process.cwd(), options.from);
+  const warnings: string[] = [];
+  const codeBuddyPath = path.join(roots.projectRoot, 'CODEBUDDY.md');
+  const mcpPath = path.join(roots.projectRoot, '.codebuddy', 'mcp.json');
+
+  const [discoveredRules, discoveredMCP, existingRules, existingMCPText] = await Promise.all([
+    discoverRuleSources(roots.sourceRoot, roots.projectRoot, roots.projectRealRoot, warnings),
+    discoverMCPServers(roots.sourceRoot, roots.projectRoot, roots.projectRealRoot, warnings),
+    readDestinationText(codeBuddyPath, roots.projectRealRoot).then((content) => content ?? ''),
+    readDestinationText(mcpPath, roots.projectRealRoot),
+  ]);
+
+  const rulesToImport: DiscoveredRuleSource[] = [];
+  const ruleSources: RuleImportItem[] = discoveredRules.map((source) => {
+    if (hasImportedSource(existingRules, source)) {
+      return { provider: source.provider, source: source.source, status: 'already-imported' };
+    }
+    rulesToImport.push(source);
+    return { provider: source.provider, source: source.source, status: 'imported' };
+  });
+
+  const targetMCP = destinationMCPConfig(
+    existingMCPText,
+    toProjectPath(roots.projectRoot, mcpPath)
+  );
+  const claimedNames = new Set(targetMCP.existingNames);
+  const mcpToImport: DiscoveredMCPServer[] = [];
+  const mcpServers: MCPImportItem[] = discoveredMCP.map((server) => {
+    if (targetMCP.existingNames.has(server.name)) {
+      return { name: server.name, source: server.source, status: 'existing' };
+    }
+    if (claimedNames.has(server.name)) {
+      return { name: server.name, source: server.source, status: 'duplicate' };
+    }
+    claimedNames.add(server.name);
+    mcpToImport.push(server);
+    return { name: server.name, source: server.source, status: 'imported' };
+  });
+
+  const filesWritten: string[] = [];
+  if (rulesToImport.length > 0) {
+    await assertSafeDestination(codeBuddyPath, roots.projectRoot, roots.projectRealRoot);
+  }
+  if (mcpToImport.length > 0) {
+    await assertSafeDestination(mcpPath, roots.projectRoot, roots.projectRealRoot);
+  }
+  if (!dryRun && rulesToImport.length > 0) {
+    await atomicWrite(
+      codeBuddyPath,
+      appendRuleBlocks(existingRules, rulesToImport),
+      roots.projectRoot,
+      roots.projectRealRoot,
+      0o644
+    );
+    filesWritten.push('CODEBUDDY.md');
+  }
+
+  if (!dryRun && mcpToImport.length > 0) {
+    const mergedServers = Object.fromEntries([
+      ...Object.entries(targetMCP.servers),
+      ...mcpToImport.map((server) => [server.name, server.config] as const),
+    ]);
+    const mergedConfig = { ...targetMCP.config, [targetMCP.serverKey]: mergedServers };
+    await atomicWrite(
+      mcpPath,
+      `${JSON.stringify(mergedConfig, null, 2)}\n`,
+      roots.projectRoot,
+      roots.projectRealRoot,
+      0o600
+    );
+    filesWritten.push('.codebuddy/mcp.json');
+  }
+
+  return {
+    dryRun,
+    filesWritten,
+    mcpServers,
+    mcpServersImported: mcpToImport.length,
+    ruleSources,
+    ruleSourcesImported: rulesToImport.length,
+    sourceRoot: toProjectPath(roots.projectRoot, roots.sourceRoot) || '.',
+    warnings,
+  };
+}
+
+function countLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function formatConfigImportResult(result: ConfigImportResult): string {
+  const lines = [
+    result.dryRun
+      ? `Aperçu de l’import depuis ${result.sourceRoot} (aucun fichier écrit)`
+      : `Import depuis ${result.sourceRoot}`,
+  ];
+
+  for (const item of result.ruleSources) {
+    const status =
+      item.status === 'already-imported'
+        ? 'déjà importée'
+        : result.dryRun
+          ? 'à importer'
+          : 'importée';
+    lines.push(
+      `  ${item.status === 'already-imported' ? '=' : '+'} Règles ${item.provider}: ${item.source} (${status})`
+    );
+  }
+  for (const item of result.mcpServers) {
+    const status =
+      item.status === 'existing'
+        ? 'nom déjà présent, conservé'
+        : item.status === 'duplicate'
+          ? 'doublon dans les sources, ignoré'
+          : result.dryRun
+            ? 'à importer'
+            : 'importé';
+    lines.push(
+      `  ${item.status === 'imported' ? '+' : '='} MCP ${item.name}: ${item.source} (${status})`
+    );
+  }
+  for (const warning of result.warnings) lines.push(`  ! ${warning}`);
+
+  const summaryPrefix = result.dryRun ? 'À importer' : 'Importé';
+  lines.push(
+    `${summaryPrefix} : ${countLabel(result.ruleSourcesImported, 'source de règles', 'sources de règles')}, ` +
+      `${countLabel(result.mcpServersImported, 'serveur MCP', 'serveurs MCP')}.`
+  );
+  return lines.join('\n');
+}
+
+export function createImportCommand(dependencies: ImportConfigDependencies = {}): Command {
+  return new Command('import')
+    .description('Importer les règles et serveurs MCP d’agents concurrents sans écraser l’existant')
+    .option('--dry-run', 'Lister les imports sans écrire de fichier', false)
+    .option('--from <chemin>', 'Dossier source situé dans le projet courant', '.')
+    .action(async (options: ImportConfigOptions) => {
+      const result = await importProjectConfiguration(options, dependencies);
+      const write =
+        dependencies.stdout ?? ((message: string) => process.stdout.write(`${message}\n`));
+      write(formatConfigImportResult(result));
+    });
+}

--- a/src/git/changelog.ts
+++ b/src/git/changelog.ts
@@ -1,0 +1,160 @@
+export interface ChangelogCommit {
+  hash: string;
+  subject: string;
+  body: string;
+}
+
+export type ChangelogSectionId =
+  | 'breaking'
+  | 'features'
+  | 'fixes'
+  | 'performance'
+  | 'docs'
+  | 'other';
+
+export interface ParsedConventionalCommit {
+  hash: string;
+  shortHash: string;
+  rawSubject: string;
+  subject: string;
+  type: string | null;
+  scope: string | null;
+  breaking: boolean;
+  conventional: boolean;
+}
+
+export type ChangelogEntry = ParsedConventionalCommit;
+
+export interface ChangelogSection {
+  id: ChangelogSectionId;
+  title: string;
+  entries: ChangelogEntry[];
+}
+
+export interface GroupedChangelog {
+  totalCommits: number;
+  sections: ChangelogSection[];
+}
+
+export const CHANGELOG_SECTION_ORDER: ReadonlyArray<
+  Readonly<{ id: ChangelogSectionId; title: string }>
+> = [
+  { id: 'breaking', title: '⚠ Breaking Changes' },
+  { id: 'features', title: 'Features' },
+  { id: 'fixes', title: 'Bug Fixes' },
+  { id: 'performance', title: 'Performance' },
+  { id: 'docs', title: 'Docs' },
+  { id: 'other', title: 'Autres' },
+];
+
+const CONVENTIONAL_HEADER = /^([a-z][a-z0-9-]*)(?:\(([^)\r\n]+)\))?(!)?:\s+(.+)$/;
+const BREAKING_FOOTER = /^BREAKING(?: CHANGE|-CHANGE):[ \t]*/m;
+const CONVENTIONAL_TYPES = new Set([
+  'feat',
+  'fix',
+  'docs',
+  'style',
+  'refactor',
+  'perf',
+  'test',
+  'chore',
+  'ci',
+  'build',
+  'revert',
+]);
+
+/** Parse one commit without reading Git or touching the filesystem. */
+export function parseConventionalCommit(commit: ChangelogCommit): ParsedConventionalCommit {
+  const rawSubject = commit.subject.trim();
+  const match = CONVENTIONAL_HEADER.exec(rawSubject);
+  const type = match?.[1]?.toLowerCase();
+
+  if (!match || !type || !CONVENTIONAL_TYPES.has(type)) {
+    return {
+      hash: commit.hash,
+      shortHash: commit.hash.slice(0, 7),
+      rawSubject,
+      subject: rawSubject || '(sans sujet)',
+      type: null,
+      scope: null,
+      breaking: false,
+      conventional: false,
+    };
+  }
+
+  const scope = match[2]?.trim() || null;
+  const subject = match[4]?.trim() || '(sans sujet)';
+
+  return {
+    hash: commit.hash,
+    shortHash: commit.hash.slice(0, 7),
+    rawSubject,
+    subject,
+    type,
+    scope,
+    breaking: match[3] === '!' || BREAKING_FOOTER.test(commit.body),
+    conventional: true,
+  };
+}
+
+function sectionFor(entry: ParsedConventionalCommit): ChangelogSectionId {
+  if (!entry.conventional) return 'other';
+  if (entry.breaking) return 'breaking';
+
+  switch (entry.type) {
+    case 'feat':
+      return 'features';
+    case 'fix':
+      return 'fixes';
+    case 'perf':
+      return 'performance';
+    case 'docs':
+      return 'docs';
+    default:
+      return 'other';
+  }
+}
+
+/** Group commits in the stable release-note section order. Each commit appears once. */
+export function groupChangelogCommits(commits: readonly ChangelogCommit[]): GroupedChangelog {
+  const sections: ChangelogSection[] = CHANGELOG_SECTION_ORDER.map((section) => ({
+    ...section,
+    entries: [],
+  }));
+  const sectionsById = new Map(sections.map((section) => [section.id, section]));
+
+  for (const commit of commits) {
+    const entry = parseConventionalCommit(commit);
+    sectionsById.get(sectionFor(entry))?.entries.push(entry);
+  }
+
+  return {
+    totalCommits: commits.length,
+    sections,
+  };
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replace(/([\\`*_[\]<>])/g, '\\$1');
+}
+
+function renderEntry(entry: ChangelogEntry): string {
+  const subject = escapeMarkdownInline(entry.subject);
+  const prefix = entry.scope ? `**${escapeMarkdownInline(entry.scope)}:** ` : '';
+  return `- ${prefix}${subject} (${entry.shortHash})`;
+}
+
+/** Render only populated groups, preserving the canonical section order. */
+export function renderChangelogMarkdown(changelog: GroupedChangelog): string {
+  if (changelog.totalCommits === 0) {
+    return '# Release notes\n\n_Aucun commit trouvé sur la plage demandée._\n';
+  }
+
+  const lines = ['# Release notes', ''];
+  for (const section of changelog.sections) {
+    if (section.entries.length === 0) continue;
+    lines.push(`## ${section.title}`, '', ...section.entries.map(renderEntry), '');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3431,6 +3431,39 @@ addLazyCommand(
   },
 );
 
+// Cost dashboard — read-only aggregation of persisted session JSON
+addLazyCommand(
+  program,
+  'cost',
+  'Aggregate saved-session cost and token usage by model, provider, or day',
+  async () => {
+    const { createCostCommand } = await import('./commands/cost.js');
+    return createCostCommand();
+  },
+);
+
+// Changelog — grouped release notes from Conventional Commits
+addLazyCommand(
+  program,
+  'changelog',
+  'Generate grouped release notes from Conventional Commits',
+  async () => {
+    const { createChangelogCommand } = await import('./commands/changelog.js');
+    return createChangelogCommand();
+  },
+);
+
+// Import — project rules + MCP servers from Cursor / Cline / Copilot / Claude Code
+addLazyCommand(
+  program,
+  'import',
+  'Import project rules and MCP servers from Cursor, Cline, Copilot, or Claude Code',
+  async () => {
+    const { createImportCommand } = await import('./commands/import.js');
+    return createImportCommand();
+  },
+);
+
 // AI-Scientist-lite (Phases 0-3) — human-gated, sandboxed experiment: single pass or bounded discovery loop (opt-in)
 addLazyCommand(
   program,

--- a/tests/commands/changelog.test.ts
+++ b/tests/commands/changelog.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createChangelogCommand, type ChangelogGitRunner } from '../../src/commands/changelog.js';
+import type { ChangelogCommit } from '../../src/git/changelog.js';
+
+const temporaryDirectories: string[] = [];
+const TO_HASH = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const SINCE_HASH = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function gitLog(commits: readonly ChangelogCommit[]): string {
+  return `${commits.map((commit) => `${commit.hash}\0${commit.subject}\0${commit.body}`).join('\0')}\0`;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('buddy changelog command', () => {
+  it('uses the last reachable tag by default and prints Markdown to stdout', async () => {
+    const calls: string[][] = [];
+    const runGit: ChangelogGitRunner = async (args) => {
+      calls.push([...args]);
+      if (args[0] === 'rev-parse' && args[1] === '--git-dir') return '.git\n';
+      if (args[0] === 'rev-parse' && args.at(-1) === 'HEAD^{commit}') return `${TO_HASH}\n`;
+      if (args[0] === 'describe') return 'v1.2.0\n';
+      if (args[0] === 'rev-parse' && args.at(-1) === 'v1.2.0^{commit}') {
+        return `${SINCE_HASH}\n`;
+      }
+      if (args[0] === 'log') {
+        return gitLog([
+          {
+            hash: '1234567890abcdef1234567890abcdef12345678',
+            subject: 'feat(cli): ajoute changelog',
+            body: '',
+          },
+        ]);
+      }
+      throw new Error(`Commande Git inattendue : ${args.join(' ')}`);
+    };
+    const stdout: string[] = [];
+
+    await createChangelogCommand({
+      cwd: '/repo',
+      runGit,
+      stdout: (value) => stdout.push(value),
+    }).parseAsync(['node', 'changelog']);
+
+    expect(calls).toContainEqual([
+      'log',
+      '-z',
+      '--no-color',
+      '--format=%H%x00%s%x00%b',
+      `${SINCE_HASH}..${TO_HASH}`,
+      '--',
+    ]);
+    expect(stdout.join('')).toContain('## Features');
+    expect(stdout.join('')).toContain('**cli:** ajoute changelog (1234567)');
+  });
+
+  it('falls back to the full history when no tag is reachable', async () => {
+    const calls: string[][] = [];
+    const runGit: ChangelogGitRunner = async (args) => {
+      calls.push([...args]);
+      if (args[0] === 'rev-parse' && args[1] === '--git-dir') return '.git\n';
+      if (args[0] === 'rev-parse') return `${TO_HASH}\n`;
+      if (args[0] === 'describe') throw new Error('No names found');
+      if (args[0] === 'log') {
+        return gitLog([
+          {
+            hash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+            subject: 'Initial import',
+            body: '',
+          },
+        ]);
+      }
+      throw new Error(`Commande Git inattendue : ${args.join(' ')}`);
+    };
+    const stdout: string[] = [];
+
+    await createChangelogCommand({
+      cwd: '/repo',
+      runGit,
+      stdout: (value) => stdout.push(value),
+    }).parseAsync(['node', 'changelog']);
+
+    expect(calls).toContainEqual([
+      'log',
+      '-z',
+      '--no-color',
+      '--format=%H%x00%s%x00%b',
+      TO_HASH,
+      '--',
+    ]);
+    expect(stdout.join('')).toContain('## Autres');
+    expect(stdout.join('')).toContain('Initial import (abcdefa)');
+  });
+
+  it('emits valid grouped JSON and a clear message for an empty date range', async () => {
+    const runGit: ChangelogGitRunner = async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-dir') return '.git\n';
+      if (args[0] === 'rev-parse') return `${TO_HASH}\n`;
+      if (args[0] === 'log') return '';
+      throw new Error(`Commande Git inattendue : ${args.join(' ')}`);
+    };
+    const stdout: string[] = [];
+
+    await createChangelogCommand({
+      cwd: '/repo',
+      runGit,
+      stdout: (value) => stdout.push(value),
+    }).parseAsync(['node', 'changelog', '--since', '2026-08-16', '--json']);
+
+    const result = JSON.parse(stdout.join('')) as {
+      totalCommits: number;
+      message: string;
+      range: { mode: string; since: string };
+      sections: Array<{ title: string }>;
+    };
+    expect(result.totalCommits).toBe(0);
+    expect(result.message).toContain('Aucun commit trouvé sur la plage');
+    expect(result.range).toMatchObject({ mode: 'date', since: '2026-08-16' });
+    expect(result.sections.map((section) => section.title)).toEqual([
+      '⚠ Breaking Changes',
+      'Features',
+      'Bug Fixes',
+      'Performance',
+      'Docs',
+      'Autres',
+    ]);
+  });
+
+  it('prepends Markdown to --out while preserving the existing file', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'buddy-changelog-test-'));
+    temporaryDirectories.push(cwd);
+    const outputPath = path.join(cwd, 'CHANGELOG.md');
+    await fs.writeFile(outputPath, '# Changelog\n\nAncien contenu.\n', 'utf8');
+
+    const runGit: ChangelogGitRunner = async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-dir') return '.git\n';
+      if (args[0] === 'rev-parse' && args.at(-1) === 'HEAD^{commit}') return `${TO_HASH}\n`;
+      if (args[0] === 'rev-parse' && args.at(-1) === 'v1.0.0^{commit}') {
+        return `${SINCE_HASH}\n`;
+      }
+      if (args[0] === 'log') {
+        return gitLog([
+          {
+            hash: '76543210abcdef76543210abcdef76543210abcd',
+            subject: 'fix(output): conserve le contenu',
+            body: '',
+          },
+        ]);
+      }
+      throw new Error(`Commande Git inattendue : ${args.join(' ')}`);
+    };
+
+    await createChangelogCommand({ cwd, runGit }).parseAsync([
+      'node',
+      'changelog',
+      '--since',
+      'v1.0.0',
+      '--out',
+      'CHANGELOG.md',
+    ]);
+
+    const written = await fs.readFile(outputPath, 'utf8');
+    expect(written).toMatch(/^# Release notes/);
+    expect(written).toContain('- **output:** conserve le contenu (7654321)');
+    expect(written.indexOf('# Release notes')).toBeLessThan(written.indexOf('# Changelog'));
+    expect(written).toContain('Ancien contenu.');
+  });
+
+  it('fails explicitly outside a Git repository', async () => {
+    const runGit: ChangelogGitRunner = async () => {
+      throw new Error('fatal: not a git repository');
+    };
+    const stderr: string[] = [];
+    const command = createChangelogCommand({ cwd: '/pas-un-repo', runGit });
+    command.exitOverride();
+    command.configureOutput({ writeErr: (value) => stderr.push(value) });
+
+    await expect(command.parseAsync(['node', 'changelog'])).rejects.toMatchObject({
+      code: 'buddy.changelog',
+      exitCode: 1,
+    });
+    expect(stderr.join('')).toContain('Ce dossier n’est pas un dépôt Git : /pas-un-repo');
+  });
+});

--- a/tests/commands/cost.test.ts
+++ b/tests/commands/cost.test.ts
@@ -1,0 +1,173 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createCostCommand,
+  readSavedCostSessions,
+  type SavedCostSessions,
+} from '../../src/commands/cost.js';
+import type { CostSessionEntry } from '../../src/analytics/cost-report.js';
+
+describe('buddy cost', () => {
+  const now = new Date('2026-08-16T12:00:00.000Z');
+  let sessions: CostSessionEntry[];
+
+  beforeEach(() => {
+    sessions = [
+      {
+        id: 'older',
+        model: 'gpt-4o-mini',
+        provider: 'openai',
+        createdAt: '2026-08-10T08:00:00.000Z',
+        lastAccessedAt: '2026-08-10T08:05:00.000Z',
+        turns: [
+          {
+            timestamp: '2026-08-10T08:00:00.000Z',
+            inputTokens: 1_000,
+            outputTokens: 500,
+            costUsd: 0.001,
+          },
+        ],
+      },
+      {
+        id: 'latest',
+        model: 'qwen3:8b',
+        provider: 'ollama',
+        createdAt: '2026-08-15T08:00:00.000Z',
+        lastAccessedAt: '2026-08-15T08:05:00.000Z',
+        messages: [
+          { type: 'user', content: 'Question', timestamp: '2026-08-15T08:00:00.000Z' },
+          { type: 'assistant', content: 'Réponse', timestamp: '2026-08-15T08:01:00.000Z' },
+        ],
+      },
+    ];
+  });
+
+  it('renders an aligned provider table and signals unknown cost', async () => {
+    const output: string[] = [];
+    await createCostCommand({
+      loadSessions: async (): Promise<SavedCostSessions> => ({ sessions, warnings: [] }),
+      now: () => now,
+      stdout: (message) => output.push(message),
+    })
+      .exitOverride()
+      .parseAsync(['node', 'cost', '--by', 'provider']);
+
+    expect(output).toHaveLength(1);
+    expect(output[0]).toContain('Code Buddy — tableau de bord des dépenses');
+    expect(output[0]).toContain('Ventilation par provider');
+    expect(output[0]).toContain('openai');
+    expect(output[0]).toContain('ollama');
+    expect(output[0]).toContain('Coût inconnu : 1 tour dans 1 session');
+    expect(output[0]).toMatch(/Provider\s+Coût\s+Tokens in\s+Tokens out\s+Tours/);
+  });
+
+  it('selects --last and emits machine-readable JSON', async () => {
+    const output: string[] = [];
+    await createCostCommand({
+      loadSessions: async () => sessions,
+      now: () => now,
+      stdout: (message) => output.push(message),
+    })
+      .exitOverride()
+      .parseAsync(['node', 'cost', '--last', '--json']);
+
+    const report = JSON.parse(output[0] ?? '{}') as {
+      sessions: number;
+      turns: number;
+      groupBy: string;
+      byModel: Record<string, unknown>;
+      unknownCostSessions: number;
+    };
+    expect(report.sessions).toBe(1);
+    expect(report.turns).toBe(1);
+    expect(report.groupBy).toBe('model');
+    expect(Object.keys(report.byModel)).toEqual(['qwen3:8b']);
+    expect(report.unknownCostSessions).toBe(1);
+  });
+
+  it('returns a clear no-session result without throwing', async () => {
+    const human: string[] = [];
+    await createCostCommand({
+      loadSessions: async () => [],
+      now: () => now,
+      stdout: (message) => human.push(message),
+    })
+      .exitOverride()
+      .parseAsync(['node', 'cost']);
+    expect(human).toEqual(['Aucune session sauvegardée ne correspond aux filtres.']);
+
+    const json: string[] = [];
+    await createCostCommand({
+      loadSessions: async () => [],
+      now: () => now,
+      stdout: (message) => json.push(message),
+    })
+      .exitOverride()
+      .parseAsync(['node', 'cost', '--json']);
+    expect(JSON.parse(json[0] ?? '{}')).toMatchObject({
+      sessions: 0,
+      turns: 0,
+      message: 'Aucune session sauvegardée ne correspond aux filtres.',
+    });
+  });
+
+  it('rejects conflicting selectors and unknown session IDs', async () => {
+    const command = () =>
+      createCostCommand({
+        loadSessions: async () => sessions,
+        now: () => now,
+        stdout: () => undefined,
+      }).exitOverride();
+
+    await expect(
+      command().parseAsync(['node', 'cost', '--last', '--session', 'latest'])
+    ).rejects.toThrow('incompatibles');
+    await expect(command().parseAsync(['node', 'cost', '--session', 'missing'])).rejects.toThrow(
+      'Session introuvable'
+    );
+  });
+});
+
+describe('readSavedCostSessions', () => {
+  let tempDirectory: string;
+
+  beforeEach(async () => {
+    tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'buddy-cost-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDirectory, { recursive: true, force: true });
+  });
+
+  it('reads direct and legacy-container JSON while skipping malformed files', async () => {
+    await fs.writeFile(
+      path.join(tempDirectory, 'direct.json'),
+      JSON.stringify({ id: 'direct', model: 'gpt-4o', messages: [] })
+    );
+    await fs.writeFile(
+      path.join(tempDirectory, 'sessions.json'),
+      JSON.stringify({
+        sessions: [
+          { id: 'legacy', model: 'grok-3', messages: [] },
+          { id: 'direct', model: 'stale-container-copy', messages: [] },
+        ],
+      })
+    );
+    await fs.writeFile(path.join(tempDirectory, 'broken.json'), '{');
+
+    const result = await readSavedCostSessions(tempDirectory);
+
+    expect(result.sessions.map((entry) => entry.id).sort()).toEqual(['direct', 'legacy']);
+    expect(result.sessions.find((entry) => entry.id === 'direct')?.model).toBe('gpt-4o');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('broken.json');
+  });
+
+  it('does not create a missing sessions directory', async () => {
+    const missing = path.join(tempDirectory, 'does-not-exist');
+    await expect(readSavedCostSessions(missing)).resolves.toEqual({ sessions: [], warnings: [] });
+    await expect(fs.stat(missing)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/tests/commands/import.test.ts
+++ b/tests/commands/import.test.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createImportCommand,
+  formatConfigImportResult,
+  importProjectConfiguration,
+} from '../../src/commands/import.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryProject(prefix = 'codebuddy-import-'): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeFixture(root: string, relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+async function readJson(root: string, relativePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(path.join(root, relativePath), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('buddy import', () => {
+  it('consolidates every supported rule source and merges MCP servers by name', async () => {
+    const root = await temporaryProject();
+    await writeFixture(
+      root,
+      'CODEBUDDY.md',
+      '# Règles Code Buddy existantes\n\nConserver ce texte.\n'
+    );
+    await writeFixture(root, 'AGENTS.md', '# Guide partagé\n\nNe pas modifier.\n');
+    await writeFixture(
+      root,
+      '.cursor/rules/typescript.mdc',
+      '---\ndescription: TypeScript strict\n---\n\nToujours typer les retours.\n'
+    );
+    await writeFixture(root, '.cursorrules', 'Règle Cursor historique.\n');
+    await writeFixture(root, '.clinerules/01-tests.md', 'Tester les chemins d’échec.\n');
+    await writeFixture(root, '.clinerules/nested/02-docs.md', 'Documenter les décisions.\n');
+    await writeFixture(root, '.github/copilot-instructions.md', 'Copilot exige des imports ESM.\n');
+    await writeFixture(root, 'CLAUDE.md', 'Claude exige des imports avec extension .js.\n');
+
+    await writeFixture(
+      root,
+      '.codebuddy/mcp.json',
+      `${JSON.stringify(
+        {
+          description: 'À préserver',
+          mcpServers: {
+            existing: { command: 'existing-command', args: ['--keep'], enabled: false },
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
+    await writeFixture(
+      root,
+      '.cursor/mcp.json',
+      JSON.stringify({
+        mcpServers: {
+          existing: { command: 'must-not-win' },
+          shared: { command: 'cursor-shared' },
+          cursor: { command: 'cursor-only', env: { CURSOR_TOKEN: '${CURSOR_TOKEN}' } },
+        },
+      })
+    );
+    await writeFixture(
+      root,
+      '.vscode/mcp.json',
+      JSON.stringify({
+        servers: {
+          shared: { command: 'vscode-must-not-win' },
+          vscode: { type: 'http', url: 'https://mcp.example.test' },
+        },
+      })
+    );
+    await writeFixture(
+      root,
+      'claude_desktop_config.json',
+      JSON.stringify({ mcpServers: { claude: { command: 'claude-server' } } })
+    );
+    await writeFixture(
+      root,
+      '.mcp.json',
+      JSON.stringify({ mcpServers: { portable: { command: 'portable-server' } } })
+    );
+
+    const result = await importProjectConfiguration({}, { cwd: root });
+
+    expect(result.ruleSourcesImported).toBe(6);
+    expect(result.mcpServersImported).toBe(5);
+    expect(result.filesWritten).toEqual(['CODEBUDDY.md', '.codebuddy/mcp.json']);
+
+    const codeBuddy = await fs.readFile(path.join(root, 'CODEBUDDY.md'), 'utf8');
+    expect(codeBuddy).toMatch(/^# Règles Code Buddy existantes/);
+    expect(codeBuddy).toContain('Conserver ce texte.');
+    expect(codeBuddy).toContain('# Importé de Cursor (.cursor/rules/typescript.mdc)');
+    expect(codeBuddy).toContain('# Importé de Cursor (.cursorrules)');
+    expect(codeBuddy).toContain('# Importé de Cline (.clinerules/01-tests.md)');
+    expect(codeBuddy).toContain('# Importé de Cline (.clinerules/nested/02-docs.md)');
+    expect(codeBuddy).toContain('# Importé de GitHub Copilot (.github/copilot-instructions.md)');
+    expect(codeBuddy).toContain('# Importé de Claude Code (CLAUDE.md)');
+    expect(codeBuddy).toContain('description: TypeScript strict');
+    expect(await fs.readFile(path.join(root, 'AGENTS.md'), 'utf8')).toBe(
+      '# Guide partagé\n\nNe pas modifier.\n'
+    );
+
+    const mcp = await readJson(root, '.codebuddy/mcp.json');
+    expect(mcp.description).toBe('À préserver');
+    expect(mcp.mcpServers).toEqual({
+      existing: { command: 'existing-command', args: ['--keep'], enabled: false },
+      shared: { command: 'cursor-shared' },
+      cursor: { command: 'cursor-only', env: { CURSOR_TOKEN: '${CURSOR_TOKEN}' } },
+      vscode: { type: 'http', url: 'https://mcp.example.test' },
+      claude: { command: 'claude-server' },
+      portable: { command: 'portable-server' },
+    });
+
+    const summary = formatConfigImportResult(result);
+    expect(summary).toContain('Importé : 6 sources de règles, 5 serveurs MCP.');
+    expect(summary).toContain('MCP existing: .cursor/mcp.json (nom déjà présent, conservé)');
+    expect(summary).toContain('MCP shared: .vscode/mcp.json (doublon dans les sources, ignoré)');
+  });
+
+  it('is byte-for-byte idempotent on a second run', async () => {
+    const root = await temporaryProject();
+    await writeFixture(root, '.cursorrules', 'Ne jamais écraser le travail local.\n');
+    await writeFixture(
+      root,
+      '.cursor/mcp.json',
+      JSON.stringify({ mcpServers: { browser: { command: 'browser-mcp' } } })
+    );
+
+    const first = await importProjectConfiguration({}, { cwd: root });
+    const firstRules = await fs.readFile(path.join(root, 'CODEBUDDY.md'));
+    const firstMCP = await fs.readFile(path.join(root, '.codebuddy/mcp.json'));
+    const second = await importProjectConfiguration({}, { cwd: root });
+
+    expect(first.ruleSourcesImported).toBe(1);
+    expect(first.mcpServersImported).toBe(1);
+    expect(second.ruleSourcesImported).toBe(0);
+    expect(second.mcpServersImported).toBe(0);
+    expect(second.filesWritten).toEqual([]);
+    expect(await fs.readFile(path.join(root, 'CODEBUDDY.md'))).toEqual(firstRules);
+    expect(await fs.readFile(path.join(root, '.codebuddy/mcp.json'))).toEqual(firstMCP);
+    expect(firstRules.toString('utf8').match(/codebuddy-import:/g) ?? []).toHaveLength(1);
+  });
+
+  it('supports a Cline rules file and leaves the project untouched in dry-run mode', async () => {
+    const root = await temporaryProject();
+    await writeFixture(root, 'migration/.clinerules', 'Règle Cline monofichier.\n');
+    await writeFixture(
+      root,
+      'migration/.mcp.json',
+      JSON.stringify({ mcpServers: { fixture: { command: 'fixture-mcp' } } })
+    );
+    const output: string[] = [];
+    const command = createImportCommand({ cwd: root, stdout: (message) => output.push(message) });
+
+    await command.parseAsync(['node', 'import', '--dry-run', '--from', 'migration']);
+
+    expect(output.join('\n')).toContain(
+      'Aperçu de l’import depuis migration (aucun fichier écrit)'
+    );
+    expect(output.join('\n')).toContain('À importer : 1 source de règles, 1 serveur MCP.');
+    await expect(fs.stat(path.join(root, 'CODEBUDDY.md'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.stat(path.join(root, '.codebuddy'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects --from paths outside the current project', async () => {
+    const root = await temporaryProject('codebuddy-import-project-');
+    const outside = await temporaryProject('codebuddy-import-outside-');
+    await writeFixture(outside, '.cursorrules', 'Ne doit pas être lu.\n');
+
+    await expect(importProjectConfiguration({ from: outside }, { cwd: root })).rejects.toThrow(
+      '--from doit rester dans le projet courant'
+    );
+    await expect(fs.stat(path.join(root, 'CODEBUDDY.md'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('does not partially append rules when the existing MCP destination is invalid', async () => {
+    const root = await temporaryProject();
+    await writeFixture(root, 'CODEBUDDY.md', '# Contenu intact\n');
+    await writeFixture(root, '.cursorrules', 'Nouvelle règle.\n');
+    await writeFixture(root, '.codebuddy/mcp.json', '{ invalide');
+
+    await expect(importProjectConfiguration({}, { cwd: root })).rejects.toThrow(
+      'JSON invalide dans .codebuddy/mcp.json'
+    );
+    expect(await fs.readFile(path.join(root, 'CODEBUDDY.md'), 'utf8')).toBe('# Contenu intact\n');
+    expect(await fs.readFile(path.join(root, '.codebuddy/mcp.json'), 'utf8')).toBe('{ invalide');
+  });
+});


### PR DESCRIPTION
## Périmètre

Découpe (a) de la PR parapluie #70 (`feat/mysoulmate-media-pipeline`, 613 fichiers, non mergeable). Extraire uniquement les CLI utilitaires qui n'existent pas sur `main`.

Livré :

- `buddy cost` — tableau de bord read-only des dépenses agrégées depuis les sessions JSON persistées (`--last` / `--session` / `--since` / `--by` / `--json`)
- `buddy changelog` — release notes groupées depuis les Conventional Commits (`--since` / `--to` / `--out` / `--json`)
- `buddy import` — import des règles et serveurs MCP depuis Cursor, Cline, Copilot, Claude Code (idempotent, `--dry-run`, refuse `--from` hors projet)

Fichiers :

- `src/commands/cost.ts`, `src/commands/changelog.ts`, `src/commands/import.ts`
- moteurs purs requis par ces commandes (absents de `main`, zéro I/O, zéro couplage hors Node) : `src/analytics/cost-report.ts`, `src/git/changelog.ts`
- tests : `tests/commands/cost.test.ts`, `tests/commands/changelog.test.ts`, `tests/commands/import.test.ts`
- câblage **minimal** dans `src/index.ts` : 3 × `addLazyCommand` calqués sur `papers` (+33 lignes). Pas le diff de 251 lignes de `index.ts` de #70.

## Adapté aux API actuelles de `main`

- imports `.js`, `logger` (aucun `console.*`)
- `getModelPricing()` de `src/config/model-pricing.ts` (registre canonique actuel) pour estimer les tours sans coût stocké ; providers unmetered (ollama, chatgpt-oauth, lemonade, …) restent à $0
- `CostSessionEntry` est un record lâche : accepte les formes de session camelCase / snake_case déjà persistées
- pas de `ModelRoutingFacade` / `cost-tracker` : le dashboard lit les fichiers de session, distinct de `buddy insights cost` (singleton in-process)

## Écarté

**`buddy explain`** (et `tests/commands/explain.test.ts`). Trop couplé à du code absent de `main` (> 1 h de réparation) :

- `src/analytics/repo-explainer.ts` (~915 L)
- `src/analytics/repo-explainer-collector.ts` (~442 L) — importe `RepoProfiler`, `CodeExplorerManager`, `generateDocs`, `code-evolution`, `codebase-heatmap`, `complexity-analyzer`
- `src/export/repo-explanation.ts` (~414 L) — importe `exportStandaloneHtmlDocument` depuis `session-share.js`, **absent** de `main` (`src/export/` n'a que `knowledge-base-export.ts`)

Le 1er test d'`explain` appelle le collecteur réel ; un stub ne produit pas l'artefact attendu. À re-porter plus tard avec le moteur explainer, pas dans cette PR.

Non repris volontairement (hors lot) : `mcp serve`, first-run/onboarding, LSP, mentions `@file`, pipeline média/LoRA/influencer, docs/studies.

## Vérification

```
npx tsc --noEmit
# exit 0

npx eslint src/commands/cost.ts src/commands/changelog.ts src/commands/import.ts src/analytics/cost-report.ts src/git/changelog.ts src/index.ts
# 0 error (1 warning préexistant @typescript-eslint/no-explicit-any src/index.ts:1511)

npx vitest run tests/commands/cost.test.ts tests/commands/changelog.test.ts tests/commands/import.test.ts
# Test Files 3 passed / Tests 16 passed

npx tsx src/index.ts cost --help
# Usage: buddy cost [options]

npx tsx src/index.ts changelog --help
# Usage: buddy changelog [options]

npx tsx src/index.ts import --help
# Usage: buddy import [options]
```

Ne pas merger depuis cette PR sans relecture humaine. La PR #70 parapluie reste ouverte jusqu'aux autres lots.
