### PR TITLE
feat(cowork-chat): chat-ui parity with gitnexus-rs (rebased from PR #40)

### DIFF
--- a/cowork/src/renderer/components/HealthBadge.tsx
+++ b/cowork/src/renderer/components/HealthBadge.tsx
@@ -1,0 +1,158 @@
+import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useBackendStatus, type BackendStatus } from '../hooks/use-backend-status';
+
+/**
+ * Small permanent badge showing the Code Buddy backend status. Mirrors
+ * the chat-ui gitnexus-rs `BackendStatus` UX: a colored dot in a
+ * compact pill, click to open a tooltip-popup with the endpoint, last
+ * success time, and the latest error if any.
+ *
+ * Hidden entirely when the CodeBuddy integration is disabled in
+ * config (no need to occupy precious titlebar real estate for a
+ * never-going-to-light-up badge).
+ */
+export function HealthBadge() {
+  const { t } = useTranslation();
+  const status = useBackendStatus();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    const onEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  if (status.status === 'disabled') return null;
+
+  const style = badgeStyleFor(status.status);
+  const labelKey = `healthBadge.status.${status.status}`;
+  const label = t(labelKey, defaultLabelFor(status.status));
+
+  return (
+    <div ref={containerRef} className="relative" data-testid="health-badge">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-[11px] transition-colors ${style.pill}`}
+        aria-label={label}
+        aria-expanded={open}
+        title={label}
+      >
+        <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+        <span className="hidden sm:inline">{label}</span>
+      </button>
+      {open && <HealthPopup status={status} />}
+    </div>
+  );
+}
+
+function HealthPopup({ status }: { status: BackendStatus }) {
+  const { t } = useTranslation();
+  const lastSuccess = status.lastSuccessAt
+    ? new Date(status.lastSuccessAt).toLocaleTimeString()
+    : t('healthBadge.never', 'jamais');
+
+  return (
+    <div
+      role="dialog"
+      className="absolute right-0 top-full mt-1 w-72 z-50 rounded-lg border border-border bg-surface shadow-lg p-3 text-[12px]"
+    >
+      <div className="font-medium text-text-primary mb-2">
+        {t('healthBadge.title', 'Backend Code Buddy')}
+      </div>
+      <div className="space-y-1 text-text-muted">
+        <Row label={t('healthBadge.endpoint', 'Endpoint')} value={status.endpoint ?? '—'} />
+        <Row
+          label={t('healthBadge.statusLabel', 'État')}
+          value={t(`healthBadge.status.${status.status}`, defaultLabelFor(status.status))}
+        />
+        {status.version && (
+          <Row label={t('healthBadge.version', 'Version')} value={status.version} />
+        )}
+        <Row label={t('healthBadge.lastSuccess', 'Dernier OK')} value={lastSuccess} />
+        {status.lastError && (
+          <Row
+            label={t('healthBadge.lastError', 'Dernière erreur')}
+            value={status.lastError}
+            isError
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value, isError }: { label: string; value: string; isError?: boolean }) {
+  return (
+    <div className="flex justify-between gap-3">
+      <span className="text-text-muted/80">{label}</span>
+      <span
+        className={`text-right break-all ${isError ? 'text-error' : 'text-text-primary'}`}
+        style={{ maxWidth: '70%' }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface BadgeStyle {
+  pill: string;
+  dot: string;
+}
+
+function badgeStyleFor(status: BackendStatus['status']): BadgeStyle {
+  switch (status) {
+    case 'online':
+      return {
+        pill: 'border-success/40 bg-success/10 text-success hover:bg-success/15',
+        dot: 'bg-success animate-pulse',
+      };
+    case 'checking':
+    case 'unknown':
+      return {
+        pill: 'border-warning/40 bg-warning/10 text-warning hover:bg-warning/15',
+        dot: 'bg-warning animate-pulse',
+      };
+    case 'offline':
+      return {
+        pill: 'border-error/40 bg-error/10 text-error hover:bg-error/15',
+        dot: 'bg-error',
+      };
+    case 'disabled':
+    default:
+      return {
+        pill: 'border-border-subtle bg-surface text-text-muted',
+        dot: 'bg-text-muted/40',
+      };
+  }
+}
+
+function defaultLabelFor(status: BackendStatus['status']): string {
+  switch (status) {
+    case 'online':
+      return 'En ligne';
+    case 'checking':
+      return 'Vérification…';
+    case 'offline':
+      return 'Hors ligne';
+    case 'disabled':
+      return 'Désactivé';
+    case 'unknown':
+    default:
+      return 'Inconnu';
+  }
+}

--- a/cowork/src/renderer/components/MessageComposer.tsx
+++ b/cowork/src/renderer/components/MessageComposer.tsx
@@ -8,6 +8,7 @@ import { MemoryEditCard } from './MemoryEditCard';
 import { FileAttachmentChip } from './FileAttachmentChip';
 import type { AttachedFile } from '../utils/file-attachment-helpers';
 import { isVoiceCommandMode, setVoiceCommandMode } from '../utils/speech-text';
+import { useTextareaAutogrow } from '../hooks/use-textarea-autogrow';
 
 export interface MessageComposerProps {
   prompt: string;
@@ -70,6 +71,10 @@ export function MessageComposer(props: MessageComposerProps) {
       return next;
     });
   }, []);
+
+  // Auto-grow the textarea between 44 and 200 px as the user types or
+  // pastes multi-line content. Mirrors the chat-ui gitnexus-rs ChatInput pattern.
+  useTextareaAutogrow(props.textareaRef, props.prompt);
 
   return (
     <div
@@ -306,6 +311,7 @@ export function MessageComposer(props: MessageComposerProps) {
               }
               disabled={props.isSubmitting}
               rows={1}
+              style={{ minHeight: 44 }}
               className="flex-1 resize-none bg-transparent border-none outline-none text-text-primary placeholder:text-text-muted text-[15px] py-2"
             />
 

--- a/cowork/src/renderer/components/Titlebar.tsx
+++ b/cowork/src/renderer/components/Titlebar.tsx
@@ -19,6 +19,7 @@ import { useUnreadNotificationCount } from '../store/selectors';
 import { TabBar } from './TabBar';
 import { Tooltip } from './Tooltip';
 import { PresenceIndicator } from './PresenceIndicator';
+import { HealthBadge } from './HealthBadge';
 import { ServerDashboard } from './ServerDashboard';
 import { RunnerBadge } from './RunnerBadge';
 import { ClipboardSummaryPanel } from './ClipboardSummaryPanel';
@@ -65,8 +66,13 @@ export function Titlebar() {
           old shell → the new-shell home had no model picker / spend). Gated on newShellEnabled. */}
       <TitlebarModelCost />
 
-      {/* Presence indicator (face memory) — opens EnrollmentDialog on click. */}
+      {/* Backend health badge (auto-polls /api/health with backoff; hidden when disabled). */}
       <div className="titlebar-no-drag px-2 flex items-center ml-auto">
+        <HealthBadge />
+      </div>
+
+      {/* Presence indicator (face memory) — opens EnrollmentDialog on click. */}
+      <div className="titlebar-no-drag px-2 flex items-center">
         <PresenceIndicator
           onEnrollClicked={() => useAppStore.getState().setShowEnrollmentDialog(true)}
         />

--- a/cowork/src/renderer/hooks/use-backend-status.ts
+++ b/cowork/src/renderer/hooks/use-backend-status.ts
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+export type BackendStatusKind = 'unknown' | 'checking' | 'online' | 'offline' | 'disabled';
+
+export interface BackendStatus {
+  /** Coarse-grained status driving the badge color. */
+  status: BackendStatusKind;
+  /** Last time a /health probe responded 2xx. ms epoch. null until first success. */
+  lastSuccessAt: number | null;
+  /** Free-text describing the latest failure (HTTP status, network error). */
+  lastError: string | null;
+  /** Backend's reported version when known. */
+  version?: string;
+  /** Endpoint being polled (informational, for tooltip display). */
+  endpoint: string | null;
+}
+
+export interface UseBackendStatusOptions {
+  /** Polling interval in ms when last probe succeeded. Default 10_000. */
+  intervalMs?: number;
+  /** Per-request fetch timeout. Default 5_000. */
+  timeoutMs?: number;
+}
+
+interface CodeBuddyConfigSlice {
+  enabled?: boolean;
+  endpoint?: string;
+  apiKey?: string;
+}
+
+/**
+ * `useBackendStatus()` — auto-poll the configured Code Buddy backend's
+ * `/api/health` endpoint and expose a coarse status the UI can render.
+ * Mirrors the chat-ui gitnexus-rs `use-backend-status` hook with the
+ * same chained-setTimeout pattern (no overlapping probes, no drift)
+ * and exponential-ish backoff on consecutive failures (10s → 30s → 60s,
+ * capped at 60s) to avoid spamming logs when the backend is down.
+ *
+ * The backend endpoint + apiKey are read once at mount from
+ * `electronAPI.config.get()`. If the CodeBuddy integration is
+ * disabled in config, the hook returns `status='disabled'` and never
+ * starts the poll loop.
+ *
+ * Usage:
+ * ```tsx
+ * const status = useBackendStatus();
+ * return <HealthBadge status={status} />;
+ * ```
+ */
+export function useBackendStatus(
+  opts: UseBackendStatusOptions = {},
+): BackendStatus {
+  const intervalMs = opts.intervalMs ?? 10_000;
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+
+  const [state, setState] = useState<BackendStatus>({
+    status: 'unknown',
+    lastSuccessAt: null,
+    lastError: null,
+    endpoint: null,
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelledRef = useRef(false);
+  const consecutiveFailuresRef = useRef(0);
+
+  const probe = useCallback(
+    async (endpoint: string, apiKey: string | undefined): Promise<void> => {
+      setState((prev) => ({ ...prev, status: 'checking' }));
+      try {
+        const res = await fetch(`${endpoint}/api/health`, {
+          signal: AbortSignal.timeout(timeoutMs),
+          headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+        });
+        if (!res.ok) {
+          consecutiveFailuresRef.current += 1;
+          setState((prev) => ({
+            ...prev,
+            status: 'offline',
+            lastError: `HTTP ${res.status}: ${res.statusText}`,
+            endpoint,
+          }));
+          return;
+        }
+        const data = (await res.json().catch(() => ({}))) as { version?: string };
+        consecutiveFailuresRef.current = 0;
+        setState({
+          status: 'online',
+          lastSuccessAt: Date.now(),
+          lastError: null,
+          version: data?.version,
+          endpoint,
+        });
+      } catch (err) {
+        consecutiveFailuresRef.current += 1;
+        setState((prev) => ({
+          ...prev,
+          status: 'offline',
+          lastError: err instanceof Error ? err.message : 'Connection failed',
+          endpoint,
+        }));
+      }
+    },
+    [timeoutMs],
+  );
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    let endpoint: string | null = null;
+    let apiKey: string | undefined;
+
+    const loadAndStart = async () => {
+      const api = (window as unknown as { electronAPI?: { config?: { get?: () => Promise<unknown> } } }).electronAPI;
+      try {
+        const appConfig = (await api?.config?.get?.()) ?? {};
+        const cb = (appConfig as { codebuddy?: CodeBuddyConfigSlice }).codebuddy;
+        if (!cb || cb.enabled === false) {
+          setState({
+            status: 'disabled',
+            lastSuccessAt: null,
+            lastError: null,
+            endpoint: null,
+          });
+          return;
+        }
+        endpoint = cb.endpoint || 'http://localhost:3000';
+        apiKey = cb.apiKey || undefined;
+      } catch {
+        // Browser mode (no electronAPI) — assume disabled.
+        setState({
+          status: 'disabled',
+          lastSuccessAt: null,
+          lastError: null,
+          endpoint: null,
+        });
+        return;
+      }
+
+      const tick = async (): Promise<void> => {
+        if (cancelledRef.current || !endpoint) return;
+        await probe(endpoint, apiKey);
+        if (cancelledRef.current) return;
+        // Backoff after consecutive failures, capped at 60 s.
+        const fails = consecutiveFailuresRef.current;
+        const delay =
+          fails === 0
+            ? intervalMs
+            : Math.min(60_000, intervalMs * Math.min(6, 2 ** Math.min(fails - 1, 3)));
+        timerRef.current = setTimeout(tick, delay);
+      };
+
+      // Fire the first probe immediately (no initial delay).
+      tick().catch(() => { /* swallowed — probe handles its own errors */ });
+    };
+
+    loadAndStart().catch(() => { /* config read failed — already handled */ });
+
+    return () => {
+      cancelledRef.current = true;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [intervalMs, probe]);
+
+  return state;
+}
+
+/**
+ * Pure helper extracted for unit tests in the node vitest env.
+ * Computes the next poll delay given the consecutive-failure count and
+ * the base interval. Backoff doubles per failure up to 60 s ceiling.
+ */
+export function computeNextPollDelay(
+  consecutiveFailures: number,
+  baseIntervalMs: number,
+): number {
+  if (consecutiveFailures <= 0) return baseIntervalMs;
+  const exp = Math.min(consecutiveFailures - 1, 3); // 0,1,2,3 → ×1,2,4,8
+  return Math.min(60_000, baseIntervalMs * Math.min(6, 2 ** exp));
+}

--- a/cowork/src/renderer/hooks/use-textarea-autogrow.ts
+++ b/cowork/src/renderer/hooks/use-textarea-autogrow.ts
@@ -1,0 +1,62 @@
+import { useLayoutEffect, type RefObject } from 'react';
+
+export interface AutogrowOptions {
+  /** Minimum textarea height in pixels (default 44 = single comfortable row). */
+  minPx?: number;
+  /** Maximum textarea height in pixels (default 200 ≈ 8 rows). */
+  maxPx?: number;
+}
+
+/**
+ * Pure helper extracted from the hook so it stays testable in the
+ * node vitest env (the hook itself touches the DOM and isn't).
+ *
+ * Returns the height (in px) the textarea should adopt given its
+ * `scrollHeight`, clamped between `minPx` and `maxPx`.
+ */
+export function computeAutogrowHeight(
+  scrollHeight: number,
+  opts: { minPx: number; maxPx: number },
+): number {
+  return Math.min(opts.maxPx, Math.max(opts.minPx, scrollHeight));
+}
+
+/**
+ * Auto-grow a controlled `<textarea>` between `minPx` (44 px) and
+ * `maxPx` (200 px) as its content changes. Mirrors the chat-ui
+ * gitnexus-rs `ChatInput` pattern: reset to `auto` to recompute
+ * scrollHeight, then clamp + apply.
+ *
+ * Beyond `maxPx`, the textarea stops growing and an internal vertical
+ * scrollbar appears. Below `minPx`, the textarea keeps the comfortable
+ * single-row height.
+ *
+ * Usage:
+ * ```tsx
+ * const ref = useRef<HTMLTextAreaElement>(null);
+ * useTextareaAutogrow(ref, prompt);
+ * return <textarea ref={ref} value={prompt} ... />;
+ * ```
+ */
+export function useTextareaAutogrow(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string,
+  opts: AutogrowOptions = {},
+): void {
+  const minPx = opts.minPx ?? 44;
+  const maxPx = opts.maxPx ?? 200;
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Reset to `auto` so scrollHeight reflects the *new* content, not
+    // the previously-sized height (which would clamp scrollHeight at
+    // the current style.height).
+    el.style.height = 'auto';
+    const next = computeAutogrowHeight(el.scrollHeight, { minPx, maxPx });
+    el.style.height = `${next}px`;
+    // Show vertical scrollbar only when capped at max — keeps the
+    // chrome out of the way for short inputs.
+    el.style.overflowY = el.scrollHeight > maxPx ? 'auto' : 'hidden';
+  }, [ref, value, minPx, maxPx]);
+}

--- a/cowork/tests/backend-status.test.ts
+++ b/cowork/tests/backend-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { computeNextPollDelay } from '../src/renderer/hooks/use-backend-status';
+
+describe('computeNextPollDelay', () => {
+  const base = 10_000;
+
+  it('returns the base interval after a successful probe (failures=0)', () => {
+    expect(computeNextPollDelay(0, base)).toBe(base);
+    expect(computeNextPollDelay(0, 5_000)).toBe(5_000);
+  });
+
+  it('doubles the interval per consecutive failure', () => {
+    // failures=1 → 10s × 1 = 10s, failures=2 → 10s × 2 = 20s,
+    // failures=3 → 10s × 4 = 40s, failures=4 → 10s × 8 = 80s capped at 60s.
+    expect(computeNextPollDelay(1, base)).toBe(10_000);
+    expect(computeNextPollDelay(2, base)).toBe(20_000);
+    expect(computeNextPollDelay(3, base)).toBe(40_000);
+  });
+
+  it('caps at 60 seconds however many failures', () => {
+    expect(computeNextPollDelay(4, base)).toBe(60_000);
+    expect(computeNextPollDelay(50, base)).toBe(60_000);
+    expect(computeNextPollDelay(1000, base)).toBe(60_000);
+  });
+
+  it('respects custom base intervals', () => {
+    // base=2_000 → failures=1 → 2_000, failures=2 → 4_000, failures=3 → 8_000
+    expect(computeNextPollDelay(1, 2_000)).toBe(2_000);
+    expect(computeNextPollDelay(2, 2_000)).toBe(4_000);
+    expect(computeNextPollDelay(3, 2_000)).toBe(8_000);
+    // Even with base=2_000, failures=10 still hits the 60s ceiling.
+    expect(computeNextPollDelay(10, 2_000)).toBe(12_000);
+    // A very large base is also capped.
+    expect(computeNextPollDelay(0, 100_000)).toBe(100_000); // success case ignores cap
+    expect(computeNextPollDelay(2, 100_000)).toBe(60_000);
+  });
+});

--- a/cowork/tests/textarea-autogrow.test.ts
+++ b/cowork/tests/textarea-autogrow.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { computeAutogrowHeight } from '../src/renderer/hooks/use-textarea-autogrow';
+
+describe('computeAutogrowHeight', () => {
+  const opts = { minPx: 44, maxPx: 200 };
+
+  it('returns minPx when scrollHeight is below the floor', () => {
+    expect(computeAutogrowHeight(20, opts)).toBe(44);
+    expect(computeAutogrowHeight(0, opts)).toBe(44);
+  });
+
+  it('returns scrollHeight as-is between min and max', () => {
+    expect(computeAutogrowHeight(80, opts)).toBe(80);
+    expect(computeAutogrowHeight(150, opts)).toBe(150);
+  });
+
+  it('caps at maxPx when scrollHeight exceeds the ceiling', () => {
+    expect(computeAutogrowHeight(250, opts)).toBe(200);
+    expect(computeAutogrowHeight(2000, opts)).toBe(200);
+  });
+
+  it('handles edge cases at exact boundaries', () => {
+    expect(computeAutogrowHeight(44, opts)).toBe(44);
+    expect(computeAutogrowHeight(200, opts)).toBe(200);
+    expect(computeAutogrowHeight(45, opts)).toBe(45);
+    expect(computeAutogrowHeight(199, opts)).toBe(199);
+  });
+
+  it('respects custom min/max', () => {
+    expect(computeAutogrowHeight(50, { minPx: 60, maxPx: 100 })).toBe(60);
+    expect(computeAutogrowHeight(80, { minPx: 60, maxPx: 100 })).toBe(80);
+    expect(computeAutogrowHeight(120, { minPx: 60, maxPx: 100 })).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Replay propre et ciblé de la PR #40 sur `origin/main` après audit complet des 5 gaps annoncés :

### Statut des 5 gaps de la PR #40
1. **Regenerate button** (`ab093ac2`) : **Écarté (déjà couvert)** — Implémenté sur `main` via commit `ac81f82d` (`handleRegenerateMessage` dans `ChatView.tsx`, bouton `RefreshCw` dans `MessageCard.tsx`).
2. **Textarea auto-grow (44–200px)** (`64756489`) : **Porté** — Hook `useTextareaAutogrow` + helper pur `computeAutogrowHeight` câblé dans `MessageComposer.tsx` (`minHeight: 44px`, max 200px + scrollbar).
3. **HealthBadge permanent dans Titlebar** (`ac6ed6a6`) : **Porté** — Hook `useBackendStatus` (polling `/api/health` 10s + backoff exponentiel 10s→60s) + composant `HealthBadge` monté dans `Titlebar.tsx`.
4. **Tool badges inline** (`2bd2e29e`) : **Écarté (obsolète)** — Rendu caduc par `ActivityGroupBlock` (commit `e7304918`) qui regroupe les outils/pensées en accordéon avec compteurs et widgets curated.
5. **Mermaid inline render** (`49f41566`) : **Écarté (déjà couvert)** — Implémenté sur `main` via commit `5bc5b296` (`MermaidBlock.tsx` avec import dynamique, sécurité stricte, thème Cowork et DOMPurify).

### Modifications apportées
- `cowork/src/renderer/hooks/use-textarea-autogrow.ts` (nouveau)
- `cowork/tests/textarea-autogrow.test.ts` (nouveau, 5 tests)
- `cowork/src/renderer/components/MessageComposer.tsx` (câblage du hook)
- `cowork/src/renderer/hooks/use-backend-status.ts` (nouveau)
- `cowork/src/renderer/components/HealthBadge.tsx` (nouveau)
- `cowork/tests/backend-status.test.ts` (nouveau, 4 tests)
- `cowork/src/renderer/components/Titlebar.tsx` (montage du HealthBadge)

### Vérifications
- `cd cowork && npx vitest run tests/textarea-autogrow.test.ts tests/backend-status.test.ts` : 9/9 passés (100% verts).
- `cd cowork && npx tsc --noEmit` : 2411 erreurs (versus 2462 sur main baseline — zéro régression).