### PR TITLE
fix: audit batch 2 — partie mergeable (cowork, fleet, CKG, sensory) — découpe de #69

### DIFF
--- a/buddy-sense/src/senses/video.rs
+++ b/buddy-sense/src/senses/video.rs
@@ -55,117 +55,184 @@ pub fn detect_motion_events(
     out
 }
 
-/// Live camera capture (behind `live-vision`): grab downsampled grayscale frames
-/// from a v4l2 device via ffmpeg, run the shared motion core, and emit a salient
-/// `vision/motion` event WITH a full-resolution JPEG keyframe path so Code Buddy's
-/// cognition layer can describe it with a local vision model. No heavy camera
-/// crate — reuses the already-present ffmpeg. Capture runs in spawn_blocking so it
-/// never starves the async runtime.
+/// Live camera capture (behind `live-vision`): keep one ffmpeg process attached to
+/// the v4l2 device, read downsampled grayscale frames from its rawvideo stdout,
+/// and emit a salient `vision/motion` event. A second output of that same ffmpeg
+/// filter graph atomically keeps the current full-resolution JPEG, so a motion
+/// event can retain a keyframe without opening the camera a second time. Capture
+/// runs in spawn_blocking so it never starves the async runtime.
 #[cfg(feature = "live-vision")]
 pub mod live {
     use super::{motion_score, MOTION_SALIENCE};
     use crate::event::{now_ms, Modality, SensoryEvent};
-    use std::process::Command;
+    use std::ffi::OsStr;
+    use std::io::Read;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
     use tokio::sync::mpsc;
 
     const W: usize = 64;
     const H: usize = 48;
 
-    /// One downsampled grayscale frame (W*H bytes) from the camera, or None on glitch.
-    fn capture_gray(device: &str) -> Option<Vec<u8>> {
-        let out = Command::new("ffmpeg")
-            .args([
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-f",
-                "v4l2",
-                "-i",
-                device,
-                "-frames:v",
-                "1",
-                "-vf",
-                &format!("scale={W}x{H},format=gray"),
-                "-f",
-                "rawvideo",
-                "pipe:1",
-            ])
-            .output()
-            .ok()?;
-        if !out.status.success() || out.stdout.len() != W * H {
-            return None;
-        }
-        Some(out.stdout)
+    fn ffmpeg_bin() -> String {
+        std::env::var("BUDDY_SENSE_FFMPEG")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "ffmpeg".to_string())
     }
 
-    /// Grab a full-resolution JPEG keyframe to `path`. Returns true on success.
-    fn capture_keyframe(device: &str, path: &str) -> bool {
-        Command::new("ffmpeg")
-            .args([
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-y",
-                "-f",
-                "v4l2",
-                "-i",
-                device,
-                "-frames:v",
-                "1",
-                path,
-            ])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+    fn ffmpeg_args(device: &str, interval_ms: u64, latest_frame: &Path) -> Vec<String> {
+        let interval_ms = interval_ms.max(200);
+        let filter = format!(
+            "[0:v]fps=1000/{interval_ms},split=2[keyframe][motion_src];\
+             [motion_src]scale={W}:{H},format=gray[motion]"
+        );
+        vec![
+            "-hide_banner".into(),
+            "-loglevel".into(),
+            "error".into(),
+            "-nostdin".into(),
+            "-y".into(),
+            "-f".into(),
+            "v4l2".into(),
+            "-i".into(),
+            device.into(),
+            "-filter_complex".into(),
+            filter,
+            // Write this output first. By the time its paired raw frame reaches
+            // stdout, an atomic, complete JPEG from the same capture stream is
+            // available for a motion event to retain.
+            "-map".into(),
+            "[keyframe]".into(),
+            "-an".into(),
+            "-q:v".into(),
+            "3".into(),
+            "-f".into(),
+            "image2".into(),
+            "-update".into(),
+            "1".into(),
+            "-atomic_writing".into(),
+            "1".into(),
+            latest_frame.to_string_lossy().into_owned(),
+            "-map".into(),
+            "[motion]".into(),
+            "-an".into(),
+            "-pix_fmt".into(),
+            "gray".into(),
+            "-f".into(),
+            "rawvideo".into(),
+            "pipe:1".into(),
+        ]
     }
 
     /// Where keyframes are written (`~/.codebuddy/companion/` by default).
-    fn frame_dir() -> std::path::PathBuf {
+    fn frame_dir() -> PathBuf {
         let base = std::env::var("BUDDY_SENSE_FRAME_DIR")
             .ok()
-            .map(std::path::PathBuf::from)
+            .map(PathBuf::from)
             .or_else(|| {
                 std::env::var("HOME")
                     .ok()
-                    .map(|h| std::path::Path::new(&h).join(".codebuddy/companion"))
+                    .map(|h| Path::new(&h).join(".codebuddy/companion"))
             })
             .unwrap_or_else(std::env::temp_dir);
         let _ = std::fs::create_dir_all(&base);
         base
     }
 
-    /// Capture every `interval_ms`; emit `vision/motion` (+ keyframe) on rising
-    /// motion (hysteresis → one event per sustained change, not a storm).
+    fn camera_name(device: &str) -> String {
+        device
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("camera")
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect()
+    }
+
+    fn retain_keyframe(latest_frame: &Path, destination: &Path) -> bool {
+        std::fs::copy(latest_frame, destination)
+            .map(|bytes| bytes > 0)
+            .unwrap_or(false)
+    }
+
+    /// Capture continuously at the configured cadence; emit `vision/motion`
+    /// (+ a keyframe from the current stream) on rising motion. Hysteresis keeps
+    /// a sustained scene change to one event rather than an event storm.
     pub async fn run(
         tx: mpsc::Sender<SensoryEvent>,
         device: String,
         interval_ms: u64,
         threshold: f64,
     ) {
+        let dir = frame_dir();
+        let program = ffmpeg_bin();
+        let _ = tokio::task::spawn_blocking(move || {
+            capture_loop(tx, &device, interval_ms, threshold, &dir, program.as_ref())
+        })
+        .await;
+    }
+
+    fn capture_loop(
+        tx: mpsc::Sender<SensoryEvent>,
+        device: &str,
+        interval_ms: u64,
+        threshold: f64,
+        dir: &Path,
+        program: &OsStr,
+    ) {
         let camera = device.rsplit('/').next().unwrap_or("camera").to_string();
+        let safe_camera = camera_name(device);
+        let latest_frame = dir.join(format!(".buddy-sense-{safe_camera}-latest.jpg"));
+        // Never use a stale keyframe if capture fails before ffmpeg's first JPEG.
+        let _ = std::fs::remove_file(&latest_frame);
+
+        let mut child = match Command::new(program)
+            .args(ffmpeg_args(device, interval_ms, &latest_frame))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(error) => {
+                eprintln!(
+                    "[buddy-sense] live-vision: ffmpeg spawn failed ({error}); is ffmpeg installed? sense disabled"
+                );
+                return;
+            }
+        };
+        let mut stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                eprintln!("[buddy-sense] live-vision: no ffmpeg stdout; sense disabled");
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+        };
+
         let mut prev: Option<Vec<u8>> = None;
         let mut moving = false;
-        let mut ticker =
-            tokio::time::interval(std::time::Duration::from_millis(interval_ms.max(200)));
+        let mut frame = vec![0_u8; W * H];
         loop {
-            ticker.tick().await;
-            let dev = device.clone();
-            let frame = match tokio::task::spawn_blocking(move || capture_gray(&dev)).await {
-                Ok(Some(f)) => f,
-                _ => continue,
-            };
+            if stdout.read_exact(&mut frame).is_err() {
+                break;
+            }
             if let Some(p) = &prev {
                 if p.len() == frame.len() {
-                    let score = motion_score(p, &frame);
+                    let score = motion_score(p, frame.as_slice());
                     if !moving && score >= threshold {
                         moving = true;
-                        let path = frame_dir().join(format!("cam-{}.jpg", now_ms()));
+                        let path = dir.join(format!("cam-{}.jpg", now_ms()));
                         let path_str = path.to_string_lossy().to_string();
-                        let (dev2, cap_path) = (device.clone(), path_str.clone());
-                        let ok =
-                            tokio::task::spawn_blocking(move || capture_keyframe(&dev2, &cap_path))
-                                .await
-                                .unwrap_or(false);
+                        let ok = retain_keyframe(&latest_frame, &path);
                         let payload = serde_json::json!({
                             "score": score,
                             "camera": camera,
@@ -173,7 +240,7 @@ pub mod live {
                         });
                         let ev =
                             SensoryEvent::new(Modality::Vision, "motion", MOTION_SALIENCE, payload);
-                        if tx.send(ev).await.is_err() {
+                        if tx.blocking_send(ev).is_err() {
                             break;
                         }
                     } else if moving && score < threshold {
@@ -183,7 +250,97 @@ pub mod live {
                     moving = false; // resolution change → re-baseline + re-arm
                 }
             }
-            prev = Some(frame);
+            prev = Some(frame.clone());
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(latest_frame);
+        eprintln!("[buddy-sense] live-vision: capture ended");
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn ffmpeg_is_configured_as_one_continuous_dual_output_process() {
+            let latest = Path::new("/tmp/latest.jpg");
+            let args = ffmpeg_args("/dev/video7", 1_500, latest);
+            assert_eq!(args.iter().filter(|arg| arg.as_str() == "-i").count(), 1);
+            assert!(!args.iter().any(|arg| arg == "-frames:v"));
+            assert!(args.iter().any(|arg| arg.contains("fps=1000/1500,split=2")));
+            assert!(args
+                .iter()
+                .any(|arg| arg.contains("scale=64:48,format=gray")));
+            assert!(args.iter().any(|arg| arg == "pipe:1"));
+            assert!(args
+                .iter()
+                .any(|arg| arg == latest.to_string_lossy().as_ref()));
+        }
+
+        #[test]
+        fn retain_keyframe_copies_the_existing_stream_frame() {
+            let nonce = format!("{}-{}", std::process::id(), now_ms());
+            let dir = std::env::temp_dir().join(format!("buddy-sense-video-test-{nonce}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let latest = dir.join("latest.jpg");
+            let retained = dir.join("cam-test.jpg");
+            std::fs::write(&latest, b"jpeg-from-live-stream").unwrap();
+
+            assert!(retain_keyframe(&latest, &retained));
+            assert_eq!(std::fs::read(&retained).unwrap(), b"jpeg-from-live-stream");
+            assert!(!retain_keyframe(
+                &dir.join("missing.jpg"),
+                &dir.join("never.jpg")
+            ));
+
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn capture_loop_spawns_once_and_retains_a_keyframe_without_reopening_device() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let nonce = format!("{}-{}", std::process::id(), now_ms());
+            let dir = std::env::temp_dir().join(format!("buddy-sense-capture-test-{nonce}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let program = dir.join("fake-ffmpeg.sh");
+            let spawn_log = dir.join("spawns.log");
+            let latest = dir.join(".buddy-sense-video0-latest.jpg");
+            let script = format!(
+                "#!/bin/sh\n\
+                 printf 'spawn\\n' >> '{}'\n\
+                 printf 'jpeg-from-the-persistent-process' > '{}'\n\
+                 dd if=/dev/zero bs={} count=1 2>/dev/null\n\
+                 dd if=/dev/zero bs={} count=1 2>/dev/null | tr '\\000' '\\377'\n",
+                spawn_log.display(),
+                latest.display(),
+                W * H,
+                W * H,
+            );
+            std::fs::write(&program, script).unwrap();
+            let mut permissions = std::fs::metadata(&program).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&program, permissions).unwrap();
+
+            let (tx, mut rx) = mpsc::channel(1);
+            capture_loop(tx, "/dev/video0", 1_500, 0.1, &dir, program.as_os_str());
+
+            let event = rx
+                .blocking_recv()
+                .expect("the changed raw frame should emit motion");
+            assert_eq!(event.kind, "motion");
+            let image_path = event.payload["imagePath"]
+                .as_str()
+                .expect("the in-stream keyframe should be retained");
+            assert_eq!(
+                std::fs::read(image_path).unwrap(),
+                b"jpeg-from-the-persistent-process"
+            );
+            assert_eq!(std::fs::read_to_string(spawn_log).unwrap(), "spawn\n");
+
+            std::fs::remove_dir_all(dir).unwrap();
         }
     }
 }

--- a/cowork/src/main/config/config-store.ts
+++ b/cowork/src/main/config/config-store.ts
@@ -92,6 +92,8 @@ export interface CreateConfigSetPayload {
 
 export interface ProviderProfile {
   apiKey: string;
+  hasKey?: boolean;
+  keyTail?: string;
   baseUrl?: string;
   model: string;
   contextWindow?: number;
@@ -116,6 +118,8 @@ export interface AppConfig {
 
   // API credentials
   apiKey: string;
+  hasKey?: boolean;
+  keyTail?: string;
   baseUrl?: string;
   customProtocol?: CustomProtocolType;
 
@@ -1228,6 +1232,39 @@ export class ConfigStore {
     return this.normalizeConfig(this.store.store as Partial<AppConfig>);
   }
 
+  /** Renderer-safe config view. Provider secrets never cross the IPC boundary. */
+  getAllRedacted(): AppConfig {
+    const config = this.getAll();
+    const redactProfile = (profile: ProviderProfile): ProviderProfile => {
+      const apiKey = profile.apiKey.trim();
+      return {
+        ...profile,
+        apiKey: '',
+        hasKey: apiKey.length > 0,
+        keyTail: apiKey ? apiKey.slice(-4) : undefined,
+      };
+    };
+    const redactProfiles = (
+      profiles: Partial<Record<ProviderProfileKey, ProviderProfile>>
+    ): Partial<Record<ProviderProfileKey, ProviderProfile>> =>
+      Object.fromEntries(
+        Object.entries(profiles).map(([key, profile]) => [key, redactProfile(profile)])
+      ) as Partial<Record<ProviderProfileKey, ProviderProfile>>;
+    const activeApiKey = config.apiKey.trim();
+
+    return {
+      ...config,
+      apiKey: '',
+      hasKey: activeApiKey.length > 0,
+      keyTail: activeApiKey ? activeApiKey.slice(-4) : undefined,
+      profiles: redactProfiles(config.profiles),
+      configSets: config.configSets.map((configSet) => ({
+        ...configSet,
+        profiles: redactProfiles(configSet.profiles),
+      })),
+    };
+  }
+
   /**
    * Get a specific config value
    */
@@ -1419,7 +1456,19 @@ export class ConfigStore {
     let nextConfigSets = current.configSets.map((set) => this.cloneConfigSet(set));
 
     if (Array.isArray(updates.configSets) && updates.configSets.length > 0) {
-      const normalizedSets = this.normalizeConfigSets(updates.configSets, {
+      const setsWithPreservedKeys = updates.configSets.map((configSet) => {
+        const existingSet = current.configSets.find((existing) => existing.id === configSet.id);
+        const profiles = { ...configSet.profiles };
+        for (const key of PROFILE_KEYS) {
+          const incomingProfile = profiles[key];
+          const existingApiKey = existingSet?.profiles[key]?.apiKey;
+          if (incomingProfile && !incomingProfile.apiKey.trim() && existingApiKey) {
+            profiles[key] = { ...incomingProfile, apiKey: existingApiKey };
+          }
+        }
+        return { ...configSet, profiles };
+      });
+      const normalizedSets = this.normalizeConfigSets(setsWithPreservedKeys, {
         provider: current.provider,
         customProtocol: normalizeCustomProtocol(
           current.customProtocol,
@@ -1466,7 +1515,13 @@ export class ConfigStore {
       if (updates.profiles) {
         for (const key of PROFILE_KEYS) {
           if (updates.profiles[key]) {
-            nextProfiles[key] = this.normalizeProfile(key, updates.profiles[key]);
+            const incomingProfile = updates.profiles[key];
+            nextProfiles[key] = this.normalizeProfile(key, {
+              ...incomingProfile,
+              apiKey: incomingProfile.apiKey.trim()
+                ? incomingProfile.apiKey
+                : nextProfiles[key].apiKey,
+            });
           }
         }
       }
@@ -1497,7 +1552,7 @@ export class ConfigStore {
       const nextActiveProfile = {
         ...nextProfiles[nextActiveProfileKey],
       };
-      if (updates.apiKey !== undefined) {
+      if (updates.apiKey?.trim()) {
         nextActiveProfile.apiKey = updates.apiKey;
       }
       if (updates.baseUrl !== undefined) {

--- a/cowork/src/main/index.ts
+++ b/cowork/src/main/index.ts
@@ -2470,6 +2470,7 @@ async function cleanupSandboxResources(): Promise<void> {
     logError('[App] Error stopping clipboard watcher:', error);
   }
 
+  sessionManager?.dispose();
   try {
     closeDatabase();
   } catch (error) {
@@ -2540,6 +2541,7 @@ app.on('before-quit', async (event) => {
     if (process.env.VITE_DEV_SERVER_URL) {
       stopNavServer();
       liveLauncherBridge?.shutdown();
+      sessionManager?.dispose();
       try {
         closeDatabase();
       } catch {

--- a/cowork/src/main/index.ts
+++ b/cowork/src/main/index.ts
@@ -403,6 +403,10 @@ app.disableHardwareAcceleration();
 let mainWindow: BrowserWindow | null = null;
 let engineAdapter: EngineAdapterLike | undefined;
 let sessionManager: SessionManager | null = null;
+const REMOTE_PERMISSION_TIMEOUT_MS = 5 * 60_000 + 30_000;
+let respondToEnginePermission:
+  | ((id: string, response: 'allow' | 'allow_always' | 'deny') => void)
+  | null = null;
 let skillsManager: SkillsManager | null = null;
 let pluginRuntimeService: PluginRuntimeService | null = null;
 let scheduledTaskManager: ScheduledTaskManager | null = null;
@@ -1331,7 +1335,7 @@ async function startSandboxBootstrap(): Promise<void> {
   }
 }
 
-import { sendToRenderer } from './ipc-main-bridge';
+import { sendToRenderer, setPermissionResponder } from './ipc-main-bridge';
 import { remoteBackendManager } from './remote-backend/remote-backend-manager';
 import { remoteBackendConfigStore } from './remote-backend/remote-backend-config-store';
 
@@ -1514,7 +1518,12 @@ app
           const { DesktopPermissionBridge } = await import(
             /* webpackIgnore: true */ /* @vite-ignore */ permBridgeUrl
           );
-          const permissionBridge = new DesktopPermissionBridge(sendToRenderer);
+          const permissionBridge = new DesktopPermissionBridge(
+            sendToRenderer,
+            REMOTE_PERMISSION_TIMEOUT_MS
+          );
+          respondToEnginePermission = (id, response) =>
+            permissionBridge.handleResponse(id, response);
           const adapterWithPerm = engineAdapter as unknown as {
             setPermissionCallback?: (cb: unknown) => void;
           };
@@ -1658,7 +1667,15 @@ app
       pluginRuntimeService,
       engineAdapter,
       new InProcessCoworkCognition(() => getServerBridge().getCognitionPort()),
+      (sessionId) => remoteManager.isRemoteSession(sessionId),
     );
+    setPermissionResponder((toolUseId, response, bridgeId) => {
+      if (bridgeId && respondToEnginePermission) {
+        respondToEnginePermission(bridgeId, response);
+        return;
+      }
+      sessionManager?.handlePermissionResponse(toolUseId, response);
+    });
 
     // Do not grant `allOperations` process-wide. The engine adapter wires
     // ConfirmationService to Cowork's real permission dialog, while routine

--- a/cowork/src/main/index.ts
+++ b/cowork/src/main/index.ts
@@ -1155,7 +1155,7 @@ function createWindow() {
       type: 'config.status',
       payload: {
         isConfigured,
-        config: configStore.getAll(),
+        config: configStore.getAllRedacted(),
       },
     });
 
@@ -3519,7 +3519,7 @@ ipcMain.handle('dialog.selectFiles', async () => {
 // Config IPC handlers
 ipcMain.handle('config.get', () => {
   try {
-    return configStore.getAll();
+    return configStore.getAllRedacted();
   } catch (error) {
     logError('[Config] Error getting config:', error);
     return {};
@@ -3602,15 +3602,15 @@ const syncConfigAfterMutation = async (previousConfig: AppConfig) => {
     type: 'config.status',
     payload: {
       isConfigured,
-      config: updatedConfig,
+      config: configStore.getAllRedacted(),
     },
   });
   log('[Config] Notified renderer of config update, isConfigured:', isConfigured);
-  return updatedConfig;
+  return configStore.getAllRedacted();
 };
 
 ipcMain.handle('config.save', async (_event, newConfig: Partial<AppConfig>) => {
-  log('[Config] Saving config:', { ...newConfig, apiKey: newConfig.apiKey ? '***' : '' });
+  log('[Config] Saving config fields:', Object.keys(newConfig));
 
   const previousConfig = configStore.getAll();
   // Update config
@@ -3678,7 +3678,7 @@ ipcMain.handle(
   'config.listModels',
   async (
     _event,
-    payload: { provider: AppConfig['provider']; apiKey: string; baseUrl?: string }
+    payload: { provider: AppConfig['provider']; apiKey?: string; baseUrl?: string }
   ): Promise<ProviderModelInfo[]> => {
     if (payload.provider === 'ollama') {
       return listOllamaModels(payload);
@@ -3693,7 +3693,11 @@ ipcMain.handle(
 ipcMain.handle('config.diagnose', async (_event, payload: DiagnosticInput) => {
   try {
     const { runDiagnostics } = await import('./config/api-diagnostics');
-    return await runDiagnostics(payload);
+    const storedConfig = configStore.getAll();
+    return await runDiagnostics({
+      ...payload,
+      apiKey: payload.apiKey?.trim() || storedConfig.apiKey,
+    });
   } catch (error) {
     logError('[Config] Error running diagnostics:', error);
     throw error;
@@ -5760,7 +5764,7 @@ ipcMain.handle('skills.setStoragePath', async (_event, targetPath: string, migra
     type: 'config.status',
     payload: {
       isConfigured: configStore.isConfigured(),
-      config: configStore.getAll(),
+      config: configStore.getAllRedacted(),
     },
   });
   return { success: true, ...result };
@@ -6462,7 +6466,7 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
           type: 'config.status',
           payload: {
             isConfigured: configStore.isConfigured(),
-            config: configStore.getAll(),
+            config: configStore.getAllRedacted(),
           },
         });
         }
@@ -6478,7 +6482,7 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
         type: 'config.status',
         payload: {
           isConfigured: configStore.isConfigured(),
-          config: configStore.getAll(),
+          config: configStore.getAllRedacted(),
         },
       });
       return null;

--- a/cowork/src/main/ipc-main-bridge.ts
+++ b/cowork/src/main/ipc-main-bridge.ts
@@ -5,6 +5,19 @@ import { getMainWindow } from './window-management';
 import { remoteManager as remoteManagerInstance } from './remote/remote-manager'; // Import the remoteManager instance
 import { log, logError } from './utils/logger'; // Import logger
 
+type PermissionResponse = 'allow' | 'allow_always' | 'deny';
+type PermissionResponder = (
+  toolUseId: string,
+  response: PermissionResponse,
+  bridgeId?: string
+) => void;
+
+let permissionResponder: PermissionResponder | null = null;
+
+export function setPermissionResponder(responder: PermissionResponder | null): void {
+  permissionResponder = responder;
+}
+
 /**
  * Tool-confirmation / credential events that MUST reach the renderer the user
  * is actually looking at, on time — a dropped or mis-routed one silently
@@ -43,6 +56,38 @@ function confirmationTargets(): BrowserWindow[] {
   push(BrowserWindow.getFocusedWindow());
   push(getMainWindow());
   return targets;
+}
+
+function sendToLocalRenderer(event: ServerEvent): void {
+  // Confirmation-critical events go to the ACTIVE (focused) app window as well
+  // as the canonical main window, so a tool-approval modal can never land only
+  // on a background renderer and silently expire. Everything else keeps the
+  // historical single-target `getMainWindow()` path.
+  if (CONFIRMATION_EVENT_TYPES.has(event.type)) {
+    const targets = confirmationTargets();
+    if (targets.length > 0) {
+      for (const win of targets) {
+        win.webContents.send('server-event', event);
+      }
+      return;
+    }
+    logError(
+      `[ipc-main-bridge] dropped confirmation ${event.type} — no live window (focused/main both unavailable)`
+    );
+    return;
+  }
+
+  const mainWindow = getMainWindow();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('server-event', event);
+  } else {
+    // Helps catch regressions of the "main/index.ts and window-management.ts
+    // each held a separate `let mainWindow` so getMainWindow() always
+    // returned null" bug — kept as a warning rather than spam.
+    logError(
+      `[ipc-main-bridge] dropped ${event.type} — mainWindow=${!!mainWindow} destroyed=${mainWindow?.isDestroyed()}`
+    );
+  }
 }
 
 /**
@@ -115,11 +160,20 @@ export function sendToRenderer(event: ServerEvent) {
           payload.toolName as string,
           (payload.input as Record<string, unknown> | undefined) ?? {}
         )
-        .then(() => {
-          // This part requires sessionManager, so it will need to be passed or accessed via a bridge
-          // For now, we'll assume sessionManager is accessible from where this is handled
-          // Placeholder:
-          // if (result !== null && sessionManager) { ... sessionManager.handlePermissionResponse(...) }
+        .then((result) => {
+          if (result === null) {
+            sendToLocalRenderer(event);
+            return;
+          }
+          if (!permissionResponder) {
+            logError('[Remote] Permission response dropped: responder is not configured');
+            return;
+          }
+          permissionResponder(
+            payload.toolUseId as string,
+            result.allow ? (result.remember ? 'allow_always' : 'allow') : 'deny',
+            typeof payload.bridgeId === 'string' ? payload.bridgeId : undefined
+          );
         })
         .catch((err) => {
           logError('[Remote] Failed to handle permission request:', err);
@@ -128,35 +182,5 @@ export function sendToRenderer(event: ServerEvent) {
     }
   }
 
-  // Send to local UI.
-  //
-  // Confirmation-critical events go to the ACTIVE (focused) app window as well
-  // as the canonical main window, so a tool-approval modal can never land only
-  // on a background renderer and silently expire. Everything else keeps the
-  // historical single-target `getMainWindow()` path.
-  if (CONFIRMATION_EVENT_TYPES.has(event.type)) {
-    const targets = confirmationTargets();
-    if (targets.length > 0) {
-      for (const win of targets) {
-        win.webContents.send('server-event', event);
-      }
-      return;
-    }
-    logError(
-      `[ipc-main-bridge] dropped confirmation ${event.type} — no live window (focused/main both unavailable)`
-    );
-    return;
-  }
-
-  const mainWindow = getMainWindow();
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('server-event', event);
-  } else {
-    // Helps catch regressions of the "main/index.ts and window-management.ts
-    // each held a separate `let mainWindow` so getMainWindow() always
-    // returned null" bug — kept as a warning rather than spam.
-    logError(
-      `[ipc-main-bridge] dropped ${event.type} — mainWindow=${!!mainWindow} destroyed=${mainWindow?.isDestroyed()}`
-    );
-  }
+  sendToLocalRenderer(event);
 }

--- a/cowork/src/main/session/session-manager.ts
+++ b/cowork/src/main/session/session-manager.ts
@@ -477,6 +477,8 @@ export type BackgroundSessionLifecycleListener = (
 ) => void;
 
 export class SessionManager {
+  private static readonly LOCAL_PERMISSION_TIMEOUT_MS = 60_000;
+  private static readonly REMOTE_PERMISSION_TIMEOUT_MS = 5 * 60_000 + 30_000;
   private db: DatabaseInstance;
   private sendToRenderer: (event: ServerEvent) => void;
   private pathResolver: PathResolver;
@@ -524,6 +526,7 @@ export class SessionManager {
     pluginRuntimeService?: PluginRuntimeService,
     engineAdapter?: EngineAdapterLike,
     private readonly cognition?: CoworkCognitionPort,
+    private readonly isRemoteSession: (sessionId: string) => boolean = () => false,
   ) {
     this.db = db;
     this.engineAdapter = engineAdapter;
@@ -2884,11 +2887,14 @@ export class SessionManager {
     input: Record<string, unknown>
   ): Promise<PermissionResult> {
     return new Promise((resolve) => {
+      const timeoutMs = this.isRemoteSession(sessionId)
+        ? SessionManager.REMOTE_PERMISSION_TIMEOUT_MS
+        : SessionManager.LOCAL_PERMISSION_TIMEOUT_MS;
       const timeoutId = setTimeout(() => {
         this.pendingPermissions.delete(toolUseId);
         resolve('deny');
         this.sendToRenderer({ type: 'permission.dismiss', payload: { toolUseId } });
-      }, 60_000);
+      }, timeoutMs);
       this.pendingPermissions.set(toolUseId, (result: PermissionResult) => {
         clearTimeout(timeoutId);
         resolve(result);

--- a/cowork/src/main/session/session-manager.ts
+++ b/cowork/src/main/session/session-manager.ts
@@ -2879,6 +2879,10 @@ export class SessionManager {
     }
   }
 
+  dispose(): void {
+    this.turnJournal.close();
+  }
+
   // Request permission for a tool
   async requestPermission(
     sessionId: string,

--- a/cowork/src/main/session/turn-journal.ts
+++ b/cowork/src/main/session/turn-journal.ts
@@ -88,6 +88,19 @@ export interface TurnJournalReadResult {
   replay: TurnJournalReplayResult;
 }
 
+interface OpenJournalHandle {
+  fd: number;
+  dirty: boolean;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const FSYNC_INTERVAL_MS = 100;
+const DURABLE_BOUNDARIES = new Set<TurnJournalEventType>([
+  'turn_completed',
+  'turn_failed',
+  'cancel_requested',
+]);
+
 /**
  * Identifies the exact byte prefix that belonged to the history active before
  * a branch mutation. The fence itself is committed in SQLite with the branch
@@ -103,6 +116,7 @@ export interface TurnJournalFence {
 export class TurnJournal {
   private readonly dir: string;
   private readonly runSequences: Map<string, number> = new Map();
+  private readonly openHandles: Map<string, OpenJournalHandle> = new Map();
 
   constructor(dir?: string) {
     this.dir = dir ?? path.join(app.getPath('userData'), 'turn-journals');
@@ -132,7 +146,19 @@ export class TurnJournal {
         ...(turnId ? { turnId } : {}),
         ...(Object.keys(data).length > 0 ? { data } : {}),
       };
-      appendLineDurably(this.pathFor(sessionId), `${JSON.stringify(event)}\n`);
+      const handle = this.getOrOpenHandle(sessionId);
+      try {
+        fs.writeSync(handle.fd, `${JSON.stringify(event)}\n`, undefined, 'utf8');
+        handle.dirty = true;
+      } catch (error) {
+        this.closeHandle(sessionId, false);
+        throw error;
+      }
+      if (DURABLE_BOUNDARIES.has(type)) {
+        this.closeHandle(sessionId, true);
+      } else {
+        this.scheduleFlush(sessionId, handle);
+      }
     } catch (error) {
       logWarn('[TurnJournal] append failed:', error);
     }
@@ -228,12 +254,60 @@ export class TurnJournal {
 
   delete(sessionId: string): void {
     try {
+      this.closeHandle(sessionId, false);
       const file = this.pathFor(sessionId);
       if (fs.existsSync(file)) {
         fs.unlinkSync(file);
       }
     } catch (error) {
       logWarn('[TurnJournal] delete failed:', error);
+    }
+  }
+
+  close(): void {
+    for (const sessionId of [...this.openHandles.keys()]) {
+      this.closeHandle(sessionId, true);
+    }
+  }
+
+  private getOrOpenHandle(sessionId: string): OpenJournalHandle {
+    const existing = this.openHandles.get(sessionId);
+    if (existing) return existing;
+    const handle: OpenJournalHandle = {
+      fd: fs.openSync(this.pathFor(sessionId), 'a'),
+      dirty: false,
+      flushTimer: null,
+    };
+    this.openHandles.set(sessionId, handle);
+    return handle;
+  }
+
+  private scheduleFlush(sessionId: string, handle: OpenJournalHandle): void {
+    if (handle.flushTimer) return;
+    handle.flushTimer = setTimeout(() => this.closeHandle(sessionId, true), FSYNC_INTERVAL_MS);
+    handle.flushTimer.unref?.();
+  }
+
+  private closeHandle(sessionId: string, durable: boolean): void {
+    const handle = this.openHandles.get(sessionId);
+    if (!handle) return;
+    this.openHandles.delete(sessionId);
+    if (handle.flushTimer) {
+      clearTimeout(handle.flushTimer);
+      handle.flushTimer = null;
+    }
+    try {
+      if (durable && handle.dirty) {
+        fs.fsyncSync(handle.fd);
+      }
+    } catch (error) {
+      logWarn('[TurnJournal] fsync failed:', error);
+    } finally {
+      try {
+        fs.closeSync(handle.fd);
+      } catch (error) {
+        logWarn('[TurnJournal] close failed:', error);
+      }
     }
   }
 
@@ -253,6 +327,9 @@ export class TurnJournal {
     const replay = this.read(sessionId).replay;
     const safeReason = safeJournalName(reason) || 'history-change';
     const archivedPath = `${file}.${safeReason}.${Date.now()}.${randomUUID()}.archived`;
+    // Flush + close the append handle first so later appends reopen the fresh
+    // active file instead of writing into the archived inode.
+    this.closeHandle(sessionId, true);
     fs.renameSync(file, archivedPath);
     for (const run of replay.runs) {
       this.runSequences.delete(run.runId);
@@ -505,14 +582,4 @@ function statusForEventType(type: TurnJournalEventType): TurnJournalTurnStatus {
   if (type === 'turn_failed') return 'failed';
   if (type === 'cancel_requested') return 'cancelled';
   return 'running';
-}
-
-function appendLineDurably(file: string, line: string): void {
-  const fd = fs.openSync(file, 'a');
-  try {
-    fs.writeSync(fd, line, undefined, 'utf8');
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
 }

--- a/cowork/src/main/window-management.ts
+++ b/cowork/src/main/window-management.ts
@@ -259,7 +259,7 @@ export function createWindow() {
       type: 'config.status',
       payload: {
         isConfigured,
-        config: configStore.getAll(),
+        config: configStore.getAllRedacted(),
       },
     });
 

--- a/cowork/src/main/workflows/workflow-bridge.ts
+++ b/cowork/src/main/workflows/workflow-bridge.ts
@@ -153,13 +153,30 @@ export class WorkflowBridge {
       this.cache = [];
       return this.cache;
     }
+    let raw: string;
     try {
-      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      raw = fs.readFileSync(this.filePath, 'utf-8');
+    } catch (err) {
+      logWarn('[WorkflowBridge] failed to read workflows:', err);
+      this.cache = [];
+      return this.cache;
+    }
+    try {
       const parsed = JSON.parse(raw);
-      this.cache = Array.isArray(parsed) ? (parsed as WorkflowDefinition[]) : [];
+      if (!Array.isArray(parsed)) {
+        throw new Error('workflows.json must contain an array');
+      }
+      this.cache = parsed as WorkflowDefinition[];
       return this.cache;
     } catch (err) {
-      logWarn('[WorkflowBridge] failed to load workflows:', err);
+      const corruptPath = `${this.filePath}.corrupt-${Date.now()}`;
+      try {
+        fs.renameSync(this.filePath, corruptPath);
+        logWarn('[WorkflowBridge] quarantined corrupt workflows file:', corruptPath);
+      } catch (quarantineError) {
+        logWarn('[WorkflowBridge] failed to quarantine corrupt workflows file:', quarantineError);
+      }
+      logWarn('[WorkflowBridge] failed to parse workflows:', err);
       this.cache = [];
       return this.cache;
     }
@@ -177,9 +194,7 @@ export class WorkflowBridge {
       createdAt: now,
       updatedAt: now,
     };
-    const all = this.list();
-    all.push(definition);
-    this.persist(all);
+    this.persist([...this.list(), definition]);
     return definition;
   }
 
@@ -188,8 +203,9 @@ export class WorkflowBridge {
     const index = all.findIndex((w) => w.id === id);
     if (index === -1) return null;
     const updated = { ...all[index], ...patch, id, updatedAt: Date.now() };
-    all[index] = updated;
-    this.persist(all);
+    const next = [...all];
+    next[index] = updated;
+    this.persist(next);
     return updated;
   }
 
@@ -787,11 +803,19 @@ export class WorkflowBridge {
   }
 
   private persist(workflows: WorkflowDefinition[]): void {
+    const tempPath = `${this.filePath}.tmp`;
     try {
-      fs.writeFileSync(this.filePath, JSON.stringify(workflows, null, 2), 'utf-8');
-      this.cache = workflows;
+      fs.writeFileSync(tempPath, JSON.stringify(workflows, null, 2), 'utf-8');
+      fs.renameSync(tempPath, this.filePath);
+      this.cache = [...workflows];
     } catch (err) {
+      try {
+        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      } catch {
+        // Preserve the original persistence error.
+      }
       logWarn('[WorkflowBridge] persist failed:', err);
+      throw err;
     }
   }
 }

--- a/cowork/src/preload/index.ts
+++ b/cowork/src/preload/index.ts
@@ -637,7 +637,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('config.test', config),
     listModels: (payload: {
       provider: AppConfig['provider'];
-      apiKey: string;
+      apiKey?: string;
       baseUrl?: string;
     }): Promise<ProviderModelInfo[]> => ipcRenderer.invoke('config.listModels', payload),
     diagnose: (input: DiagnosticInput): Promise<DiagnosticResult> =>
@@ -5630,7 +5630,7 @@ declare global {
         test: (config: ApiTestInput) => Promise<ApiTestResult>;
         listModels: (payload: {
           provider: AppConfig['provider'];
-          apiKey: string;
+          apiKey?: string;
           baseUrl?: string;
         }) => Promise<ProviderModelInfo[]>;
         diagnose: (input: DiagnosticInput) => Promise<DiagnosticResult>;

--- a/cowork/src/renderer/App.tsx
+++ b/cowork/src/renderer/App.tsx
@@ -311,6 +311,7 @@ function App() {
       if (result.success) {
         setIsConfigured(Boolean(result.config?.isConfigured));
         setAppConfig(result.config);
+        return result.config;
       }
     },
     [isElectron, setIsConfigured, setAppConfig]

--- a/cowork/src/renderer/components/ConfigModal.tsx
+++ b/cowork/src/renderer/components/ConfigModal.tsx
@@ -11,7 +11,7 @@ import { LLMConfigPanel } from './LLMConfigPanel';
 interface ConfigModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (config: Partial<AppConfig>) => Promise<void>;
+  onSave: (config: Partial<AppConfig>) => Promise<AppConfig | void>;
   initialConfig?: AppConfig | null;
   isFirstRun?: boolean;
 }
@@ -221,7 +221,7 @@ export function ConfigModal({
               <div className="grid grid-cols-2 gap-2">
                 <button
                   onClick={apiConfig.handleTest}
-                  disabled={apiConfig.isTesting || (apiConfig.requiresApiKey && !apiConfig.apiKey.trim())}
+                  disabled={apiConfig.isTesting || (apiConfig.requiresApiKey && !apiConfig.hasUsableApiKey)}
                   className="flex w-full items-center justify-center gap-2 rounded-xl border border-border bg-surface px-4 py-3 font-medium text-text-primary transition-all hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {apiConfig.isTesting ? (
@@ -240,7 +240,7 @@ export function ConfigModal({
                   onClick={() => {
                     void apiConfig.handleSave();
                   }}
-                  disabled={apiConfig.isSaving || (apiConfig.requiresApiKey && !apiConfig.apiKey.trim())}
+                  disabled={apiConfig.isSaving || (apiConfig.requiresApiKey && !apiConfig.hasUsableApiKey)}
                   className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 font-medium text-white transition-all hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {apiConfig.isSaving ? (

--- a/cowork/src/renderer/components/LLMConfigPanel.tsx
+++ b/cowork/src/renderer/components/LLMConfigPanel.tsx
@@ -283,9 +283,9 @@ export function LLMConfigPanel({
   const saveChoiceDisabled =
     controller.isSaving ||
     !controller.hasUnsavedChanges ||
-    (controller.requiresApiKey && !controller.apiKey.trim());
+    (controller.requiresApiKey && !controller.hasUsableApiKey);
   const testChoiceDisabled =
-    controller.isTesting || (controller.requiresApiKey && !controller.apiKey.trim());
+    controller.isTesting || (controller.requiresApiKey && !controller.hasUsableApiKey);
 
   const providerStatus = useMemo(() => {
     if (controller.provider === 'chatgpt') {
@@ -293,13 +293,13 @@ export function LLMConfigPanel({
         ? t('api.llm.connected', 'Connected')
         : t('api.llm.oauthRequired', 'Sign in');
     }
-    if (!controller.requiresApiKey || controller.apiKey.trim()) {
+    if (!controller.requiresApiKey || controller.hasUsableApiKey) {
       return t('api.llm.ready', 'Ready');
     }
     return t('api.llm.needsKey', 'Needs key');
   }, [
     chatgptStatus.signedIn,
-    controller.apiKey,
+    controller.hasUsableApiKey,
     controller.provider,
     controller.requiresApiKey,
     t,
@@ -465,7 +465,7 @@ export function LLMConfigPanel({
                   ? t('api.llm.saveChoice', 'Save this choice')
                   : t('api.llm.choiceSaved', 'Choice saved')}
             </button>
-            {controller.requiresApiKey && !controller.apiKey.trim() && (
+            {controller.requiresApiKey && !controller.hasUsableApiKey && (
               <div className="basis-full text-right text-[11px] text-warning">
                 {t('api.testError.missing_key')}
               </div>
@@ -660,7 +660,7 @@ export function LLMConfigPanel({
                 type="password"
                 value={controller.apiKey}
                 onChange={(event) => controller.setApiKey(event.target.value)}
-                placeholder={controller.currentPreset?.keyPlaceholder || t('api.enterApiKey')}
+                placeholder={controller.apiKeyPlaceholder || t('api.enterApiKey')}
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-text-primary placeholder-text-muted transition-all focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
               />
               {apiKeyHint(controller, t) && (
@@ -866,7 +866,7 @@ export function LLMConfigPanel({
                 type="password"
                 value={controller.apiKey}
                 onChange={(event) => controller.setApiKey(event.target.value)}
-                placeholder={controller.currentPreset?.keyPlaceholder || t('api.enterApiKey')}
+                placeholder={controller.apiKeyPlaceholder || t('api.enterApiKey')}
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-text-primary placeholder-text-muted transition-all focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
               />
               {apiKeyHint(controller, t) && (

--- a/cowork/src/renderer/components/settings/SettingsAPI.tsx
+++ b/cowork/src/renderer/components/settings/SettingsAPI.tsx
@@ -111,7 +111,7 @@ export function SettingsAPI() {
           isRunning={apiConfig.isDiagnosing}
           onRunDiagnostics={apiConfig.handleDiagnose}
           onRunDeepDiagnostics={apiConfig.isOllamaMode ? apiConfig.handleDeepDiagnose : undefined}
-          disabled={apiConfig.requiresApiKey && !apiConfig.apiKey.trim()}
+          disabled={apiConfig.requiresApiKey && !apiConfig.hasUsableApiKey}
         />
       </section>
     </div>

--- a/cowork/src/renderer/hooks/useApiConfigState.ts
+++ b/cowork/src/renderer/hooks/useApiConfigState.ts
@@ -34,11 +34,13 @@ export { getModelInputGuidance } from '../../shared/api-model-presets';
 interface UseApiConfigStateOptions {
   enabled?: boolean;
   initialConfig?: AppConfig | null;
-  onSave?: (config: Partial<AppConfig>) => Promise<void>;
+  onSave?: (config: Partial<AppConfig>) => Promise<AppConfig | void>;
 }
 
 interface UIProviderProfile {
   apiKey: string;
+  hasStoredApiKey: boolean;
+  apiKeyTail: string;
   baseUrl: string;
   model: string;
   customModel: string;
@@ -263,6 +265,8 @@ function defaultProfileForKey(
   const prefersCustomInput = profileKey.startsWith('custom:');
   return {
     apiKey: '',
+    hasStoredApiKey: false,
+    apiKeyTail: '',
     baseUrl: preset.baseUrl,
     model: profileKey === 'ollama' ? '' : (preset.models[0]?.id || ''),
     customModel: '',
@@ -350,7 +354,12 @@ function isPristineCustomProfile(
   const baseUrl = profile.baseUrl?.trim() || fallback.baseUrl;
   const model = profile.model?.trim() || fallback.model;
 
-  return apiKey === '' && baseUrl === fallback.baseUrl && model === fallback.model;
+  return (
+    apiKey === '' &&
+    !profile.hasKey &&
+    baseUrl === fallback.baseUrl &&
+    model === fallback.model
+  );
 }
 
 function normalizeProfile(
@@ -367,6 +376,8 @@ function normalizeProfile(
     return {
       ...fallback,
       apiKey: '',
+      hasStoredApiKey: false,
+      apiKeyTail: '',
       baseUrl: fallback.baseUrl,
       customModel: '',
       useCustomModel: true,
@@ -382,6 +393,8 @@ function normalizeProfile(
   );
   return {
     apiKey: profile?.apiKey || '',
+    hasStoredApiKey: Boolean(profile?.hasKey || profile?.apiKey?.trim()),
+    apiKeyTail: profile?.keyTail || '',
     baseUrl: profileKey === 'ollama'
       ? (normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl)
       : profileKey === 'lmstudio'
@@ -485,6 +498,9 @@ function toPersistedProfiles(
       : profile.model;
     persisted[key] = {
       apiKey: profile.apiKey,
+      ...(profile.hasStoredApiKey && !profile.apiKey.trim()
+        ? { hasKey: true, keyTail: profile.apiKeyTail || undefined }
+        : {}),
       baseUrl: profile.baseUrl.trim() || undefined,
       model: finalModel,
       contextWindow: profile.contextWindow ? Number(profile.contextWindow) : undefined,
@@ -556,6 +572,9 @@ export function buildApiConfigSets(
         const uiProfile = normalizeProfile(key, set.profiles?.[key], presets);
         normalizedProfiles[key] = {
           apiKey: uiProfile.apiKey,
+          ...(uiProfile.hasStoredApiKey && !uiProfile.apiKey.trim()
+            ? { hasKey: true, keyTail: uiProfile.apiKeyTail || undefined }
+            : {}),
           baseUrl: uiProfile.baseUrl,
           model: uiProfile.useCustomModel
             ? uiProfile.customModel.trim() || uiProfile.model
@@ -571,6 +590,9 @@ export function buildApiConfigSets(
         );
         normalizedProfiles.ollama = {
           apiKey: ollamaProfile.apiKey,
+          ...(ollamaProfile.hasStoredApiKey && !ollamaProfile.apiKey.trim()
+            ? { hasKey: true, keyTail: ollamaProfile.apiKeyTail || undefined }
+            : {}),
           baseUrl: ollamaProfile.baseUrl,
           model: ollamaProfile.useCustomModel
             ? ollamaProfile.customModel.trim() || ollamaProfile.model
@@ -585,6 +607,9 @@ export function buildApiConfigSets(
         );
         normalizedProfiles.lmstudio = {
           apiKey: lmStudioProfile.apiKey,
+          ...(lmStudioProfile.hasStoredApiKey && !lmStudioProfile.apiKey.trim()
+            ? { hasKey: true, keyTail: lmStudioProfile.apiKeyTail || undefined }
+            : {}),
           baseUrl: lmStudioProfile.baseUrl,
           model: lmStudioProfile.useCustomModel
             ? lmStudioProfile.customModel.trim() || lmStudioProfile.model
@@ -1122,6 +1147,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   );
 
   const apiKey = currentProfile.apiKey;
+  const hasUsableApiKey = Boolean(apiKey.trim() || currentProfile.hasStoredApiKey);
+  const apiKeyPlaceholder = currentProfile.hasStoredApiKey
+    ? `•••• ${currentProfile.apiKeyTail}`
+    : currentPreset.keyPlaceholder;
   const baseUrl = currentProfile.baseUrl;
   const model = currentProfile.model;
   const customModel = currentProfile.customModel;
@@ -1535,7 +1564,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   }, [activeProfileKey, baseUrl, isLocalOpenAIProvider, provider, presets]);
 
   const handleTest = useCallback(async () => {
-    if (requiresApiKey && !apiKey.trim()) {
+    if (requiresApiKey && !hasUsableApiKey) {
       showErrorKey('api.testError.missing_key');
       return;
     }
@@ -1562,7 +1591,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
       const result = await window.electronAPI.config.test({
         provider,
-        apiKey: apiKey.trim(),
+        apiKey: apiKey.trim() || undefined,
         baseUrl: resolvedBaseUrl || undefined,
         customProtocol,
         model: finalModel,
@@ -1595,6 +1624,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     isLocalOpenAIProvider,
     requiresApiKey,
     hasUnsavedChanges,
+    hasUsableApiKey,
     clearError,
     clearSuccessMessage,
     useCustomModel,
@@ -1603,7 +1633,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   ]);
 
   const handleDiagnose = useCallback(async (verificationLevel: 'fast' | 'deep' = 'fast') => {
-    if (requiresApiKey && !apiKey.trim()) {
+    if (requiresApiKey && !hasUsableApiKey) {
       showErrorKey('api.testError.missing_key');
       return;
     }
@@ -1622,7 +1652,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
       const result = await window.electronAPI.config.diagnose({
         provider,
-        apiKey: apiKey.trim(),
+        apiKey: apiKey.trim() || undefined,
         baseUrl: resolvedBaseUrl || undefined,
         customProtocol,
         model: finalModel || undefined,
@@ -1636,6 +1666,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     }
   }, [
     requiresApiKey,
+    hasUsableApiKey,
     apiKey,
     baseUrl,
     provider,
@@ -1676,7 +1707,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       if (models.length === 0) {
         models = await window.electronAPI.config.listModels({
           provider,
-          apiKey: apiKey.trim(),
+          apiKey: apiKey.trim() || undefined,
           baseUrl: requestedBaseUrl || undefined,
         });
       }
@@ -2056,7 +2087,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
   const handleSave = useCallback(
     async (options?: { silentSuccess?: boolean }) => {
-      if (requiresApiKey && !apiKey.trim()) {
+      if (requiresApiKey && !hasUsableApiKey) {
         showErrorKey('api.testError.missing_key');
         return false;
       }
@@ -2084,7 +2115,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
         const payload: Partial<AppConfig> = {
           provider,
-          apiKey: apiKey.trim(),
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
           baseUrl: resolvedBaseUrl || undefined,
           customProtocol,
           model: finalModel,
@@ -2094,14 +2125,19 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           enableThinking,
         };
 
+        let persistedConfig: AppConfig | void;
         if (onSave) {
-          await onSave(payload);
+          persistedConfig = await onSave(payload);
         } else {
           const result = await window.electronAPI.config.save(payload);
-          applyPersistedConfigToStore(result.config, presets);
+          persistedConfig = result.config;
         }
 
-        dispatch({ type: 'SET_SAVED_DRAFT_SIGNATURE', payload: currentDraftSignature });
+        if (persistedConfig) {
+          applyPersistedConfigToStore(persistedConfig, presets);
+        } else {
+          dispatch({ type: 'SET_SAVED_DRAFT_SIGNATURE', payload: currentDraftSignature });
+        }
         if (!options?.silentSuccess) {
           showSuccessKey('common.saved');
           dispatch({ type: 'SET_LAST_SAVE_COMPLETED_AT', payload: Date.now() });
@@ -2137,6 +2173,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       provider,
       isLocalOpenAIProvider,
       requiresApiKey,
+      hasUsableApiKey,
       clearError,
       clearSuccessMessage,
       showErrorKey,
@@ -2399,6 +2436,8 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     modelOptions,
     currentPreset,
     apiKey,
+    apiKeyPlaceholder,
+    hasUsableApiKey,
     baseUrl,
     model,
     customModel,

--- a/cowork/src/renderer/types/index.ts
+++ b/cowork/src/renderer/types/index.ts
@@ -2123,6 +2123,8 @@ export type ConfigSetId = string;
 
 export interface ProviderProfile {
   apiKey: string;
+  hasKey?: boolean;
+  keyTail?: string;
   baseUrl?: string;
   model: string;
   contextWindow?: number;
@@ -2150,6 +2152,8 @@ export interface CreateSetPayload {
 export interface AppConfig {
   provider: ProviderType;
   apiKey: string;
+  hasKey?: boolean;
+  keyTail?: string;
   baseUrl?: string;
   customProtocol?: CustomProtocolType;
   model: string;
@@ -2249,7 +2253,7 @@ export interface ModelInventorySnapshot {
 
 export interface ApiTestInput {
   provider: AppConfig['provider'];
-  apiKey: string;
+  apiKey?: string;
   baseUrl?: string;
   customProtocol?: AppConfig['customProtocol'];
   model?: string;
@@ -2305,7 +2309,7 @@ export interface DiagnosticResult {
 
 export interface DiagnosticInput {
   provider: AppConfig['provider'];
-  apiKey: string;
+  apiKey?: string;
   baseUrl?: string;
   customProtocol?: AppConfig['customProtocol'];
   model?: string;

--- a/cowork/tests/api-config-state.test.ts
+++ b/cowork/tests/api-config-state.test.ts
@@ -178,6 +178,32 @@ describe('api config state helpers', () => {
     expect(snapshot.profiles['custom:anthropic'].apiKey).toBe('sk-custom-anthropic');
   });
 
+  it('keeps redacted stored keys write-only in renderer state', () => {
+    const config = {
+      provider: 'openai',
+      activeProfileKey: 'openai',
+      apiKey: '',
+      hasKey: true,
+      keyTail: '1234',
+      model: 'gpt-5.4',
+      profiles: {
+        openai: {
+          apiKey: '',
+          hasKey: true,
+          keyTail: '1234',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-5.4',
+        },
+      },
+      isConfigured: true,
+    } as AppConfig;
+
+    const snapshot = buildApiConfigSnapshot(config, FALLBACK_PROVIDER_PRESETS);
+    expect(snapshot.profiles.openai.apiKey).toBe('');
+    expect(snapshot.profiles.openai.hasStoredApiKey).toBe(true);
+    expect(snapshot.profiles.openai.apiKeyTail).toBe('1234');
+  });
+
   it('applies defaults only for missing profiles', () => {
     const config = {
       provider: 'openai',

--- a/cowork/tests/config-store-config-sets.test.ts
+++ b/cowork/tests/config-store-config-sets.test.ts
@@ -102,6 +102,57 @@ describe('ConfigStore config sets', () => {
     expect(defaultSetView.apiKey).toBe('sk-openrouter-origin');
   });
 
+  it('redacts every profile key and preserves secrets on renderer round-trip', () => {
+    mocks.seed = {
+      provider: 'openrouter',
+      customProtocol: 'anthropic',
+      apiKey: 'sk-openrouter-origin',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'anthropic/claude-sonnet-4-6',
+      enableThinking: false,
+      isConfigured: true,
+    };
+    const store = new ConfigStore();
+    store.createSet({ name: 'Work', mode: 'clone' });
+    store.update({ provider: 'openai', apiKey: 'sk-openai-work', model: 'gpt-5-mini' });
+    const before = store.getAll();
+
+    const redacted = store.getAllRedacted();
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain('sk-openrouter-origin');
+    expect(serialized).not.toContain('sk-openai-work');
+    expect(redacted.apiKey).toBe('');
+    expect(redacted.hasKey).toBe(true);
+    expect(redacted.keyTail).toBe('work');
+    expect(redacted.profiles.openai).toMatchObject({
+      apiKey: '',
+      hasKey: true,
+      keyTail: 'work',
+    });
+    expect(
+      redacted.configSets.every((set) =>
+        Object.values(set.profiles).every((profile) => profile?.apiKey === '')
+      )
+    ).toBe(true);
+
+    store.update(redacted);
+    const after = store.getAll();
+    expect(after.apiKey).toBe(before.apiKey);
+    expect(
+      after.configSets.map((set) =>
+        Object.fromEntries(
+          Object.entries(set.profiles).map(([key, profile]) => [key, profile?.apiKey])
+        )
+      )
+    ).toEqual(
+      before.configSets.map((set) =>
+        Object.fromEntries(
+          Object.entries(set.profiles).map(([key, profile]) => [key, profile?.apiKey])
+        )
+      )
+    );
+  });
+
   it('guards default set deletion and falls back to default after delete', () => {
     const store = new ConfigStore();
     const created = store.createSet({ name: 'My Set', mode: 'clone' });

--- a/cowork/tests/index-config-window-behavior.test.ts
+++ b/cowork/tests/index-config-window-behavior.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 
 const indexPath = path.resolve(process.cwd(), 'src/main/index.ts');
+const windowManagementPath = path.resolve(process.cwd(), 'src/main/window-management.ts');
 
 describe('Main process window/config behavior', () => {
   it('second-instance path focuses existing window and only recreates when none found', () => {
@@ -35,5 +36,16 @@ describe('Main process window/config behavior', () => {
 
     expect(continueGuard).toContain('hasUsableCredentialsForActiveSet');
     expect(continueGuard).toContain('sendActiveSetConfigRequiredError(event.payload.sessionId)');
+  });
+
+  it('only exposes redacted provider config to the renderer', () => {
+    const indexSource = fs.readFileSync(indexPath, 'utf8');
+    const windowSource = fs.readFileSync(windowManagementPath, 'utf8');
+
+    expect(indexSource).toContain("ipcMain.handle('config.get'");
+    expect(indexSource).toContain('return configStore.getAllRedacted();');
+    expect(indexSource).not.toContain('config: configStore.getAll(),');
+    expect(windowSource).not.toContain('config: configStore.getAll(),');
+    expect(windowSource).toContain('config: configStore.getAllRedacted(),');
   });
 });

--- a/cowork/tests/ipc-main-bridge-remote-permission.test.ts
+++ b/cowork/tests/ipc-main-bridge-remote-permission.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handlePermissionRequest: vi.fn(),
+  isRemoteSession: vi.fn(),
+  webContentsSend: vi.fn(),
+}));
+
+vi.mock('../src/main/remote/remote-manager', () => ({
+  remoteManager: {
+    isRemoteSession: mocks.isRemoteSession,
+    handlePermissionRequest: mocks.handlePermissionRequest,
+    sendResponseToChannel: vi.fn(),
+    sendToolProgress: vi.fn(),
+    clearSessionBuffer: vi.fn(),
+  },
+}));
+
+vi.mock('../src/main/window-management', () => ({
+  getMainWindow: () => ({
+    isDestroyed: () => false,
+    webContents: { send: mocks.webContentsSend },
+  }),
+}));
+
+vi.mock('../src/main/utils/logger', () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { sendToRenderer, setPermissionResponder } from '../src/main/ipc-main-bridge';
+
+describe('ipc-main-bridge remote permissions', () => {
+  beforeEach(() => {
+    mocks.isRemoteSession.mockReturnValue(true);
+    mocks.handlePermissionRequest.mockResolvedValue({ allow: true });
+  });
+
+  afterEach(() => {
+    setPermissionResponder(null);
+    vi.clearAllMocks();
+  });
+
+  it('applies an allowed remote response instead of forwarding it to the renderer', async () => {
+    const responder = vi.fn();
+    setPermissionResponder(responder);
+
+    sendToRenderer({
+      type: 'permission.request',
+      payload: {
+        sessionId: 'remote-session',
+        toolUseId: 'tool-1',
+        toolName: 'bash',
+        input: { command: 'pwd' },
+      },
+    });
+    await vi.waitFor(() => expect(responder).toHaveBeenCalledWith('tool-1', 'allow', undefined));
+
+    expect(mocks.webContentsSend).not.toHaveBeenCalled();
+  });
+
+  it('routes remembered engine approvals through the bridge id', async () => {
+    mocks.handlePermissionRequest.mockResolvedValue({ allow: true, remember: true });
+    const responder = vi.fn();
+    setPermissionResponder(responder);
+
+    sendToRenderer({
+      type: 'permission.request',
+      payload: {
+        sessionId: 'remote-session',
+        toolUseId: 'tool-2',
+        toolName: 'write_file',
+        input: { path: 'notes.txt' },
+        bridgeId: 'engine-bridge-2',
+      },
+    });
+    await vi.waitFor(() =>
+      expect(responder).toHaveBeenCalledWith('tool-2', 'allow_always', 'engine-bridge-2')
+    );
+  });
+});

--- a/cowork/tests/session-manager-crud.test.ts
+++ b/cowork/tests/session-manager-crud.test.ts
@@ -810,6 +810,35 @@ describe('SessionManager.handlePermissionResponse', () => {
     // Should not throw
     expect(() => manager.handlePermissionResponse('nonexistent', 'deny')).not.toThrow();
   });
+
+  it('keeps remote permission requests pending beyond the channel timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const db = makeDb();
+      const sendToRenderer = vi.fn();
+      const manager = new SessionManager(
+        db,
+        sendToRenderer,
+        undefined,
+        undefined,
+        undefined,
+        () => true
+      );
+      const permissionPromise = manager.requestPermission('remote-s1', 'tool-remote', 'bash', {
+        command: 'pwd',
+      });
+      const resolved = vi.fn();
+      void permissionPromise.then(resolved);
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      expect(resolved).not.toHaveBeenCalled();
+
+      manager.handlePermissionResponse('tool-remote', 'allow');
+      await expect(permissionPromise).resolves.toBe('allow');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ------------------------------------------------------------------

--- a/cowork/tests/turn-journal.test.ts
+++ b/cowork/tests/turn-journal.test.ts
@@ -1,18 +1,47 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { TurnJournal } from '../src/main/session/turn-journal';
 
+const fsCallCounts = vi.hoisted(() => ({ open: 0, fsync: 0, close: 0 }));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      fsCallCounts.open += 1;
+      return actual.openSync(...args);
+    },
+    fsyncSync: (fd: number) => {
+      fsCallCounts.fsync += 1;
+      return actual.fsyncSync(fd);
+    },
+    closeSync: (fd: number) => {
+      fsCallCounts.close += 1;
+      return actual.closeSync(fd);
+    },
+  };
+});
+
 const tempDirs: string[] = [];
+const journals: TurnJournal[] = [];
 
 function makeJournal(): TurnJournal {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-turn-journal-'));
   tempDirs.push(dir);
-  return new TurnJournal(dir);
+  const journal = new TurnJournal(dir);
+  journals.push(journal);
+  return journal;
 }
 
 afterEach(() => {
+  for (const journal of journals.splice(0)) journal.close();
+  vi.useRealTimers();
+  fsCallCounts.open = 0;
+  fsCallCounts.fsync = 0;
+  fsCallCounts.close = 0;
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
@@ -102,5 +131,52 @@ describe('TurnJournal', () => {
     expect(result.events.map((event) => event.type)).toEqual(['message_saved', 'turn_failed']);
     expect(result.pendingTurnCount).toBe(0);
     expect(result.turns[0]?.status).toBe('failed');
+  });
+
+  it('coalesces a streaming burst into one open and one delayed fsync', async () => {
+    vi.useFakeTimers();
+    const journal = makeJournal();
+
+    for (let index = 0; index < 1_000; index += 1) {
+      journal.append('streaming', 'trace_update', { index });
+    }
+
+    expect(fsCallCounts.open).toBe(1);
+    expect(fsCallCounts.fsync).toBe(0);
+    expect(journal.read('streaming').totalEventCount).toBe(1_000);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fsCallCounts.fsync).toBe(1);
+    expect(fsCallCounts.close).toBe(1);
+  });
+
+  it('fsyncs and closes immediately at a turn boundary', async () => {
+    vi.useFakeTimers();
+    const journal = makeJournal();
+
+    journal.append('s1', 'trace_step', { stepId: 'step-1' });
+    journal.append('s1', 'turn_completed', {}, 'turn-1');
+
+    expect(fsCallCounts.fsync).toBe(1);
+    expect(fsCallCounts.close).toBe(1);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fsCallCounts.fsync).toBe(1);
+  });
+
+  it('closes the active handle before rotating and reopens a fresh journal', () => {
+    const journal = makeJournal();
+    journal.append('s1', 'trace_step', { stepId: 'before-rotate' });
+
+    const archivedPath = journal.rotate('s1', 'test');
+    expect(archivedPath).not.toBeNull();
+    expect(fsCallCounts.fsync).toBe(1);
+    expect(fsCallCounts.close).toBe(1);
+
+    journal.append('s1', 'trace_step', { stepId: 'after-rotate' });
+
+    expect(journal.read('s1').events).toHaveLength(1);
+    expect(journal.read('s1').events[0]?.data).toEqual({ stepId: 'after-rotate' });
+    expect(fs.readFileSync(archivedPath!, 'utf8')).toContain('before-rotate');
+    expect(fs.readFileSync(archivedPath!, 'utf8')).not.toContain('after-rotate');
   });
 });

--- a/cowork/tests/workflow-bridge-persistence.test.ts
+++ b/cowork/tests/workflow-bridge-persistence.test.ts
@@ -1,0 +1,63 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkflowBridge } from '../src/main/workflows/workflow-bridge';
+
+vi.mock('../src/main/utils/logger', () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+describe('WorkflowBridge persistence', () => {
+  let userDataPath: string;
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'cowork-workflows-'));
+  });
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true });
+  });
+
+  it('quarantines an invalid workflows file before creating a new one', () => {
+    const bridge = new WorkflowBridge(userDataPath);
+    const workflowDir = join(userDataPath, 'workflows');
+    const workflowPath = join(workflowDir, 'workflows.json');
+    writeFileSync(workflowPath, '{truncated', 'utf8');
+
+    expect(bridge.list()).toEqual([]);
+    expect(existsSync(workflowPath)).toBe(false);
+    const corruptName = readdirSync(workflowDir).find((name) =>
+      name.startsWith('workflows.json.corrupt-')
+    );
+    expect(corruptName).toBeDefined();
+    expect(readFileSync(join(workflowDir, corruptName!), 'utf8')).toBe('{truncated');
+
+    bridge.create({ name: 'Recovered', nodes: [], edges: [] });
+    expect(JSON.parse(readFileSync(workflowPath, 'utf8'))).toHaveLength(1);
+    expect(readFileSync(join(workflowDir, corruptName!), 'utf8')).toBe('{truncated');
+  });
+
+  it('keeps the persisted file and cache unchanged when the atomic write fails', () => {
+    const bridge = new WorkflowBridge(userDataPath);
+    const original = bridge.create({ name: 'Original', nodes: [], edges: [] });
+    const workflowPath = join(userDataPath, 'workflows', 'workflows.json');
+    const before = readFileSync(workflowPath, 'utf8');
+
+    mkdirSync(`${workflowPath}.tmp`);
+    expect(() => bridge.create({ name: 'Not persisted', nodes: [], edges: [] })).toThrow();
+
+    expect(readFileSync(workflowPath, 'utf8')).toBe(before);
+    expect(bridge.list().map((workflow) => workflow.id)).toEqual([original.id]);
+  });
+});

--- a/src/fleet/fleet-listener.ts
+++ b/src/fleet/fleet-listener.ts
@@ -304,6 +304,10 @@ export class FleetListener extends EventEmitter {
         this.connected = false;
         this.authenticated = false;
         this.emit('disconnected');
+        // Responses sent to the old socket can never arrive on a replacement
+        // connection. Reject immediately instead of leaving callers blocked
+        // until their individual request timeouts expire.
+        this.rejectPendingRequests('connection closed');
         // If we never settled, the connection died before auth — reject.
         settle(new Error('Connection closed before authentication'));
         // Phase (d).6 — schedule auto-reconnect only if:

--- a/src/fleet/peer-chat-bridge.ts
+++ b/src/fleet/peer-chat-bridge.ts
@@ -20,7 +20,7 @@
  */
 
 import type { CodeBuddyClient, ChatOptions } from '../codebuddy/client.js';
-import { beginFleetWork } from './fleet-load.js';
+import { beginFleetWork, isFleetSaturated } from './fleet-load.js';
 import { executeCostCappedFleetCall } from './fleet-cost-cap.js';
 import { registerPeerMethod, unregisterPeerMethod } from '../server/websocket/peer-method-registry.js';
 import { logger } from '../utils/logger.js';
@@ -64,6 +64,13 @@ const providerClients = new Map<PeerChatProviderId, {
 let wired = false;
 
 const DEFAULT_SYSTEM_PROMPT = 'Answer this side question briefly. Do not use tools.';
+
+function assertFleetCapacity(method: string): void {
+  if (!isFleetSaturated()) return;
+  const error = new Error(`${method}: fleet concurrency limit reached`);
+  (error as Error & { code: 'SATURATED' }).code = 'SATURATED';
+  throw error;
+}
 
 export type { FleetDispatchProfile as PeerDispatchProfile } from './dispatch-profile.js';
 
@@ -205,6 +212,7 @@ export function wirePeerChatBridge(
       // dispatchPeerRequest wraps thrown errors as METHOD_ERROR.
       throw new Error('peer.chat: prompt is required (string)');
     }
+    assertFleetCapacity('peer.chat');
     const selected = resolveClientForRequest(provider, model, 'peer.chat');
     const client = selected.client;
 
@@ -267,6 +275,7 @@ export function wirePeerChatBridge(
     if (!prompt) {
       throw new Error('peer.chat-stream: prompt is required (string)');
     }
+    assertFleetCapacity('peer.chat-stream');
     const selected = resolveClientForRequest(provider, model, 'peer.chat-stream');
     const client = selected.client;
 

--- a/src/memory/collective-knowledge-graph.ts
+++ b/src/memory/collective-knowledge-graph.ts
@@ -30,7 +30,17 @@
  * @module memory/collective-knowledge-graph
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  statSync,
+  writeFileSync,
+  type Stats,
+} from 'fs';
 import { dirname, join } from 'path';
 import { logger } from '../utils/logger.js';
 import { contentHash, computeSalience, type EntityType, type RelationType } from './knowledge-graph.js';
@@ -50,7 +60,6 @@ import {
   type FactVerdict,
   type StructuredFact,
 } from './ckg-fact-reconciliation.js';
-import { writeFileSync } from 'fs';
 import { redactRememberInput } from './ckg-redaction.js';
 
 /** Multilingual embeddings — all-MiniLM (the global default) is English-leaning and misses
@@ -227,6 +236,13 @@ export class CollectiveKnowledgeGraph {
   /** Invalidated (superseded) versions, keyed by `id@contentHash`. */
   private readonly superseded = new Map<string, CkgEntity>();
   private readonly relations = new Map<string, CkgRelation>();
+  /** Byte position immediately after the last complete JSONL line applied to the view. */
+  private ledgerOffset = 0;
+  /** Last observed file metadata, used to make unchanged loads an O(1) stat. */
+  private ledgerSize = 0;
+  private ledgerMtimeMs = 0;
+  private ledgerDevice: number | null = null;
+  private ledgerInode: number | null = null;
   /** contentHash → embedding vector. Content-addressed, so it survives ledger reloads. */
   private readonly embCache = new Map<string, Float32Array>();
   private readonly embeddingModel: string;
@@ -299,7 +315,6 @@ export class CollectiveKnowledgeGraph {
         ...(safeInput.source ? { source: safeInput.source } : {}),
       };
       this.append(entityEvent);
-      this.applyEntity(entityEvent);
 
       for (const rel of safeInput.relations ?? []) {
         const targetType: EntityType = rel.targetType ?? 'concept';
@@ -312,14 +327,12 @@ export class CollectiveKnowledgeGraph {
           ...(safeInput.source ? { source: safeInput.source } : {}),
         };
         this.append(relEvent);
-        this.applyRelation(relEvent);
         if (!this.current.has(targetId)) {
           const tEvent: LedgerEvent = {
             v: 1, kind: 'entity', recordedAt, agentId, contentHash: contentHash(targetType, rel.targetName),
             id: targetId, type: targetType, name: rel.targetName, text: rel.targetName, confidence: 0.5,
           };
           this.append(tEvent);
-          this.applyEntity(tEvent);
         }
       }
       return this.toResult(this.current.get(id)!);
@@ -673,7 +686,6 @@ export class CollectiveKnowledgeGraph {
         ...(opts.reason ? { reason: opts.reason } : {}),
       };
       this.append(event);
-      this.applyRetraction(event);
       return { retracted: true, id, status: 'retracted' };
     } catch (err) {
       logger.warn(`[ckg] retract failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -866,20 +878,86 @@ export class CollectiveKnowledgeGraph {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     // O_APPEND keeps concurrent small-line writes from interleaving (POSIX atomic append).
     appendFileSync(this.ledgerPath, `${JSON.stringify(event)}\n`, 'utf8');
+    // `load` is the single event-application path. This avoids double-applying a local
+    // append while still picking up writes that another process raced in before ours.
+    this.load();
   }
 
-  /** Rebuild the in-memory view by replaying the whole ledger (Phase 0/1; SQLite index in Phase 2). */
+  /**
+   * Bring the in-memory view up to date from the append-only ledger. Unchanged files cost
+   * one stat; growth reads only bytes after the last complete JSONL line. Truncation,
+   * replacement, or an in-place rewrite falls back to a full replay.
+   */
   private load(): void {
-    this.current.clear();
-    this.superseded.clear();
-    this.relations.clear();
-    if (!existsSync(this.ledgerPath)) return;
-    let content: string;
+    if (!existsSync(this.ledgerPath)) {
+      if (this.ledgerSize > 0 || this.ledgerOffset > 0) this.resetLedgerView();
+      return;
+    }
+
+    let stats: Stats;
     try {
-      content = readFileSync(this.ledgerPath, 'utf8');
+      stats = statSync(this.ledgerPath);
     } catch {
       return;
     }
+
+    const sameFile =
+      this.ledgerDevice === null ||
+      (this.ledgerDevice === stats.dev && this.ledgerInode === stats.ino);
+    const unchanged =
+      sameFile && stats.size === this.ledgerSize && stats.mtimeMs === this.ledgerMtimeMs;
+    if (unchanged) return;
+
+    const requiresFullReplay =
+      !sameFile ||
+      stats.size < this.ledgerSize ||
+      stats.size < this.ledgerOffset ||
+      (stats.size === this.ledgerSize && stats.mtimeMs !== this.ledgerMtimeMs);
+    if (requiresFullReplay) this.resetLedgerView();
+
+    const bytesToRead = stats.size - this.ledgerOffset;
+    if (bytesToRead <= 0) {
+      this.rememberLedgerMetadata(stats);
+      return;
+    }
+
+    const chunk = Buffer.allocUnsafe(bytesToRead);
+    let fd: number | null = null;
+    let bytesRead = 0;
+    try {
+      fd = openSync(this.ledgerPath, 'r');
+      while (bytesRead < bytesToRead) {
+        const count = readSync(
+          fd,
+          chunk,
+          bytesRead,
+          bytesToRead - bytesRead,
+          this.ledgerOffset + bytesRead,
+        );
+        if (count === 0) break;
+        bytesRead += count;
+      }
+    } catch {
+      return;
+    } finally {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {
+          // The bytes already read remain usable; a close failure must not break recall.
+        }
+      }
+    }
+
+    // Do not advance past a torn final line. A later append completes it and the next
+    // incremental read starts from the same byte offset.
+    const completeEnd = chunk.subarray(0, bytesRead).lastIndexOf(0x0a) + 1;
+    if (completeEnd === 0) {
+      this.rememberLedgerMetadata(stats);
+      return;
+    }
+
+    const content = chunk.subarray(0, completeEnd).toString('utf8');
     for (const line of content.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) continue;
@@ -893,6 +971,26 @@ export class CollectiveKnowledgeGraph {
       else if (event.kind === 'relation') this.applyRelation(event);
       else if (event.kind === 'retraction') this.applyRetraction(event);
     }
+    this.ledgerOffset += completeEnd;
+    this.rememberLedgerMetadata(stats);
+  }
+
+  private resetLedgerView(): void {
+    this.current.clear();
+    this.superseded.clear();
+    this.relations.clear();
+    this.ledgerOffset = 0;
+    this.ledgerSize = 0;
+    this.ledgerMtimeMs = 0;
+    this.ledgerDevice = null;
+    this.ledgerInode = null;
+  }
+
+  private rememberLedgerMetadata(stats: Stats): void {
+    this.ledgerSize = stats.size;
+    this.ledgerMtimeMs = stats.mtimeMs;
+    this.ledgerDevice = stats.dev;
+    this.ledgerInode = stats.ino;
   }
 
   /**
@@ -972,7 +1070,6 @@ export class CollectiveKnowledgeGraph {
       sourceId, targetId, relType, reason: `semantic neighbour (${sim.toFixed(2)})`,
     };
     this.append(event);
-    this.applyRelation(event);
   }
 
   private applyRelation(e: LedgerEvent): void {

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -66,6 +66,8 @@ interface ConnectionState {
   toolWindowStart: number;
   peerRequestCount: number;
   peerWindowStart: number;
+  peerHandlersActive: number;
+  peerHandlerQueue: PeerHandlerTask[];
   // Phase (d).7 — count of broadcast() calls skipped for this client
   // because its ws.bufferedAmount exceeded SERVER_CONFIG.WS_BROADCAST_BUFFER_LIMIT.
   // Reset only on disconnect; surfaced via getConnectionStats().totalBroadcastsDropped.
@@ -82,6 +84,15 @@ interface ConnectionTurn {
   cancelled: boolean;
   abortDelivered: boolean;
 }
+
+interface PeerHandlerTask {
+  run: () => Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+const MAX_PARALLEL_PEER_HANDLERS = 3;
+const MAX_PENDING_PEER_HANDLERS = 200;
 
 // Active connections
 const connections = new Map<WebSocket, ConnectionState>();
@@ -406,6 +417,48 @@ function sendError(ws: WebSocket, code: string, message: string, id?: string): v
     error: { code, message },
     timestamp: new Date().toISOString(),
   });
+}
+
+function startPeerHandler(state: ConnectionState, task: PeerHandlerTask): void {
+  state.peerHandlersActive += 1;
+  void task.run()
+    .then(task.resolve, task.reject)
+    .finally(() => {
+      state.peerHandlersActive = Math.max(0, state.peerHandlersActive - 1);
+      const next = state.peerHandlerQueue.shift();
+      if (next) startPeerHandler(state, next);
+    });
+}
+
+/**
+ * Bound peer RPC concurrency independently from serial chat/tool messages.
+ * The shared LaneQueue only admits parallel work that was pending in the same
+ * batch, so requests arriving while a long handler is running also need this
+ * small per-connection scheduler to preserve true RPC multiplexing.
+ */
+function enqueuePeerHandler(
+  state: ConnectionState,
+  run: () => Promise<void>,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const task: PeerHandlerTask = { run, resolve, reject };
+    if (state.peerHandlersActive < MAX_PARALLEL_PEER_HANDLERS) {
+      startPeerHandler(state, task);
+      return;
+    }
+    if (state.peerHandlerQueue.length >= MAX_PENDING_PEER_HANDLERS) {
+      reject(new Error('Peer request queue has too many pending tasks'));
+      return;
+    }
+    state.peerHandlerQueue.push(task);
+  });
+}
+
+function rejectQueuedPeerHandlers(state: ConnectionState, reason: string): void {
+  const error = new Error(reason);
+  for (const task of state.peerHandlerQueue.splice(0)) {
+    task.reject(error);
+  }
 }
 
 /**
@@ -1044,9 +1097,37 @@ async function processMessage(ws: WebSocket, state: ConnectionState, data: RawDa
 
   try {
     const enqueueMessage = await getEnqueueMessage();
-    await enqueueMessage(sessionKey, () => handler(ws, state, payload ?? {}, envelope));
+    if (type === 'peer:request') {
+      const frame = payload && typeof payload === 'object'
+        ? payload as { id?: unknown }
+        : {};
+      const peerRequestId = typeof frame.id === 'string' ? frame.id : 'unknown';
+      await enqueuePeerHandler(state, () => enqueueMessage(
+        `${sessionKey}:peer:${peerRequestId}`,
+        () => handler(ws, state, payload ?? {}, envelope),
+        { parallel: true },
+      ));
+    } else {
+      await enqueueMessage(sessionKey, () => handler(ws, state, payload ?? {}, envelope));
+    }
   } catch (error) {
-    sendError(ws, 'HANDLER_ERROR', error instanceof Error ? error.message : String(error), id);
+    const message = error instanceof Error ? error.message : String(error);
+    if (type === 'peer:request') {
+      const frame = payload && typeof payload === 'object'
+        ? payload as { id?: unknown }
+        : {};
+      send(ws, {
+        type: 'peer:response',
+        payload: {
+          id: typeof frame.id === 'string' ? frame.id : 'unknown',
+          ok: false,
+          error: { code: 'HANDLER_ERROR', message },
+        },
+        timestamp: new Date().toISOString(),
+      });
+    } else {
+      sendError(ws, 'HANDLER_ERROR', message, id);
+    }
   }
 }
 
@@ -1129,6 +1210,8 @@ export async function setupWebSocket(
       toolWindowStart: now,
       peerRequestCount: 0,
       peerWindowStart: now,
+      peerHandlersActive: 0,
+      peerHandlerQueue: [],
       droppedBroadcasts: 0,
     };
 
@@ -1149,6 +1232,7 @@ export async function setupWebSocket(
     });
 
     ws.on('close', () => {
+      rejectQueuedPeerHandlers(state, 'WebSocket closed before peer request execution');
       abortActiveTurn(state);
       cleanupWebSocketExtensions(state);
       connections.delete(ws);
@@ -1157,6 +1241,7 @@ export async function setupWebSocket(
 
     ws.on('error', (error) => {
       logger.error(`WebSocket error [${state.id}]:`, error);
+      rejectQueuedPeerHandlers(state, 'WebSocket failed before peer request execution');
       abortActiveTurn(state);
       cleanupWebSocketExtensions(state);
       connections.delete(ws);

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -37,6 +37,7 @@ const RATE_LIMITS = {
   authWindowMs: 60000,      // 1 minute window for auth
   messagesPerMinute: 60,    // Max messages per minute
   toolExecutionsPerMinute: 20, // Max tool executions per minute
+  peerRequestsPerMinute: 30, // LLM-capable peer RPC calls per minute
 };
 
 // Connection state
@@ -63,6 +64,8 @@ interface ConnectionState {
   messageWindowStart: number;
   toolCount: number;
   toolWindowStart: number;
+  peerRequestCount: number;
+  peerWindowStart: number;
   // Phase (d).7 — count of broadcast() calls skipped for this client
   // because its ws.bufferedAmount exceeded SERVER_CONFIG.WS_BROADCAST_BUFFER_LIMIT.
   // Reset only on disconnect; surfaced via getConnectionStats().totalBroadcastsDropped.
@@ -379,8 +382,8 @@ function send(ws: WebSocket, message: WebSocketResponse): void {
  */
 function checkRateLimit(
   state: ConnectionState,
-  counter: 'authAttempts' | 'messageCount' | 'toolCount',
-  windowField: 'authWindowStart' | 'messageWindowStart' | 'toolWindowStart',
+  counter: 'authAttempts' | 'messageCount' | 'toolCount' | 'peerRequestCount',
+  windowField: 'authWindowStart' | 'messageWindowStart' | 'toolWindowStart' | 'peerWindowStart',
   maxCount: number,
   windowMs: number
 ): boolean {
@@ -913,7 +916,6 @@ messageHandlers.set('peer:request', async (ws, state, payload) => {
     sendError(ws, 'FORBIDDEN', 'peer:invoke scope required');
     return;
   }
-  const { dispatchPeerRequest } = await import('./peer-rpc.js');
   // payload is the request frame { id, method, params, traceId?, depth? }
   const frame = (payload ?? {}) as {
     id?: string;
@@ -923,6 +925,28 @@ messageHandlers.set('peer:request', async (ws, state, payload) => {
     depth?: number;
   };
   const requestId = frame.id ?? '';
+  if (!checkRateLimit(
+    state,
+    'peerRequestCount',
+    'peerWindowStart',
+    RATE_LIMITS.peerRequestsPerMinute,
+    60_000,
+  )) {
+    send(ws, {
+      type: 'peer:response',
+      payload: {
+        id: requestId || 'unknown',
+        ok: false,
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Peer request rate limit exceeded. Please slow down.',
+        },
+      },
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+  const { dispatchPeerRequest } = await import('./peer-rpc.js');
   // Phase (d).19 — emitChunk forwards a partial result delta to the
   // caller as a `peer:chunk` frame keyed by the same request id. The
   // caller's FleetListener routes chunks to its onChunk callback. We
@@ -1103,6 +1127,8 @@ export async function setupWebSocket(
       messageWindowStart: now,
       toolCount: 0,
       toolWindowStart: now,
+      peerRequestCount: 0,
+      peerWindowStart: now,
       droppedBroadcasts: 0,
     };
 

--- a/src/server/websocket/peer-rpc.ts
+++ b/src/server/websocket/peer-rpc.ts
@@ -28,6 +28,7 @@ import {
   normalizeDispatchProfile,
 } from '../../fleet/dispatch-profile.js';
 import type { PeerChatProviderId } from '../../fleet/peer-chat-client-factory.js';
+import { isFleetSaturated } from '../../fleet/fleet-load.js';
 import { logger } from '../../utils/logger.js';
 import {
   _clearPeerMethodsForTests,
@@ -223,6 +224,11 @@ function registerBuiltInMethods(): void {
         `peer.dispatch: dispatchProfile must be one of ${FLEET_DISPATCH_PROFILES.join(', ')}`,
       );
     }
+    if (isFleetSaturated()) {
+      const error = new Error('peer.dispatch: fleet concurrency limit reached');
+      (error as Error & { code: 'SATURATED' }).code = 'SATURATED';
+      throw error;
+    }
     const dispatchId =
       typeof id === 'string' && id.length > 0
         ? id
@@ -381,11 +387,14 @@ export async function dispatchPeerRequest(
     return { id: frame.id, ok: true, payload };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const code = err instanceof Error && 'code' in err && err.code === 'SATURATED'
+      ? 'SATURATED'
+      : 'METHOD_ERROR';
     logger.debug(`[peer-rpc] method "${frame.method}" threw`, { error: message, traceId, depth });
     return {
       id: frame.id,
       ok: false,
-      error: { code: 'METHOD_ERROR', message },
+      error: { code, message },
     };
   }
 }

--- a/tests/fleet/fleet-listener.test.ts
+++ b/tests/fleet/fleet-listener.test.ts
@@ -966,6 +966,29 @@ describe('FleetListener — Phase (d).5 V0.4.1', () => {
       expect(l.getPendingRequestCount()).toBe(0);
     });
 
+    it('rejects in-flight requests immediately when the socket closes unexpectedly', async () => {
+      const { l, fake } = await authedListener();
+      const request = l.request('peer.chat', { prompt: 'slow answer' }, { timeoutMs: 30_000 });
+      const outcome = request.then(
+        () => ({ ok: true as const }),
+        (error: Error & { code?: string }) => ({
+          ok: false as const,
+          code: error.code,
+          message: error.message,
+        }),
+      );
+
+      expect(l.getPendingRequestCount()).toBe(1);
+      fake.close();
+
+      await expect(outcome).resolves.toMatchObject({
+        ok: false,
+        code: 'DISCONNECTED',
+        message: expect.stringContaining('connection closed'),
+      });
+      expect(l.getPendingRequestCount()).toBe(0);
+    });
+
     it('two concurrent requests get matching responses by id (no swap)', async () => {
       const { l, fake } = await authedListener();
       const p1 = l.request('peer.echo', { which: 'first' });

--- a/tests/memory/collective-knowledge-graph.test.ts
+++ b/tests/memory/collective-knowledge-graph.test.ts
@@ -82,6 +82,43 @@ describe('CollectiveKnowledgeGraph (Phase 0)', () => {
     expect(hits[0]!.mentions).toBe(2); // both contributions counted (replay-from-ledger)
   });
 
+  it('keeps the incremental view identical to a full replay after 5k cross-instance writes', () => {
+    const writer = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'writer/repo' });
+    const incremental = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'reader/repo' });
+
+    for (let i = 0; i < 2_500; i++) {
+      writer.remember({ name: `fact-${i}`, text: `shared ledger fact batch one ${i}`, type: 'fact' });
+    }
+    expect(incremental.getStats().entities).toBe(2_500); // establish the replay offset
+
+    for (let i = 2_500; i < 5_000; i++) {
+      writer.remember({ name: `fact-${i}`, text: `shared ledger fact batch two ${i}`, type: 'fact' });
+    }
+    writer.remember({
+      name: 'fact-10',
+      text: 'shared ledger fact ten was updated',
+      type: 'fact',
+      relations: [{ predicate: 'related_to', targetName: 'fact-12', targetType: 'fact' }],
+    });
+    writer.retract('fact-11', { reason: 'obsolete fixture' });
+
+    // `incremental` consumes only the appended half; `fullReplay` starts from byte zero.
+    const incrementalStats = incremental.getStats();
+    const fullReplay = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'fresh/repo' });
+    expect(incrementalStats).toEqual(fullReplay.getStats());
+    expect(incremental.listEntities({ limit: 6_000 })).toEqual(fullReplay.listEntities({ limit: 6_000 }));
+    const incrementalHistory = incremental.getSuperseded()
+      .map(({ salience: _timeDependentSalience, ...hit }) => hit);
+    const fullReplayHistory = fullReplay.getSuperseded()
+      .map(({ salience: _timeDependentSalience, ...hit }) => hit);
+    expect(incrementalHistory).toEqual(fullReplayHistory);
+    const recallView = (ckg: CollectiveKnowledgeGraph) =>
+      ckg.recall('', { limit: 6_000 })
+        .map(({ salience: _timeDependentSalience, ...hit }) => hit)
+        .sort((a, b) => a.id.localeCompare(b.id));
+    expect(recallView(incremental)).toEqual(recallView(fullReplay));
+  });
+
   it('stores typed relations (Code-Explorer edge shape) and returns them on recall', () => {
     const ckg = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'host/repo' });
     ckg.remember({

--- a/tests/server/broadcast-backpressure.test.ts
+++ b/tests/server/broadcast-backpressure.test.ts
@@ -57,6 +57,8 @@ function buildState(opts: {
     toolWindowStart: Date.now(),
     peerRequestCount: 0,
     peerWindowStart: Date.now(),
+    peerHandlersActive: 0,
+    peerHandlerQueue: [],
     droppedBroadcasts: 0,
   };
 }

--- a/tests/server/broadcast-backpressure.test.ts
+++ b/tests/server/broadcast-backpressure.test.ts
@@ -55,6 +55,8 @@ function buildState(opts: {
     messageWindowStart: Date.now(),
     toolCount: 0,
     toolWindowStart: Date.now(),
+    peerRequestCount: 0,
+    peerWindowStart: Date.now(),
     droppedBroadcasts: 0,
   };
 }

--- a/tests/server/peer-chat-bridge.test.ts
+++ b/tests/server/peer-chat-bridge.test.ts
@@ -24,6 +24,7 @@ import {
   _resetPeerRpcForTests,
   type PeerMethodContext,
 } from '../../src/server/websocket/peer-rpc.js';
+import { _resetFleetLoadForTests } from '../../src/fleet/fleet-load.js';
 
 // ---- helpers ---------------------------------------------------------
 
@@ -64,6 +65,7 @@ describe('peer-chat-bridge — Phase (d).15', () => {
   beforeEach(() => {
     _unwireForTests();
     _resetPeerRpcForTests();
+    _resetFleetLoadForTests();
   });
 
   describe('wire / unwire', () => {
@@ -90,6 +92,52 @@ describe('peer-chat-bridge — Phase (d).15', () => {
   });
 
   describe('peer.chat — error paths', () => {
+    it('rejects chat, stream, and dispatch with SATURATED while capacity is full', async () => {
+      const previousCapacity = process.env.CODEBUDDY_FLEET_MAX_CONCURRENCY;
+      process.env.CODEBUDDY_FLEET_MAX_CONCURRENCY = '1';
+      let release: (() => void) | undefined;
+      const chat = vi.fn(() => new Promise((resolve) => {
+        release = () => resolve({
+          choices: [{ message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }],
+        });
+      }));
+      wirePeerChatBridge(() => ({ chat } as never));
+
+      try {
+        const inFlight = dispatchPeerRequest(
+          { id: 'saturation-holder', method: 'peer.chat', params: { prompt: 'hold' } },
+          baseCtx,
+        );
+        await vi.waitFor(() => expect(chat).toHaveBeenCalledOnce());
+
+        for (const [method, params] of [
+          ['peer.chat', { prompt: 'second' }],
+          ['peer.chat-stream', { prompt: 'stream' }],
+          ['peer.dispatch', { id: 'saturated-dispatch', prompt: 'dispatch' }],
+        ] as const) {
+          const response = await dispatchPeerRequest(
+            { id: `blocked-${method}`, method, params },
+            baseCtx,
+          );
+          expect(response).toMatchObject({
+            ok: false,
+            error: { code: 'SATURATED' },
+          });
+        }
+
+        expect(getDispatchState('saturated-dispatch')).toBeNull();
+        release?.();
+        await expect(inFlight).resolves.toMatchObject({ ok: true });
+      } finally {
+        if (previousCapacity === undefined) {
+          delete process.env.CODEBUDDY_FLEET_MAX_CONCURRENCY;
+        } else {
+          process.env.CODEBUDDY_FLEET_MAX_CONCURRENCY = previousCapacity;
+        }
+        _resetFleetLoadForTests();
+      }
+    });
+
     it('METHOD_ERROR when prompt is missing or empty', async () => {
       wirePeerChatBridge(() => null);
       const r1 = await dispatchPeerRequest(

--- a/tests/server/websocket-peer-multiplex.test.ts
+++ b/tests/server/websocket-peer-multiplex.test.ts
@@ -1,0 +1,84 @@
+import { createServer, type Server } from 'http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocketServer } from 'ws';
+
+import { FleetListener } from '../../src/fleet/fleet-listener.js';
+import { createApiKey, deleteApiKey } from '../../src/server/auth/api-keys.js';
+import { DEFAULT_SERVER_CONFIG } from '../../src/server/types.js';
+import { setupWebSocket } from '../../src/server/websocket/handler.js';
+import {
+  registerPeerMethod,
+  unregisterPeerMethod,
+} from '../../src/server/websocket/peer-rpc.js';
+
+describe('WebSocket peer RPC multiplexing', () => {
+  const userId = 'peer-multiplex-test';
+  let server: Server | null = null;
+  let wss: WebSocketServer | null = null;
+  let listener: FleetListener | null = null;
+  let keyId: string | null = null;
+
+  afterEach(async () => {
+    unregisterPeerMethod('test.concurrent');
+    if (listener) await listener.disconnect().catch(() => undefined);
+    if (wss) await new Promise<void>((resolve) => wss?.close(() => resolve()));
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((error) => error ? reject(error) : resolve());
+      });
+    }
+    if (keyId) deleteApiKey(keyId, userId);
+    listener = null;
+    wss = null;
+    server = null;
+    keyId = null;
+  });
+
+  it('runs two correlated peer requests concurrently on one connection', async () => {
+    const created = createApiKey({
+      name: userId,
+      userId,
+      scopes: ['peer:invoke'],
+    });
+    keyId = created.apiKey.id;
+    server = createServer();
+    wss = await setupWebSocket(server, {
+      ...DEFAULT_SERVER_CONFIG,
+      authEnabled: true,
+    });
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected an ephemeral TCP server address');
+    }
+    listener = new FleetListener({
+      url: `ws://127.0.0.1:${address.port}/ws`,
+      apiKey: created.key,
+    });
+    await listener.connect();
+
+    let started = 0;
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    registerPeerMethod('test.concurrent', async (params) => {
+      started += 1;
+      await gate;
+      return { value: params.value };
+    });
+
+    const first = listener.request('test.concurrent', { value: 'first' });
+    const second = listener.request('test.concurrent', { value: 'second' });
+    try {
+      await vi.waitFor(() => expect(started).toBe(2), { timeout: 1_000 });
+    } finally {
+      release?.();
+    }
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { value: 'first' },
+      { value: 'second' },
+    ]);
+  });
+});

--- a/tests/server/websocket-peer-security.test.ts
+++ b/tests/server/websocket-peer-security.test.ts
@@ -1,0 +1,68 @@
+import { createServer, type Server } from 'http';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { WebSocketServer } from 'ws';
+
+import { FleetListener } from '../../src/fleet/fleet-listener.js';
+import { createApiKey, deleteApiKey } from '../../src/server/auth/api-keys.js';
+import { DEFAULT_SERVER_CONFIG } from '../../src/server/types.js';
+import { setupWebSocket } from '../../src/server/websocket/handler.js';
+
+describe('WebSocket peer request security', () => {
+  let server: Server | null = null;
+  let wss: WebSocketServer | null = null;
+  let listener: FleetListener | null = null;
+  let keyId: string | null = null;
+
+  afterEach(async () => {
+    if (listener) {
+      await listener.disconnect().catch(() => undefined);
+    }
+    if (wss) {
+      await new Promise<void>((resolve) => wss?.close(() => resolve()));
+    }
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((error) => error ? reject(error) : resolve());
+      });
+    }
+    if (keyId) deleteApiKey(keyId, 'peer-rate-limit-test');
+    listener = null;
+    wss = null;
+    server = null;
+    keyId = null;
+  });
+
+  it('returns a correlated RATE_LIMITED response after 30 peer requests per minute', async () => {
+    const created = createApiKey({
+      name: 'peer-rate-limit-test',
+      userId: 'peer-rate-limit-test',
+      scopes: ['peer:invoke'],
+    });
+    keyId = created.apiKey.id;
+    server = createServer();
+    wss = await setupWebSocket(server, {
+      ...DEFAULT_SERVER_CONFIG,
+      authEnabled: true,
+    });
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected an ephemeral TCP server address');
+    }
+    listener = new FleetListener({
+      url: `ws://127.0.0.1:${address.port}/ws`,
+      apiKey: created.key,
+    });
+    await listener.connect();
+
+    for (let request = 0; request < 30; request++) {
+      await expect(listener.request('peer.ping')).resolves.toMatchObject({ pong: true });
+    }
+
+    await expect(listener.request('peer.ping')).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      message: expect.stringContaining('RATE_LIMITED'),
+    });
+    expect(listener.getPendingRequestCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Découpe de la vieille PR #69 (Audit Fable 5 batch 2) en une branche rejouée sur `main` (worktree propre, 9 commits), par la flotte (sol) — vérifiée indépendamment.

**Porté** (un commit par fix) : cowork — remote permission responses, turn-journal durability (batch), workflows atomiques, redaction des clés provider côté renderer ; fleet — capacité/rate-limit peer (30 req/min → `RATE_LIMITED` corrélé), multiplexage des requêtes WS, rejet des requêtes pendantes à la fermeture ; CKG — chargement incrémental du ledger append-only ; sensory (Rust `live-vision`) — capture caméra persistante réutilisée.

**Écarté** : `agent-executor.ts` (cœur réécrit depuis), sandbox (réécrit le 22/08), fixes déjà couverts sur main (voir commentaire de bilan sur #69).

**Vérifications** : `tsc --noEmit` 0 (racine + cowork) ; vitest racine 6 fichiers / 98 tests du lot (listener, CKG, backpressure, peer-chat, multiplex, peer-security) ; cowork `ipc-main-bridge` 5/5 (sol : 213/213 racine, 176/176 cowork) ; `cargo test --features live-vision` 37/37 ; eslint 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)