### PR TITLE
feat(cli): buddy explain (découpe de #70)

### DIFF
--- a/src/analytics/repo-explainer-collector.ts
+++ b/src/analytics/repo-explainer-collector.ts
@@ -1,0 +1,496 @@
+/** Read-only, best-effort collection for `buddy explain`. */
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { RepoProfiler, type RepoProfile } from '../agent/repo-profiler.js';
+import { CodeExplorerManager } from '../plugins/code-explorer/CodeExplorerManager.js';
+import { generateDocs, type GeneratedDocs } from '../tools/doc-generator.js';
+import { logger } from '../utils/logger.js';
+import { generateEvolutionReport, type EvolutionReport } from './code-evolution.js';
+import { generateHeatmap, type HeatmapData } from './codebase-heatmap.js';
+import type { ComplexityReport } from './complexity-analyzer.js';
+import type {
+  RepoCodeExplorerInput,
+  RepoExplainDepth,
+  RepoExplanationInput,
+  RepoFileInput,
+} from './repo-explainer.js';
+
+const TREE_IGNORES = [
+  '**/.git/**',
+  '**/.codebuddy/**',
+  '**/.codeexplorer/**',
+  '**/.gitnexus/**',
+  '**/node_modules/**',
+  '**/vendor/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/out/**',
+  '**/target/**',
+  '**/coverage/**',
+  '**/.next/**',
+  '**/.nuxt/**',
+  '**/.cache/**',
+  '**/__pycache__/**',
+  '**/.venv/**',
+  '**/venv/**',
+];
+
+const JS_TS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const EVOLUTION_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.py',
+  '.go',
+  '.rs',
+  '.java',
+  '.cpp',
+  '.c',
+  '.h',
+]);
+const TEST_RE = /(?:^|\/)(?:tests?|__tests__|spec)(?:\/|$)|\.(?:test|spec)\.[^/]+$|_test\.[^/]+$/i;
+
+export interface RepoExplanationCollectorOptions {
+  rootPath: string;
+  depth: RepoExplainDepth;
+  generatedAt: Date;
+}
+
+async function bestEffort<T>(
+  stage: string,
+  fallback: T,
+  notices: string[],
+  operation: () => Promise<T> | T
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    logger.debug(`[repo-explainer] ${stage} unavailable`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    notices.push(`${stage} indisponible; le reste de l’analyse a continué.`);
+    return fallback;
+  }
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+async function collectFileTree(
+  rootPath: string,
+  depth: RepoExplainDepth,
+  notices: string[]
+): Promise<RepoFileInput[]> {
+  const entries = await fg('**/*', {
+    cwd: rootPath,
+    absolute: false,
+    onlyFiles: true,
+    dot: true,
+    followSymbolicLinks: false,
+    objectMode: true,
+    stats: true,
+    suppressErrors: true,
+    deep: depth === 'quick' ? 8 : 20,
+    ignore: TREE_IGNORES,
+  });
+  const limit = depth === 'quick' ? 8_000 : 30_000;
+  const sorted = entries
+    .map((entry) => ({
+      path: normalizePath(entry.path),
+      sizeBytes: entry.stats?.size ?? 0,
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  if (sorted.length > limit) {
+    notices.push(
+      `Arbre borné à ${limit.toLocaleString('fr-FR')} fichiers sur ${sorted.length.toLocaleString('fr-FR')}.`
+    );
+  }
+  return sorted.slice(0, limit);
+}
+
+async function readPrefix(filePath: string, maxBytes: number): Promise<string> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    return buffer.toString('utf8', 0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readReadmeExcerpt(
+  rootPath: string,
+  files: RepoFileInput[]
+): Promise<string | undefined> {
+  const readme = files.find((file) => /^readme(?:\.[^/]*)?$/i.test(file.path));
+  if (!readme) return undefined;
+  const content = await readPrefix(path.join(rootPath, readme.path), 48 * 1024);
+  return content.trim() || undefined;
+}
+
+function isGitRepository(rootPath: string): boolean {
+  try {
+    const topLevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: rootPath,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+    }).trim();
+    return realpathSync(topLevel) === realpathSync(rootPath);
+  } catch {
+    return false;
+  }
+}
+
+function analysisPriority(file: RepoFileInput): number {
+  const normalized = file.path.toLowerCase();
+  let priority = Math.min(file.sizeBytes ?? 0, 2_000_000);
+  if (/(?:^|\/)(?:index|main|app|server|cli)\.(?:ts|tsx|js|jsx)$/.test(normalized)) {
+    priority += 5_000_000;
+  }
+  if (normalized.includes('/agent/') || normalized.includes('/core/')) priority += 1_000_000;
+  return priority;
+}
+
+function selectJsTsFiles(files: RepoFileInput[], maxFiles: number): RepoFileInput[] {
+  return files
+    .filter(
+      (file) =>
+        JS_TS_EXTENSIONS.has(path.extname(file.path).toLowerCase()) &&
+        !TEST_RE.test(file.path) &&
+        (file.sizeBytes ?? 0) <= 2 * 1024 * 1024
+    )
+    .sort(
+      (left, right) =>
+        analysisPriority(right) - analysisPriority(left) || left.path.localeCompare(right.path)
+    )
+    .slice(0, maxFiles);
+}
+
+function exactGlobPatterns(files: RepoFileInput[]): string[] {
+  return files.map((file) => fg.escapePath(file.path));
+}
+
+function mergeKnownLineCounts(files: RepoFileInput[], profile?: RepoProfile): RepoFileInput[] {
+  const counts = new Map(
+    (profile?.cartography?.fileStats.largestFiles ?? []).map((file) => [
+      normalizePath(file.path),
+      file.lines,
+    ])
+  );
+  return files.map((file) => {
+    const lines = counts.get(file.path);
+    return lines === undefined ? file : { ...file, lines };
+  });
+}
+
+function codeExplorerCandidates(profile?: RepoProfile, docs?: GeneratedDocs): string[] {
+  const components = profile?.cartography?.components;
+  const candidates = [
+    ...(components?.facades.map((entry) => entry.name) ?? []),
+    ...(components?.agents.map((entry) => entry.name) ?? []),
+    ...(components?.keyExports.flatMap((entry) => entry.exports) ?? []),
+    ...(docs?.modules.flatMap((module) => module.entries.map((entry) => entry.name)) ?? []),
+  ];
+  return [...new Set(candidates.filter((candidate) => /^[A-Za-z_$][\w$]*$/.test(candidate)))]
+    .filter((candidate) => !/^(?:index|main|default|config|options|result)$/i.test(candidate))
+    .slice(0, 3);
+}
+
+function safeFreshnessGit(args: string, cwd: string): string {
+  const match = /^rev-list --count ([0-9a-fA-F]+)\.\.HEAD$/.exec(args);
+  const commit = match?.[1];
+  if (!commit) throw new Error('Unsafe Code Explorer commit range');
+  return execFileSync('git', ['rev-list', '--count', `${commit}..HEAD`], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 10_000,
+  }).trim();
+}
+
+/**
+ * Ask the indexed engine for one Mermaid diagram. `CodeExplorerManager` on
+ * main has no `generateDiagram()`, so this stays a best-effort CLI call and
+ * returns '' when the binary or target is unavailable.
+ */
+function requestCodeExplorerDiagram(rootPath: string, target: string): string {
+  if (!target.trim()) return '';
+  for (const binary of ['code-explorer', 'gitnexus'] as const) {
+    try {
+      const output = execFileSync(
+        binary,
+        ['diagram', target, '--type', 'flowchart', '--format', 'mermaid', '--path', rootPath],
+        {
+          cwd: rootPath,
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 20_000,
+          maxBuffer: 4 * 1024 * 1024,
+        }
+      ).trim();
+      const diagramStart = output.search(
+        /^(?:flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram)\b/m
+      );
+      return diagramStart >= 0 ? output.slice(diagramStart).trim() : '';
+    } catch {
+      // Binary missing or target unknown — try the next name.
+    }
+  }
+  return '';
+}
+
+function collectCodeExplorer(
+  rootPath: string,
+  profile?: RepoProfile,
+  docs?: GeneratedDocs
+): RepoCodeExplorerInput {
+  const manager = new CodeExplorerManager(rootPath);
+  try {
+    const stats = manager.getStats();
+    if (!stats.indexed) return { indexed: false };
+    // main's getFreshness(runGit) has no `{ autoIndex }` option; auto-index
+    // stays gated on CODEBUDDY_CODE_EXPLORER_AUTOINDEX.
+    const freshness = manager.getFreshness(safeFreshnessGit);
+    let mermaid = '';
+    let target: string | undefined;
+    for (const candidate of codeExplorerCandidates(profile, docs)) {
+      mermaid = requestCodeExplorerDiagram(rootPath, candidate);
+      if (mermaid) {
+        target = candidate;
+        break;
+      }
+    }
+    return {
+      indexed: true,
+      stale: freshness.stale || stats.stale,
+      ...(freshness.commitsBehind !== undefined ? { commitsBehind: freshness.commitsBehind } : {}),
+      symbols: stats.symbols,
+      relations: stats.relations,
+      processes: stats.processes,
+      clusters: stats.clusters,
+      ...(mermaid ? { mermaid } : {}),
+      ...(target ? { target } : {}),
+    };
+  } finally {
+    manager.dispose();
+  }
+}
+
+function emptyComplexity(): ComplexityReport {
+  return {
+    files: [],
+    summary: {
+      totalFiles: 0,
+      totalFunctions: 0,
+      averageComplexity: 0,
+      maxComplexity: 0,
+      totalLinesOfCode: 0,
+      complexFunctions: 0,
+      veryComplexFunctions: 0,
+      overallRating: 'A',
+    },
+    hotspots: [],
+    recommendations: [],
+    generatedAt: new Date(0),
+  };
+}
+
+function emptyHeatmap(): HeatmapData {
+  return {
+    files: [],
+    summary: {
+      totalFiles: 0,
+      totalCommits: 0,
+      totalAdditions: 0,
+      totalDeletions: 0,
+      hotspots: [],
+      coldspots: [],
+      topAuthors: [],
+    },
+    generatedAt: new Date(0),
+  };
+}
+
+function emptyEvolution(): EvolutionReport {
+  const date = new Date(0);
+  return {
+    dataPoints: [],
+    summary: {
+      startDate: date,
+      endDate: date,
+      startLoc: 0,
+      endLoc: 0,
+      locChange: 0,
+      locChangePercent: 0,
+      startFiles: 0,
+      endFiles: 0,
+      fileChange: 0,
+      avgCommitsPerDay: 0,
+    },
+    trends: { locTrend: 'stable', fileTrend: 'stable', velocity: 0 },
+    generatedAt: date,
+  };
+}
+
+function emptyDocs(): GeneratedDocs {
+  return { modules: [], totalEntries: 0, generatedAt: new Date(0) };
+}
+
+/**
+ * Profile without writing `.codebuddy/` caches. main has `getProfile()` only
+ * (`inspect()` lived on the PR #70 branch).
+ */
+async function profileRepository(rootPath: string): Promise<RepoProfile> {
+  const previous = process.env.CODEBUDDY_REPO_PROFILE_READONLY;
+  process.env.CODEBUDDY_REPO_PROFILE_READONLY = 'true';
+  try {
+    return await new RepoProfiler(rootPath).getProfile();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODEBUDDY_REPO_PROFILE_READONLY;
+    } else {
+      process.env.CODEBUDDY_REPO_PROFILE_READONLY = previous;
+    }
+  }
+}
+
+/**
+ * Collect every source independently. Failures are converted to notices, so a
+ * readable artifact can still be produced for an empty directory, a non-Git
+ * project, malformed manifests, or an unavailable Code Explorer binary.
+ */
+export async function collectRepoExplanationInput(
+  options: RepoExplanationCollectorOptions
+): Promise<RepoExplanationInput> {
+  const rootPath = path.resolve(options.rootPath);
+  const notices: string[] = [];
+  let files = await bestEffort('Arbre de fichiers', [], notices, () =>
+    collectFileTree(rootPath, options.depth, notices)
+  );
+  const profile = await bestEffort<RepoProfile | undefined>(
+    'Profil du dépôt',
+    undefined,
+    notices,
+    () => profileRepository(rootPath)
+  );
+  files = mergeKnownLineCounts(files, profile);
+  const readmeExcerpt = await bestEffort<string | undefined>(
+    'Lecture du README',
+    undefined,
+    notices,
+    () => readReadmeExcerpt(rootPath, files)
+  );
+
+  const jsTsFiles = selectJsTsFiles(files, options.depth === 'quick' ? 260 : 1_500);
+  const complexity =
+    jsTsFiles.length === 0
+      ? emptyComplexity()
+      : await bestEffort('Analyse de complexité', emptyComplexity(), notices, async () => {
+          // Named `glob` import in complexity-analyzer.ts is not ESM-loadable
+          // via tsx; missing/unloadable collector → explicit degradation.
+          const { analyzeComplexity } = await import('./complexity-analyzer.js');
+          return analyzeComplexity({
+            rootPath,
+            include: exactGlobPatterns(jsTsFiles),
+            exclude: [],
+            complexityThreshold: 10,
+            maxHotspots: options.depth === 'quick' ? 20 : 50,
+          });
+        });
+
+  const documentedFiles = jsTsFiles.slice(0, options.depth === 'quick' ? 100 : 700);
+  const documentation =
+    documentedFiles.length === 0
+      ? emptyDocs()
+      : await bestEffort('Inventaire documentaire du code', emptyDocs(), notices, () =>
+          generateDocs({
+            rootDir: rootPath,
+            include: exactGlobPatterns(documentedFiles),
+            exclude: [],
+            exportedOnly: true,
+            includePrivate: false,
+          })
+        );
+
+  const gitAvailable = isGitRepository(rootPath);
+  const heatmap = gitAvailable
+    ? await bestEffort('Heatmap Git', emptyHeatmap(), notices, () =>
+        generateHeatmap({
+          repoPath: rootPath,
+          days: options.depth === 'quick' ? 90 : 365,
+          maxFiles: options.depth === 'quick' ? 100 : 300,
+        })
+      )
+    : emptyHeatmap();
+
+  const sourceExtensions = [
+    ...new Set(
+      files
+        .map((file) => path.extname(file.path).toLowerCase())
+        .filter((extension) => EVOLUTION_EXTENSIONS.has(extension))
+    ),
+  ];
+  const sourceFileCount = Math.max(
+    files.filter((file) => EVOLUTION_EXTENSIONS.has(path.extname(file.path).toLowerCase())).length,
+    profile?.cartography?.fileStats.totalSourceFiles ?? 0
+  );
+  const evolutionLimit = options.depth === 'quick' ? 120 : 350;
+  let evolution = emptyEvolution();
+  if (gitAvailable && sourceExtensions.length > 0 && sourceFileCount <= evolutionLimit) {
+    evolution = await bestEffort('Évolution du code', emptyEvolution(), notices, () =>
+      generateEvolutionReport({
+        repoPath: rootPath,
+        dataPoints: options.depth === 'quick' ? 3 : 6,
+        days: options.depth === 'quick' ? 90 : 365,
+        extensions: sourceExtensions,
+      })
+    );
+  } else if (gitAvailable && sourceFileCount > evolutionLimit) {
+    notices.push(
+      `Évolution historique détaillée ignorée au-delà de ${evolutionLimit} fichiers source; la heatmap Git reste active.`
+    );
+  }
+
+  const codeExplorer = await bestEffort<RepoCodeExplorerInput>(
+    'Code Explorer',
+    { indexed: false },
+    notices,
+    () => collectCodeExplorer(rootPath, profile, documentation)
+  );
+
+  return {
+    rootPath,
+    rootName: path.basename(rootPath) || 'repo',
+    depth: options.depth,
+    generatedAt: options.generatedAt.toISOString(),
+    files,
+    profile: {
+      name: profile?.name,
+      description: profile?.description,
+      readmeExcerpt,
+      languages: profile?.languages,
+      framework: profile?.framework,
+      packageManager: profile?.packageManager,
+      testFramework: profile?.testFramework,
+      entryPoints: profile?.entryPoints,
+      commands: profile?.commands,
+      topDependencies: profile?.topDependencies,
+    },
+    cartography: profile?.cartography,
+    complexity,
+    heatmap,
+    evolution,
+    documentation,
+    codeExplorer,
+    git: { available: gitAvailable },
+    notices,
+  };
+}

--- a/src/analytics/repo-explainer.ts
+++ b/src/analytics/repo-explainer.ts
@@ -1,0 +1,915 @@
+/**
+ * Repository explainer
+ *
+ * Pure synthesis layer for `buddy explain`. Heavy and fallible collection is
+ * deliberately kept outside this module: callers inject a file tree, profile,
+ * analytics reports, documentation inventory, and an optional Code Explorer
+ * graph. Given the same input this module always returns the same explanation.
+ */
+
+import path from 'node:path';
+
+export type RepoExplainDepth = 'quick' | 'deep';
+
+export interface RepoFileInput {
+  path: string;
+  sizeBytes?: number;
+  lines?: number;
+}
+
+export interface RepoProfileInput {
+  name?: string;
+  description?: string;
+  readmeExcerpt?: string;
+  languages?: string[];
+  framework?: string;
+  frameworks?: string[];
+  packageManager?: string;
+  testFramework?: string;
+  entryPoints?: string[];
+  commands?: Record<string, string | undefined>;
+  topDependencies?: string[];
+}
+
+export interface RepoArchitectureLayerInput {
+  name: string;
+  directory: string;
+  fileCount: number;
+}
+
+export interface RepoCartographyInput {
+  architecture?: {
+    style?: string;
+    layers?: RepoArchitectureLayerInput[];
+    maxDepth?: number;
+  };
+  fileStats?: {
+    largestFiles?: Array<{ path: string; lines: number }>;
+    totalSourceFiles?: number;
+    totalTestFiles?: number;
+  };
+  importGraph?: {
+    hotModules?: Array<{ module: string; importedBy: number }>;
+    circularRisks?: Array<{ a: string; b: string }>;
+  };
+  importEdges?: Array<[string, string]>;
+}
+
+export interface RepoComplexityFileInput {
+  filePath: string;
+  maxComplexity: number;
+  averageComplexity?: number;
+  totalLinesOfCode: number;
+  maintainabilityIndex?: number;
+}
+
+export interface RepoComplexityHotspotInput {
+  filePath: string;
+  name?: string;
+  cyclomaticComplexity: number;
+  cognitiveComplexity?: number;
+  linesOfCode?: number;
+}
+
+export interface RepoComplexityInput {
+  files: RepoComplexityFileInput[];
+  hotspots?: RepoComplexityHotspotInput[];
+  summary?: {
+    totalFiles?: number;
+    totalFunctions?: number;
+    averageComplexity?: number;
+    maxComplexity?: number;
+    overallRating?: string;
+  };
+}
+
+export interface RepoHeatFileInput {
+  filePath: string;
+  commits: number;
+  additions: number;
+  deletions: number;
+  churnScore: number;
+  heatLevel?: string;
+}
+
+export interface RepoHeatmapInput {
+  files: RepoHeatFileInput[];
+}
+
+export interface RepoEvolutionInput {
+  dataPoints?: unknown[];
+  summary?: {
+    locChange?: number;
+    locChangePercent?: number;
+    fileChange?: number;
+  };
+  trends?: {
+    locTrend?: 'growing' | 'shrinking' | 'stable';
+    fileTrend?: 'growing' | 'shrinking' | 'stable';
+    velocity?: number;
+  };
+}
+
+export interface RepoDocumentationInput {
+  modules: Array<{
+    path: string;
+    description?: string;
+    entries: Array<{ name: string; kind: string; description?: string }>;
+  }>;
+  totalEntries?: number;
+}
+
+export interface RepoCodeExplorerInput {
+  indexed: boolean;
+  stale?: boolean;
+  commitsBehind?: number;
+  symbols?: number;
+  relations?: number;
+  processes?: number;
+  clusters?: number;
+  mermaid?: string;
+  target?: string;
+}
+
+export interface RepoExplanationInput {
+  rootPath?: string;
+  rootName: string;
+  depth: RepoExplainDepth;
+  generatedAt: string;
+  files: RepoFileInput[];
+  profile?: RepoProfileInput;
+  cartography?: RepoCartographyInput;
+  complexity?: RepoComplexityInput;
+  heatmap?: RepoHeatmapInput;
+  evolution?: RepoEvolutionInput;
+  documentation?: RepoDocumentationInput;
+  codeExplorer?: RepoCodeExplorerInput;
+  git?: { available: boolean };
+  notices?: string[];
+}
+
+export interface RepoLanguageSummary {
+  name: string;
+  files: number;
+  percent: number;
+}
+
+export interface RepoEntryPoint {
+  path: string;
+  reason: string;
+  exportedSymbols: string[];
+}
+
+export interface RepoModuleSummary {
+  name: string;
+  directory: string;
+  fileCount: number;
+  purpose: string;
+}
+
+export interface RepoDependencyDiagram {
+  mermaid: string;
+  source: 'code-explorer' | 'file-analysis';
+  note: string;
+}
+
+export type RepoRiskLevel = 'critical' | 'high' | 'medium' | 'low';
+
+export interface RepoHotspot {
+  path: string;
+  score: number;
+  level: RepoRiskLevel;
+  maxComplexity?: number;
+  lines?: number;
+  sizeBytes?: number;
+  churn?: number;
+  commits?: number;
+  reasons: string[];
+}
+
+export interface RepoExplanation {
+  repo: {
+    name: string;
+    purpose: string;
+    depth: RepoExplainDepth;
+    generatedAt: string;
+    totalFiles: number;
+    sourceFiles: number;
+    testFiles: number;
+  };
+  overview: {
+    languages: RepoLanguageSummary[];
+    frameworks: string[];
+    packageManager?: string;
+    testFramework?: string;
+    dependencies: string[];
+    entryPoints: RepoEntryPoint[];
+  };
+  architecture: {
+    style: string;
+    modules: RepoModuleSummary[];
+    diagram: RepoDependencyDiagram;
+    centralModules: Array<{ path: string; importedBy: number }>;
+  };
+  risks: {
+    hotspots: RepoHotspot[];
+    complexity?: RepoComplexityInput['summary'];
+    evolution?: RepoEvolutionInput;
+    gitAvailable: boolean;
+  };
+  gettingStarted: {
+    path: string[];
+    docs: string[];
+    tests: string[];
+    commands: Record<string, string>;
+  };
+  limitations: string[];
+}
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  '.c': 'C',
+  '.cc': 'C++',
+  '.cpp': 'C++',
+  '.cs': 'C#',
+  '.css': 'CSS',
+  '.dart': 'Dart',
+  '.ex': 'Elixir',
+  '.exs': 'Elixir',
+  '.go': 'Go',
+  '.h': 'C/C++',
+  '.hpp': 'C++',
+  '.java': 'Java',
+  '.js': 'JavaScript',
+  '.jsx': 'JavaScript',
+  '.kt': 'Kotlin',
+  '.kts': 'Kotlin',
+  '.php': 'PHP',
+  '.py': 'Python',
+  '.rb': 'Ruby',
+  '.rs': 'Rust',
+  '.scala': 'Scala',
+  '.sh': 'Shell',
+  '.sol': 'Solidity',
+  '.svelte': 'Svelte',
+  '.swift': 'Swift',
+  '.ts': 'TypeScript',
+  '.tsx': 'TypeScript',
+  '.vue': 'Vue',
+};
+
+const SOURCE_EXTENSIONS = new Set(Object.keys(LANGUAGE_BY_EXTENSION));
+const TEST_PATH_RE =
+  /(?:^|\/)(?:tests?|__tests__|spec)(?:\/|$)|\.(?:test|spec)\.[^/]+$|_test\.[^/]+$/i;
+const DOC_PATH_RE =
+  /(?:^|\/)(?:readme|contributing|architecture|getting-started|quickstart|claude|agents|codebuddy)(?:\.[^/]*)?$|^(?:docs?|documentation)\//i;
+const ORIENTATION_NOISE_RE =
+  /(?:^|\/)(?:__fixtures__|__mocks__|__snapshots__|demos?|examples?|fixtures?|mocks?|scratch|test-data)(?:\/|$)/i;
+const READABLE_DOC_EXTENSIONS = new Set(['.adoc', '.md', '.mdx', '.rst', '.text', '.txt']);
+
+const MODULE_PURPOSES: Record<string, string> = {
+  agent: 'Boucle agent et orchestration',
+  agents: 'Agents spécialisés',
+  analytics: 'Mesures et analyse du code',
+  api: 'API et contrats réseau',
+  app: 'Application principale',
+  cli: 'Interface en ligne de commande',
+  commands: 'Commandes et parcours utilisateur',
+  components: 'Composants d’interface',
+  config: 'Configuration et capacités',
+  context: 'Contexte et compression',
+  controllers: 'Contrôleurs applicatifs',
+  database: 'Persistance et accès aux données',
+  db: 'Persistance et accès aux données',
+  docs: 'Documentation',
+  export: 'Production d’artefacts',
+  fleet: 'Coordination multi-agent',
+  integrations: 'Intégrations externes',
+  knowledge: 'Graphe et connaissance du code',
+  memory: 'Mémoire persistante',
+  middleware: 'Pipeline de middlewares',
+  models: 'Modèles de données',
+  plugins: 'Extensions et plugins',
+  providers: 'Adaptateurs de fournisseurs',
+  routes: 'Routes et endpoints',
+  security: 'Sécurité et permissions',
+  server: 'Serveur et transports',
+  services: 'Services métier',
+  tests: 'Tests automatisés',
+  tools: 'Outils exécutables',
+  ui: 'Interface utilisateur',
+  utils: 'Utilitaires partagés',
+  workflows: 'Workflows et orchestration',
+};
+
+function normalizeSlashes(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function normalizeRepoPath(filePath: string, rootPath?: string): string {
+  if (!filePath) return filePath;
+  if (rootPath && path.isAbsolute(filePath)) {
+    const relative = path.relative(rootPath, filePath);
+    if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+      return normalizeSlashes(relative);
+    }
+  }
+  return normalizeSlashes(filePath);
+}
+
+function isSourceFile(filePath: string): boolean {
+  return SOURCE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function isTestFile(filePath: string): boolean {
+  return TEST_PATH_RE.test(normalizeSlashes(filePath));
+}
+
+function unique<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.min(max, Math.max(min, Number.isFinite(value) ? value : 0));
+}
+
+function cleanPurposeText(value: string): string {
+  const paragraphs = value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .split(/\n\s*\n/)
+    .map((paragraph) =>
+      paragraph
+        .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+        .replace(/^\s*(?:[-*+]|\d+\.)\s+/gm, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+    )
+    .filter((paragraph) => paragraph.length >= 24 && !/^build|^status|^license$/i.test(paragraph));
+  const purpose = paragraphs[0] ?? value.replace(/\s+/g, ' ').trim();
+  return purpose.length > 420 ? `${purpose.slice(0, 417).trimEnd()}…` : purpose;
+}
+
+function inferPurpose(input: RepoExplanationInput, languages: RepoLanguageSummary[]): string {
+  const explicit = input.profile?.description?.trim() || input.profile?.readmeExcerpt?.trim();
+  if (explicit) return cleanPurposeText(explicit);
+
+  const languageText = languages
+    .slice(0, 3)
+    .map((language) => language.name)
+    .join(', ');
+  if (input.files.length === 0) {
+    return 'Dépôt minimal ou vide : aucun fichier exploitable n’a été détecté, mais les points de départ disponibles sont listés ci-dessous.';
+  }
+  if (languageText) {
+    return `Projet principalement écrit en ${languageText}. Aucun résumé produit explicite n’a été trouvé dans les métadonnées ou la documentation racine.`;
+  }
+  return 'Dépôt de projet sans langage principal détecté. Consultez les fichiers de documentation et de configuration listés ci-dessous pour préciser son rôle.';
+}
+
+function summarizeLanguages(input: RepoExplanationInput): RepoLanguageSummary[] {
+  const counts = new Map<string, number>();
+  for (const file of input.files) {
+    const language = LANGUAGE_BY_EXTENSION[path.extname(file.path).toLowerCase()];
+    if (language) counts.set(language, (counts.get(language) ?? 0) + 1);
+  }
+
+  for (const language of input.profile?.languages ?? []) {
+    const normalized = language.replace(/ \(React\)$/i, '').trim();
+    if (normalized && !counts.has(normalized)) counts.set(normalized, 0);
+  }
+
+  const measuredTotal = [...counts.values()].reduce((sum, count) => sum + count, 0);
+  return [...counts.entries()]
+    .map(([name, files]) => ({
+      name,
+      files,
+      percent: measuredTotal > 0 ? Math.round((files / measuredTotal) * 100) : 0,
+    }))
+    .sort((left, right) => right.files - left.files || left.name.localeCompare(right.name));
+}
+
+function inferFrameworks(profile?: RepoProfileInput): string[] {
+  const frameworks = [profile?.framework, ...(profile?.frameworks ?? [])].filter(
+    (value): value is string => Boolean(value?.trim())
+  );
+  const dependencies = new Set(profile?.topDependencies ?? []);
+  const inferred: Array<[string, string[]]> = [
+    ['Next.js', ['next']],
+    ['Nuxt', ['nuxt']],
+    ['Angular', ['@angular/core']],
+    ['Svelte', ['svelte', '@sveltejs/kit']],
+    ['Vue', ['vue']],
+    ['Ink', ['ink']],
+    ['React', ['react', 'react-dom']],
+    ['Fastify', ['fastify']],
+    ['Express', ['express']],
+    ['Electron', ['electron']],
+    ['Tauri', ['@tauri-apps/api']],
+  ];
+  for (const [name, packages] of inferred) {
+    if (packages.some((packageName) => dependencies.has(packageName))) frameworks.push(name);
+  }
+  const seen = new Set<string>();
+  return frameworks
+    .map((value) => value.trim())
+    .filter((value) => {
+      const key = value.replace(/\s*\([^)]*\)\s*$/, '').toLocaleLowerCase('en-US');
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+function entryPointScore(filePath: string): number {
+  const normalized = normalizeSlashes(filePath).toLowerCase();
+  if (isTestFile(normalized) || ORIENTATION_NOISE_RE.test(normalized)) return -1;
+  const depthPenalty = Math.max(0, normalized.split('/').length - 2) * 3;
+  if (/^(?:src|lib|app)\/(?:index|main)\.[^/]+$/.test(normalized)) return 120;
+  if (/^(?:index|main|app|server|cli)\.[^/]+$/.test(normalized)) return 110;
+  if (/^cmd\/[^/]+\/main\.go$/.test(normalized)) return 108;
+  if (/^(?:src\/)?main\.rs$/.test(normalized)) return 108;
+  if (/(?:^|\/)program\.cs$/.test(normalized)) return 106;
+  if (/(?:^|\/)(?:manage|wsgi|asgi|__main__)\.py$/.test(normalized)) return 104;
+  if (/(?:^|\/)(?:index|main|app|server|cli)\.(?:ts|tsx|js|jsx|py|go|rs|java|cs)$/.test(normalized))
+    return Math.max(1, 90 - depthPenalty);
+  if (/(?:^|\/)bin\/[^/]+$/.test(normalized)) return Math.max(1, 80 - depthPenalty);
+  return 0;
+}
+
+function sourceEquivalent(entryPoint: string, files: Set<string>): string | undefined {
+  const normalized = normalizeSlashes(entryPoint);
+  if (files.has(normalized)) return normalized;
+  const withoutDist = normalized.replace(/^(?:dist|build|out)\//, 'src/');
+  const stem = withoutDist.replace(/\.(?:mjs|cjs|js)$/, '');
+  for (const extension of ['.ts', '.tsx', '.js', '.jsx']) {
+    if (files.has(`${stem}${extension}`)) return `${stem}${extension}`;
+  }
+  return undefined;
+}
+
+function findEntryPoints(input: RepoExplanationInput): RepoEntryPoint[] {
+  const normalizedFiles = new Set(input.files.map((file) => normalizeSlashes(file.path)));
+  const candidates = new Map<string, { score: number; reason: string }>();
+
+  for (const declared of input.profile?.entryPoints ?? []) {
+    const resolved = sourceEquivalent(declared, normalizedFiles) ?? normalizeSlashes(declared);
+    candidates.set(resolved, { score: 150, reason: 'déclaré par le manifeste du projet' });
+  }
+
+  for (const file of normalizedFiles) {
+    const score = entryPointScore(file);
+    if (score <= 0) continue;
+    const current = candidates.get(file);
+    if (!current || score > current.score) {
+      candidates.set(file, { score, reason: 'nom et emplacement conventionnels d’entrée' });
+    }
+  }
+
+  const docsByPath = new Map(
+    (input.documentation?.modules ?? []).map((module) => [normalizeSlashes(module.path), module])
+  );
+  return [...candidates.entries()]
+    .sort((left, right) => right[1].score - left[1].score || left[0].localeCompare(right[0]))
+    .slice(0, input.depth === 'deep' ? 8 : 6)
+    .map(([entryPath, value]) => ({
+      path: entryPath,
+      reason: value.reason,
+      exportedSymbols: (docsByPath.get(entryPath)?.entries ?? [])
+        .slice(0, 6)
+        .map((entry) => entry.name),
+    }));
+}
+
+function moduleDirectory(filePath: string): string {
+  const segments = normalizeSlashes(filePath).split('/').filter(Boolean);
+  if (segments.length <= 1) return '.';
+  if (segments[0] === 'packages' || segments[0] === 'apps' || segments[0] === 'crates') {
+    return segments.slice(0, 2).join('/');
+  }
+  if (
+    ['src', 'lib', 'app', 'server', 'client'].includes(segments[0] ?? '') &&
+    segments.length >= 3
+  ) {
+    return segments.slice(0, 2).join('/');
+  }
+  return segments[0] ?? '.';
+}
+
+function modulePurpose(directory: string, explicitName?: string): string {
+  const key = directory.split('/').pop()?.toLowerCase() ?? directory;
+  return (
+    MODULE_PURPOSES[key] ??
+    (explicitName && explicitName !== key ? explicitName : 'Module fonctionnel du projet')
+  );
+}
+
+function summarizeModules(input: RepoExplanationInput): RepoModuleSummary[] {
+  const layers = input.cartography?.architecture?.layers ?? [];
+  if (layers.length > 0) {
+    return layers
+      .map((layer) => ({
+        name: layer.name,
+        directory: normalizeSlashes(layer.directory),
+        fileCount: layer.fileCount,
+        purpose: modulePurpose(layer.directory, layer.name),
+      }))
+      .sort(
+        (left, right) =>
+          right.fileCount - left.fileCount || left.directory.localeCompare(right.directory)
+      )
+      .slice(0, input.depth === 'deep' ? 14 : 9);
+  }
+
+  const counts = new Map<string, number>();
+  for (const file of input.files) {
+    if (!isSourceFile(file.path) || isTestFile(file.path)) continue;
+    const directory = moduleDirectory(file.path);
+    counts.set(directory, (counts.get(directory) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([directory, fileCount]) => ({
+      name: directory === '.' ? input.rootName : (directory.split('/').pop() ?? directory),
+      directory,
+      fileCount,
+      purpose: modulePurpose(directory),
+    }))
+    .sort(
+      (left, right) =>
+        right.fileCount - left.fileCount || left.directory.localeCompare(right.directory)
+    )
+    .slice(0, input.depth === 'deep' ? 14 : 9);
+}
+
+function unwrapMermaid(value: string | undefined): string | undefined {
+  if (!value?.trim()) return undefined;
+  const fenced = /```(?:mermaid)?\s*([\s\S]*?)```/i.exec(value);
+  const candidate = (fenced?.[1] ?? value).trim();
+  // Code Explorer data comes from the inspected repository. Refuse Mermaid
+  // directives that could make the local renderer load a URL or loosen its
+  // security level; the structural diagram remains available as a fallback.
+  if (
+    /(?:https?|file|data|javascript):|%%\{|\burl\s*\(|<\s*[!/A-Za-z]|^\s*click\b/im.test(candidate)
+  ) {
+    return undefined;
+  }
+  return /^(?:flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram)\b/m.test(
+    candidate
+  )
+    ? candidate
+    : undefined;
+}
+
+function buildDependencyDiagram(
+  input: RepoExplanationInput,
+  modules: RepoModuleSummary[]
+): RepoDependencyDiagram {
+  const codeExplorerMermaid = unwrapMermaid(input.codeExplorer?.mermaid);
+  if (codeExplorerMermaid) {
+    const target = input.codeExplorer?.target ? ` autour de ${input.codeExplorer.target}` : '';
+    return {
+      mermaid: codeExplorerMermaid,
+      source: 'code-explorer',
+      note: `Graphe Code Explorer${target}${input.codeExplorer?.stale ? ' (index potentiellement en retard)' : ''}.`,
+    };
+  }
+
+  const edgeCounts = new Map<string, number>();
+  const moduleSet = new Set(modules.map((module) => module.directory));
+  for (const [rawFrom, rawTo] of input.cartography?.importEdges ?? []) {
+    const from = moduleDirectory(rawFrom);
+    const to = moduleDirectory(rawTo);
+    if (from === to) continue;
+    moduleSet.add(from);
+    moduleSet.add(to);
+    const key = `${from}\u0000${to}`;
+    edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
+  }
+
+  const selectedModules = [...moduleSet]
+    .map((directory) => ({
+      directory,
+      weight:
+        (modules.find((module) => module.directory === directory)?.fileCount ?? 0) +
+        [...edgeCounts.entries()].reduce(
+          (sum, [edge, count]) => sum + (edge.split('\u0000').includes(directory) ? count : 0),
+          0
+        ),
+    }))
+    .sort(
+      (left, right) => right.weight - left.weight || left.directory.localeCompare(right.directory)
+    )
+    .slice(0, input.depth === 'deep' ? 14 : 10);
+  const selected = new Set(selectedModules.map((module) => module.directory));
+  const ids = new Map(selectedModules.map((module, index) => [module.directory, `M${index}`]));
+  const label = (value: string): string =>
+    value
+      .replace(/[\r\n<>`]/g, ' ')
+      .replaceAll('"', "'")
+      .replaceAll('[', "'")
+      .replaceAll(']', "'")
+      .trim();
+  const lines = ['flowchart LR'];
+  for (const module of selectedModules) {
+    lines.push(`  ${ids.get(module.directory)}["${label(module.directory)}"]`);
+  }
+
+  const selectedEdges = [...edgeCounts.entries()]
+    .map(([key, count]) => {
+      const [from = '', to = ''] = key.split('\u0000');
+      return { from, to, count };
+    })
+    .filter((edge) => selected.has(edge.from) && selected.has(edge.to))
+    .sort((left, right) => right.count - left.count || left.from.localeCompare(right.from))
+    .slice(0, input.depth === 'deep' ? 24 : 14);
+  for (const edge of selectedEdges) {
+    lines.push(`  ${ids.get(edge.from)} -->|${edge.count}| ${ids.get(edge.to)}`);
+  }
+
+  if (selectedModules.length === 0) {
+    lines.push(`  ROOT["${label(input.rootName)}"]`);
+  } else if (selectedEdges.length === 0) {
+    lines.push(`  ROOT["${label(input.rootName)}"]`);
+    for (const module of selectedModules) lines.push(`  ROOT --> ${ids.get(module.directory)}`);
+  }
+
+  return {
+    mermaid: lines.join('\n'),
+    source: 'file-analysis',
+    note:
+      selectedEdges.length > 0
+        ? 'Dépendances agrégées à partir des imports détectés dans les fichiers.'
+        : 'Repli structurel : aucun graphe d’import exploitable, les modules clés sont reliés au dépôt.',
+  };
+}
+
+interface MutableHotspot {
+  path: string;
+  maxComplexity?: number;
+  lines?: number;
+  sizeBytes?: number;
+  churn?: number;
+  commits?: number;
+  circular?: boolean;
+}
+
+function buildHotspots(input: RepoExplanationInput): RepoHotspot[] {
+  const candidates = new Map<string, MutableHotspot>();
+  const get = (filePath: string): MutableHotspot => {
+    const normalized = normalizeRepoPath(filePath, input.rootPath);
+    let candidate = candidates.get(normalized);
+    if (!candidate) {
+      candidate = { path: normalized };
+      candidates.set(normalized, candidate);
+    }
+    return candidate;
+  };
+
+  for (const file of input.files) {
+    if (!isSourceFile(file.path) || isTestFile(file.path)) continue;
+    const candidate = get(file.path);
+    candidate.sizeBytes = file.sizeBytes;
+    candidate.lines = file.lines;
+  }
+  for (const file of input.cartography?.fileStats?.largestFiles ?? []) {
+    get(file.path).lines = file.lines;
+  }
+  for (const file of input.complexity?.files ?? []) {
+    const candidate = get(file.filePath);
+    candidate.maxComplexity = Math.max(candidate.maxComplexity ?? 0, file.maxComplexity);
+    candidate.lines = Math.max(candidate.lines ?? 0, file.totalLinesOfCode);
+  }
+  for (const hotspot of input.complexity?.hotspots ?? []) {
+    const candidate = get(hotspot.filePath);
+    candidate.maxComplexity = Math.max(candidate.maxComplexity ?? 0, hotspot.cyclomaticComplexity);
+  }
+  for (const file of input.heatmap?.files ?? []) {
+    if (!isSourceFile(file.filePath) || isTestFile(file.filePath)) continue;
+    const candidate = get(file.filePath);
+    candidate.churn = file.churnScore;
+    candidate.commits = file.commits;
+  }
+
+  for (const risk of input.cartography?.importGraph?.circularRisks ?? []) {
+    const normalizedA = normalizeSlashes(risk.a);
+    const normalizedB = normalizeSlashes(risk.b);
+    for (const candidate of candidates.values()) {
+      const stem = candidate.path.replace(/\.[^.]+$/, '');
+      if (
+        stem === normalizedA ||
+        stem === normalizedB ||
+        normalizedA.endsWith(stem) ||
+        normalizedB.endsWith(stem)
+      ) {
+        candidate.circular = true;
+      }
+    }
+  }
+
+  const values = [...candidates.values()];
+  const maxChurn = Math.max(...values.map((item) => item.churn ?? 0), 1);
+  const maxCommits = Math.max(...values.map((item) => item.commits ?? 0), 1);
+
+  return values
+    .map((item): RepoHotspot => {
+      const complexityRisk = clamp((item.maxComplexity ?? 0) / 25);
+      const locRisk = Math.max(
+        clamp((item.lines ?? 0) / 1_500),
+        clamp((item.sizeBytes ?? 0) / 250_000)
+      );
+      const churnRisk = clamp((item.churn ?? 0) / maxChurn) * clamp((item.churn ?? 0) / 500);
+      const commitRisk = clamp((item.commits ?? 0) / maxCommits) * clamp((item.commits ?? 0) / 20);
+      const circularRisk = item.circular ? 0.15 : 0;
+      const score = Math.round(
+        clamp(
+          complexityRisk * 0.4 + locRisk * 0.22 + churnRisk * 0.28 + commitRisk * 0.1 + circularRisk
+        ) * 100
+      );
+      const reasons: string[] = [];
+      if ((item.maxComplexity ?? 0) > 10)
+        reasons.push(`complexité cyclomatique max ${item.maxComplexity}`);
+      if ((item.lines ?? 0) >= 300) reasons.push(`${item.lines?.toLocaleString('fr-FR')} lignes`);
+      else if ((item.sizeBytes ?? 0) >= 50_000)
+        reasons.push(`${Math.round((item.sizeBytes ?? 0) / 1_024)} Kio`);
+      if ((item.churn ?? 0) > 0) {
+        reasons.push(
+          `churn ${item.churn?.toLocaleString('fr-FR')} lignes sur ${item.commits ?? 0} commit(s)`
+        );
+      }
+      if (item.circular) reasons.push('cycle d’import potentiel');
+      const level: RepoRiskLevel =
+        score >= 70 ? 'critical' : score >= 48 ? 'high' : score >= 25 ? 'medium' : 'low';
+      return {
+        path: item.path,
+        score,
+        level,
+        ...(item.maxComplexity !== undefined ? { maxComplexity: item.maxComplexity } : {}),
+        ...(item.lines !== undefined ? { lines: item.lines } : {}),
+        ...(item.sizeBytes !== undefined ? { sizeBytes: item.sizeBytes } : {}),
+        ...(item.churn !== undefined ? { churn: item.churn } : {}),
+        ...(item.commits !== undefined ? { commits: item.commits } : {}),
+        reasons,
+      };
+    })
+    .filter((hotspot) => hotspot.score >= 15 || hotspot.reasons.length > 0)
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    .slice(0, input.depth === 'deep' ? 15 : 8);
+}
+
+function docsScore(filePath: string): number {
+  const normalized = normalizeSlashes(filePath).toLowerCase();
+  if (/^readme(?:\.|$)/.test(normalized)) return 100;
+  if (/^(?:getting-started|quickstart|architecture|contributing)(?:\.|$)/.test(normalized))
+    return 95;
+  if (/^docs?\/(?:getting-started|quickstart|architecture|index|readme)/.test(normalized))
+    return 90;
+  if (/^(?:claude|agents|codebuddy)\.md$/.test(normalized)) return 80;
+  return normalized.startsWith('docs/') ? 60 : 40;
+}
+
+function isReadableDoc(filePath: string): boolean {
+  const extension = path.extname(filePath).toLowerCase();
+  return (
+    READABLE_DOC_EXTENSIONS.has(extension) ||
+    (extension === '' &&
+      /^(?:agents|architecture|claude|codebuddy|contributing|readme)$/i.test(
+        path.basename(filePath)
+      ))
+  );
+}
+
+function testScore(filePath: string): number {
+  const normalized = normalizeSlashes(filePath).toLowerCase();
+  if (ORIENTATION_NOISE_RE.test(normalized)) return 0;
+  const depthPenalty = Math.max(0, normalized.split('/').length - 2);
+  if (/^tests?\//.test(normalized)) return 100 - depthPenalty;
+  if (/(?:^|\/)unit(?:\/|$)/.test(normalized)) return 85 - depthPenalty;
+  if (/(?:^|\/)e2e(?:\/|$)/.test(normalized)) return 45 - depthPenalty;
+  return 65 - depthPenalty;
+}
+
+function buildGettingStarted(
+  input: RepoExplanationInput,
+  entryPoints: RepoEntryPoint[],
+  modules: RepoModuleSummary[]
+): RepoExplanation['gettingStarted'] {
+  const docs = input.files
+    .map((file) => normalizeSlashes(file.path))
+    .filter((filePath) => DOC_PATH_RE.test(filePath) && isReadableDoc(filePath))
+    .sort((left, right) => docsScore(right) - docsScore(left) || left.localeCompare(right))
+    .slice(0, input.depth === 'deep' ? 12 : 7);
+  const tests = input.files
+    .map((file) => normalizeSlashes(file.path))
+    .filter((filePath) => isTestFile(filePath) && testScore(filePath) > 0)
+    .sort((left, right) => testScore(right) - testScore(left) || left.localeCompare(right))
+    .slice(0, input.depth === 'deep' ? 12 : 7);
+  const commands = Object.fromEntries(
+    Object.entries(input.profile?.commands ?? {}).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === 'string' && entry[1].trim().length > 0
+    )
+  );
+  const onboardingPath = unique(
+    [
+      docs[0],
+      ...entryPoints.slice(0, input.depth === 'deep' ? 3 : 1).map((entry) => entry.path),
+      ...modules.slice(0, 3).map((module) => module.directory),
+      tests[0],
+    ].filter((value): value is string => Boolean(value))
+  );
+  return { path: onboardingPath, docs, tests, commands };
+}
+
+function buildLimitations(input: RepoExplanationInput): string[] {
+  const limitations = [...(input.notices ?? [])];
+  if (input.git?.available === false) {
+    limitations.push('Historique Git indisponible : le churn et l’évolution ne sont pas classés.');
+  } else if ((input.heatmap?.files.length ?? 0) === 0) {
+    limitations.push('Aucun churn récent exploitable dans la fenêtre analysée.');
+  }
+  if (!input.complexity || input.complexity.files.length === 0) {
+    limitations.push(
+      'Aucune métrique de complexité exploitable; les risques reposent sur la taille et la structure.'
+    );
+  }
+  if (!input.codeExplorer?.indexed) {
+    limitations.push(
+      'Code Explorer non indexé : diagramme construit depuis les imports/fichiers disponibles.'
+    );
+  } else if (!unwrapMermaid(input.codeExplorer.mermaid)) {
+    limitations.push(
+      input.codeExplorer.mermaid
+        ? 'Diagramme Code Explorer non exploitable ou non sûr pour un rendu local; repli sur les imports.'
+        : 'Index Code Explorer détecté, mais aucun diagramme ciblé n’a pu être extrait; repli sur les imports.'
+    );
+  }
+  if (input.codeExplorer?.stale) {
+    const lag = input.codeExplorer.commitsBehind;
+    limitations.push(
+      `Index Code Explorer en retard${lag !== undefined ? ` de ${lag} commit(s)` : ''}.`
+    );
+  }
+  if (input.files.length === 0) {
+    limitations.push(
+      'Arbre de fichiers vide ou illisible : le résultat est une orientation minimale.'
+    );
+  }
+  return unique(limitations.map((item) => item.trim()).filter(Boolean));
+}
+
+/** Build a complete, render-agnostic repository explanation. */
+export function explainRepository(input: RepoExplanationInput): RepoExplanation {
+  const files = input.files.map((file) => ({
+    ...file,
+    path: normalizeRepoPath(file.path, input.rootPath),
+  }));
+  const normalizedInput = { ...input, files };
+  const languages = summarizeLanguages(normalizedInput);
+  const entryPoints = findEntryPoints(normalizedInput);
+  const modules = summarizeModules(normalizedInput);
+  const testFiles = files.filter((file) => isTestFile(file.path)).length;
+  const sourceFiles = files.filter(
+    (file) => isSourceFile(file.path) && !isTestFile(file.path)
+  ).length;
+  const name = input.profile?.name?.trim() || input.rootName || 'repo';
+
+  return {
+    repo: {
+      name,
+      purpose: inferPurpose(normalizedInput, languages),
+      depth: input.depth,
+      generatedAt: input.generatedAt,
+      totalFiles: files.length,
+      sourceFiles,
+      testFiles,
+    },
+    overview: {
+      languages,
+      frameworks: inferFrameworks(input.profile),
+      ...(input.profile?.packageManager ? { packageManager: input.profile.packageManager } : {}),
+      ...(input.profile?.testFramework ? { testFramework: input.profile.testFramework } : {}),
+      dependencies: unique(input.profile?.topDependencies ?? []).slice(0, 12),
+      entryPoints,
+    },
+    architecture: {
+      style:
+        input.cartography?.architecture?.style || (modules.length > 3 ? 'modulaire' : 'simple'),
+      modules,
+      diagram: buildDependencyDiagram(normalizedInput, modules),
+      centralModules: (input.cartography?.importGraph?.hotModules ?? [])
+        .map((module) => ({ path: normalizeSlashes(module.module), importedBy: module.importedBy }))
+        .slice(0, input.depth === 'deep' ? 12 : 7),
+    },
+    risks: {
+      hotspots: buildHotspots(normalizedInput),
+      ...(input.complexity?.summary ? { complexity: input.complexity.summary } : {}),
+      ...(input.evolution && (input.evolution.dataPoints?.length ?? 0) > 0
+        ? { evolution: input.evolution }
+        : {}),
+      gitAvailable: input.git?.available === true,
+    },
+    gettingStarted: buildGettingStarted(normalizedInput, entryPoints, modules),
+    limitations: buildLimitations(normalizedInput),
+  };
+}

--- a/src/commands/explain.ts
+++ b/src/commands/explain.ts
@@ -1,0 +1,167 @@
+/** `buddy explain` — turn an unfamiliar repository into one orientation artifact. */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Command, InvalidArgumentError } from 'commander';
+import {
+  collectRepoExplanationInput,
+  type RepoExplanationCollectorOptions,
+} from '../analytics/repo-explainer-collector.js';
+import {
+  explainRepository,
+  type RepoExplainDepth,
+  type RepoExplanationInput,
+} from '../analytics/repo-explainer.js';
+import {
+  renderRepoExplanationHtml,
+  renderRepoExplanationMarkdown,
+} from '../export/repo-explanation.js';
+import { renderMermaidPng } from '../tools/video/mermaid-render.js';
+import { logger } from '../utils/logger.js';
+
+interface ExplainOptions {
+  out?: string;
+  depth: RepoExplainDepth;
+  html: boolean;
+}
+
+export interface ExplainCommandDependencies {
+  cwd?: string;
+  now?: () => Date;
+  collect?: (options: RepoExplanationCollectorOptions) => Promise<RepoExplanationInput>;
+  renderMermaid?: typeof renderMermaidPng;
+}
+
+function parseDepth(value: string): RepoExplainDepth {
+  if (value === 'quick' || value === 'deep') return value;
+  throw new InvalidArgumentError('La profondeur doit être `quick` ou `deep`.');
+}
+
+function safeRepoName(value: string): string {
+  const slug = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .replace(/-+/g, '-');
+  return slug || 'repo';
+}
+
+function resolveOutput(
+  cwd: string,
+  rootPath: string,
+  options: ExplainOptions
+): { outputPath: string; format: 'markdown' | 'html' } {
+  const requested = options.out?.trim();
+  const extension = requested ? path.extname(requested).toLowerCase() : '';
+  if (requested && extension !== '.md' && extension !== '.html') {
+    throw new Error('Le fichier de sortie doit se terminer par `.md` ou `.html`.');
+  }
+  if (options.html && extension === '.md') {
+    throw new Error('`--html` est incompatible avec un fichier de sortie `.md`.');
+  }
+  const format: 'markdown' | 'html' = options.html || extension === '.html' ? 'html' : 'markdown';
+  const defaultName = `codebuddy-explain-${safeRepoName(path.basename(rootPath))}.${format === 'html' ? 'html' : 'md'}`;
+  return {
+    outputPath: path.resolve(cwd, requested || defaultName),
+    format,
+  };
+}
+
+async function ensureDirectory(rootPath: string): Promise<void> {
+  const stat = await fs.stat(rootPath).catch(() => undefined);
+  if (!stat) throw new Error(`Chemin introuvable : ${rootPath}`);
+  if (!stat.isDirectory())
+    throw new Error(`Le chemin à expliquer n’est pas un dossier : ${rootPath}`);
+}
+
+function minimalInput(
+  rootPath: string,
+  depth: RepoExplainDepth,
+  generatedAt: Date,
+  reason: string
+): RepoExplanationInput {
+  return {
+    rootPath,
+    rootName: path.basename(rootPath) || 'repo',
+    depth,
+    generatedAt: generatedAt.toISOString(),
+    files: [],
+    git: { available: false },
+    codeExplorer: { indexed: false },
+    notices: [`Collecte globale incomplète : ${reason}`],
+  };
+}
+
+async function renderDiagramDataUri(
+  mermaid: string,
+  renderer: typeof renderMermaidPng
+): Promise<string | undefined> {
+  let tempDirectory: string | undefined;
+  try {
+    tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'buddy-explain-mermaid-'));
+    const outputPath = path.join(tempDirectory, 'architecture.png');
+    const rendered = await renderer(mermaid, outputPath, { timeoutMs: 30_000 });
+    if (!rendered) return undefined;
+    const png = await fs.readFile(rendered);
+    return `data:image/png;base64,${png.toString('base64')}`;
+  } catch (error) {
+    logger.debug('[repo-explainer] rendu Mermaid local indisponible', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  } finally {
+    if (tempDirectory) {
+      await fs.rm(tempDirectory, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+}
+
+export function createExplainCommand(dependencies: ExplainCommandDependencies = {}): Command {
+  return new Command('explain')
+    .description('Comprendre un dépôt inconnu dans un artefact Markdown ou HTML autonome')
+    .argument('[chemin]', 'Dossier du dépôt à analyser', '.')
+    .option('--out <fichier.md|.html>', 'Fichier de sortie (Markdown par défaut)')
+    .option('--depth <quick|deep>', 'Profondeur de collecte', parseDepth, 'quick')
+    .option('--html', 'Produire un HTML autonome zéro CDN', false)
+    .action(async (requestedPath: string, options: ExplainOptions) => {
+      const cwd = path.resolve(dependencies.cwd ?? process.cwd());
+      const rootPath = path.resolve(cwd, requestedPath || '.');
+      await ensureDirectory(rootPath);
+      const { outputPath, format } = resolveOutput(cwd, rootPath, options);
+      const generatedAt = dependencies.now?.() ?? new Date();
+
+      let input: RepoExplanationInput;
+      try {
+        input = await (dependencies.collect ?? collectRepoExplanationInput)({
+          rootPath,
+          depth: options.depth,
+          generatedAt,
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        logger.warn('[repo-explainer] collecte globale interrompue; artefact minimal produit', {
+          rootPath,
+          error: reason,
+        });
+        input = minimalInput(rootPath, options.depth, generatedAt, reason);
+      }
+
+      const explanation = explainRepository(input);
+      let artifact: string;
+      if (format === 'html') {
+        const diagramDataUri = await renderDiagramDataUri(
+          explanation.architecture.diagram.mermaid,
+          dependencies.renderMermaid ?? renderMermaidPng
+        );
+        artifact = renderRepoExplanationHtml(explanation, { diagramDataUri });
+      } else {
+        artifact = renderRepoExplanationMarkdown(explanation);
+      }
+
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, artifact, 'utf8');
+      logger.info(`Explication du repo générée : ${outputPath}`);
+    });
+}

--- a/src/export/repo-explanation.ts
+++ b/src/export/repo-explanation.ts
@@ -1,0 +1,414 @@
+/** Render the pure repository explanation as Markdown or autonomous HTML. */
+
+import type {
+  RepoExplanation,
+  RepoHotspot,
+  RepoLanguageSummary,
+  RepoRiskLevel,
+} from '../analytics/repo-explainer.js';
+import { exportStandaloneHtmlDocument } from './session-share.js';
+
+export interface RepoExplanationHtmlOptions {
+  /** Locally-rendered Mermaid PNG. If absent, Mermaid source stays visible. */
+  diagramDataUri?: string;
+}
+
+function markdownCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+function languageLabel(language: RepoLanguageSummary): string {
+  if (language.files === 0) return language.name;
+  return `${language.name} (${language.files} fichier${language.files === 1 ? '' : 's'}, ${language.percent} %)`;
+}
+
+function riskLabel(level: RepoRiskLevel): string {
+  if (level === 'critical') return 'critique';
+  if (level === 'high') return 'élevé';
+  if (level === 'medium') return 'modéré';
+  return 'faible';
+}
+
+function formatSigned(value: number | undefined): string {
+  if (value === undefined) return 'non mesuré';
+  return `${value > 0 ? '+' : ''}${value.toLocaleString('fr-FR')}`;
+}
+
+function renderMarkdownHotspots(hotspots: RepoHotspot[]): string[] {
+  if (hotspots.length === 0) {
+    return [
+      'Aucun point chaud mesurable. Commencez par les fichiers d’entrée et ajoutez un historique Git pour enrichir ce classement.',
+      '',
+    ];
+  }
+  const lines = ['| Rang | Fichier | Risque | Score | Pourquoi |', '|---:|---|---|---:|---|'];
+  hotspots.forEach((hotspot, index) => {
+    lines.push(
+      `| ${index + 1} | \`${markdownCell(hotspot.path)}\` | ${riskLabel(hotspot.level)} | ${hotspot.score}/100 | ${markdownCell(hotspot.reasons.join(' · ') || 'signal relatif')} |`
+    );
+  });
+  lines.push('');
+  return lines;
+}
+
+/** Render one complete Markdown artifact. */
+export function renderRepoExplanationMarkdown(explanation: RepoExplanation): string {
+  const lines: string[] = [
+    `# Comprendre ${explanation.repo.name}`,
+    '',
+    `> Analyse ${explanation.repo.depth === 'deep' ? 'approfondie' : 'rapide'} générée le ${explanation.repo.generatedAt}. ${explanation.repo.totalFiles} fichiers observés, dont ${explanation.repo.sourceFiles} source et ${explanation.repo.testFiles} test(s).`,
+    '',
+    '## 1. À quoi sert ce repo',
+    '',
+    explanation.repo.purpose,
+    '',
+    `- **Langages :** ${explanation.overview.languages.map(languageLabel).join(', ') || 'non détectés'}`,
+    `- **Frameworks :** ${explanation.overview.frameworks.join(', ') || 'non détectés'}`,
+    `- **Gestionnaire de paquets :** ${explanation.overview.packageManager ?? 'non détecté'}`,
+    `- **Tests :** ${explanation.overview.testFramework ?? (explanation.repo.testFiles > 0 ? 'présents, framework non détecté' : 'non détectés')}`,
+  ];
+
+  if (explanation.overview.dependencies.length > 0) {
+    lines.push(
+      `- **Dépendances structurantes :** ${explanation.overview.dependencies.map((dependency) => `\`${dependency}\``).join(', ')}`
+    );
+  }
+
+  lines.push('', '### Entrées principales', '');
+  if (explanation.overview.entryPoints.length === 0) {
+    lines.push(
+      '- Aucune entrée conventionnelle détectée; partez du manifeste et du premier module listé ci-dessous.'
+    );
+  } else {
+    for (const entry of explanation.overview.entryPoints) {
+      const symbols =
+        entry.exportedSymbols.length > 0
+          ? ` — exports : ${entry.exportedSymbols.map((symbol) => `\`${symbol}\``).join(', ')}`
+          : '';
+      lines.push(`- \`${entry.path}\` — ${entry.reason}${symbols}`);
+    }
+  }
+
+  lines.push(
+    '',
+    '## 2. Architecture',
+    '',
+    `Style détecté : **${explanation.architecture.style}**.`,
+    '',
+    '| Module / dossier | Rôle | Fichiers |',
+    '|---|---|---:|'
+  );
+  if (explanation.architecture.modules.length === 0) {
+    lines.push('| *(aucun module détecté)* | Dépôt minimal | 0 |');
+  } else {
+    for (const module of explanation.architecture.modules) {
+      lines.push(
+        `| \`${markdownCell(module.directory)}\` | ${markdownCell(module.purpose)} | ${module.fileCount} |`
+      );
+    }
+  }
+
+  if (explanation.architecture.centralModules.length > 0) {
+    lines.push(
+      '',
+      `Modules les plus importés : ${explanation.architecture.centralModules
+        .map((module) => `\`${module.path}\` (${module.importedBy})`)
+        .join(', ')}.`
+    );
+  }
+
+  lines.push(
+    '',
+    '### Diagramme de dépendances',
+    '',
+    `Source : **${explanation.architecture.diagram.source === 'code-explorer' ? 'Code Explorer' : 'analyse locale'}** — ${explanation.architecture.diagram.note}`,
+    '',
+    '```mermaid',
+    explanation.architecture.diagram.mermaid,
+    '```',
+    '',
+    '## 3. Points chauds et risques',
+    ''
+  );
+
+  if (explanation.risks.complexity) {
+    const summary = explanation.risks.complexity;
+    lines.push(
+      `Complexité : ${summary.totalFunctions ?? 0} fonction(s) mesurée(s), moyenne ${summary.averageComplexity?.toFixed(1) ?? 'n/a'}, maximum ${summary.maxComplexity ?? 'n/a'}, note globale ${summary.overallRating ?? 'n/a'}.`,
+      ''
+    );
+  }
+  const evolution = explanation.risks.evolution;
+  const evolutionTrends = evolution?.trends;
+  if (evolution && evolutionTrends) {
+    lines.push(
+      `Évolution Git : code **${evolutionTrends.locTrend ?? 'stable'}**, fichiers **${evolutionTrends.fileTrend ?? 'stable'}**, variation LOC ${formatSigned(evolution.summary?.locChange)} (${formatSigned(evolution.summary?.locChangePercent)} %).`,
+      ''
+    );
+  } else if (!explanation.risks.gitAvailable) {
+    lines.push('Historique Git absent : aucun churn n’est inventé.', '');
+  }
+  lines.push(...renderMarkdownHotspots(explanation.risks.hotspots));
+
+  lines.push('## 4. Par où commencer', '');
+  if (explanation.gettingStarted.path.length === 0) {
+    lines.push('1. Lisez le manifeste ou ajoutez un README décrivant le rôle du dépôt.');
+  } else {
+    explanation.gettingStarted.path.forEach((filePath, index) => {
+      lines.push(`${index + 1}. Ouvrez \`${filePath}\`.`);
+    });
+  }
+
+  if (Object.keys(explanation.gettingStarted.commands).length > 0) {
+    lines.push('', '### Commandes utiles', '', '```text');
+    for (const [name, command] of Object.entries(explanation.gettingStarted.commands)) {
+      lines.push(`${name.padEnd(12)} ${command}`);
+    }
+    lines.push('```');
+  }
+
+  lines.push('', '### Documentation et tests', '');
+  lines.push(
+    explanation.gettingStarted.docs.length > 0
+      ? `- Documentation : ${explanation.gettingStarted.docs.map((filePath) => `\`${filePath}\``).join(', ')}`
+      : '- Documentation : aucun fichier évident détecté.'
+  );
+  lines.push(
+    explanation.gettingStarted.tests.length > 0
+      ? `- Tests représentatifs : ${explanation.gettingStarted.tests.map((filePath) => `\`${filePath}\``).join(', ')}`
+      : '- Tests : aucun fichier de test évident détecté.'
+  );
+
+  lines.push('', '## Limites de cette lecture', '');
+  if (explanation.limitations.length === 0) {
+    lines.push('- Aucun repli notable pendant la collecte.');
+  } else {
+    for (const limitation of explanation.limitations) lines.push(`- ${limitation}`);
+  }
+  lines.push('', '---', '', 'Généré localement par `buddy explain` — aucun appel LLM requis.', '');
+  return lines.join('\n');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderPills(values: string[], empty: string): string {
+  const items = values.length > 0 ? values : [empty];
+  return items.map((value) => `<span class="pill">${escapeHtml(value)}</span>`).join('');
+}
+
+function renderHtmlHotspot(hotspot: RepoHotspot, index: number): string {
+  return `<article class="hotspot risk-${hotspot.level}">
+    <div class="rank">${String(index + 1).padStart(2, '0')}</div>
+    <div class="hotspot-main">
+      <div class="hotspot-head"><code>${escapeHtml(hotspot.path)}</code><span>${escapeHtml(riskLabel(hotspot.level))}</span></div>
+      <p>${escapeHtml(hotspot.reasons.join(' · ') || 'Signal relatif')}</p>
+    </div>
+    <strong>${hotspot.score}</strong>
+  </article>`;
+}
+
+const REPO_EXPLANATION_CSS = `
+  :root {
+    color-scheme: dark;
+    --page: #081019;
+    --panel: #101b28;
+    --panel-soft: #142334;
+    --line: #26384a;
+    --text: #eff7ff;
+    --muted: #8fa3b8;
+    --cyan: #56d6e8;
+    --blue: #7da7ff;
+    --green: #6ee7b7;
+    --amber: #f4c86a;
+    --red: #ff8190;
+    --shadow: 0 24px 70px rgba(0, 0, 0, .3);
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    color: var(--text);
+    background:
+      radial-gradient(circle at 15% -10%, rgba(86, 214, 232, .13), transparent 34rem),
+      radial-gradient(circle at 92% 6%, rgba(125, 167, 255, .12), transparent 30rem),
+      var(--page);
+    font: 15px/1.65 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  .shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+  .hero { padding: 72px 0 42px; }
+  .brand { color: var(--cyan); font-size: 12px; font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
+  h1 { max-width: 900px; margin: 20px 0 16px; font-size: clamp(36px, 7vw, 72px); line-height: 1; letter-spacing: -.05em; }
+  .dek { max-width: 780px; margin: 0; color: #bdcbd8; font-size: 18px; }
+  .meta, .pills { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 22px; }
+  .meta span, .pill { border: 1px solid var(--line); border-radius: 999px; padding: 5px 10px; color: #b9cad9; background: rgba(16, 27, 40, .75); font: 12px/1.2 ui-monospace, SFMono-Regular, Consolas, monospace; }
+  nav { position: sticky; top: 0; z-index: 2; border-block: 1px solid rgba(38, 56, 74, .8); background: rgba(8, 16, 25, .9); backdrop-filter: blur(14px); }
+  nav .shell { display: flex; gap: 8px; overflow-x: auto; padding-block: 10px; }
+  nav a { border-radius: 8px; padding: 6px 10px; color: var(--muted); text-decoration: none; white-space: nowrap; font-size: 12px; }
+  nav a:hover { color: var(--text); background: var(--panel); }
+  main { padding: 38px 0 68px; }
+  section { margin-bottom: 28px; padding: 28px; border: 1px solid var(--line); border-radius: 22px; background: linear-gradient(145deg, rgba(20, 35, 52, .94), rgba(11, 21, 32, .95)); box-shadow: var(--shadow); }
+  .section-number { color: var(--cyan); font: 800 12px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: .12em; }
+  h2 { margin: 10px 0 18px; font-size: clamp(24px, 4vw, 36px); letter-spacing: -.03em; }
+  h3 { margin: 25px 0 10px; color: #dce9f5; font-size: 16px; }
+  p { margin: 8px 0; }
+  .muted { color: var(--muted); }
+  .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+  .card { min-width: 0; padding: 17px; border: 1px solid var(--line); border-radius: 14px; background: rgba(7, 14, 22, .48); }
+  .card strong { display: block; margin-bottom: 6px; color: #dbe8f4; }
+  code, pre { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace; }
+  code { overflow-wrap: anywhere; }
+  .entries, .steps, .plain-list { margin: 0; padding-left: 22px; }
+  .entries li, .steps li, .plain-list li { margin: 7px 0; }
+  table { width: 100%; border-collapse: collapse; margin-top: 14px; }
+  th, td { padding: 11px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+  th { color: var(--muted); font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
+  td:last-child, th:last-child { text-align: right; }
+  .diagram { margin-top: 14px; padding: 18px; border: 1px solid var(--line); border-radius: 15px; background: #07101a; overflow: auto; }
+  .diagram img { display: block; max-width: 100%; height: auto; margin: auto; }
+  .diagram pre { margin: 0; color: #c3d5e4; white-space: pre; }
+  .hotspot { display: grid; grid-template-columns: 42px minmax(0, 1fr) 48px; gap: 12px; align-items: center; margin-top: 9px; padding: 14px; border: 1px solid var(--line); border-left: 3px solid var(--amber); border-radius: 12px; background: rgba(7, 14, 22, .48); }
+  .hotspot.risk-critical { border-left-color: var(--red); }
+  .hotspot.risk-high { border-left-color: #ffad72; }
+  .hotspot.risk-low { border-left-color: var(--green); }
+  .rank { color: var(--muted); font: 800 12px/1 ui-monospace, SFMono-Regular, Consolas, monospace; }
+  .hotspot-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .hotspot-head span { color: var(--muted); font-size: 11px; text-transform: uppercase; }
+  .hotspot p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
+  .hotspot > strong { color: var(--amber); font: 800 18px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-align: right; }
+  .commands { padding: 14px; border-radius: 12px; color: #c5e5d8; background: #07110e; white-space: pre-wrap; }
+  footer { padding: 26px 0 48px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+  @media (max-width: 720px) {
+    .shell { width: min(100% - 20px, 1120px); }
+    .hero { padding-top: 44px; }
+    section { padding: 19px; border-radius: 16px; }
+    .grid { grid-template-columns: 1fr; }
+    .hotspot { grid-template-columns: 30px minmax(0, 1fr); }
+    .hotspot > strong { display: none; }
+    .hotspot-head { display: block; }
+    table { display: block; overflow-x: auto; }
+  }
+  @media print {
+    :root { color-scheme: light; --page: #fff; --panel: #fff; --panel-soft: #fff; --line: #d6dde5; --text: #172230; --muted: #5b6978; --shadow: none; }
+    body { background: #fff; }
+    nav { display: none; }
+    section, .card, .hotspot { break-inside: avoid; background: #fff; }
+  }
+`;
+
+/** Render one complete, zero-CDN HTML artifact. */
+export function renderRepoExplanationHtml(
+  explanation: RepoExplanation,
+  options: RepoExplanationHtmlOptions = {}
+): string {
+  const diagramDataUri = options.diagramDataUri?.startsWith('data:image/png;base64,')
+    ? options.diagramDataUri
+    : undefined;
+  const frameworkValues =
+    explanation.overview.frameworks.length > 0
+      ? explanation.overview.frameworks
+      : ['Aucun framework détecté'];
+  const languageValues = explanation.overview.languages.map(languageLabel);
+  const entryHtml =
+    explanation.overview.entryPoints.length > 0
+      ? explanation.overview.entryPoints
+          .map(
+            (entry) =>
+              `<li><code>${escapeHtml(entry.path)}</code> — ${escapeHtml(entry.reason)}${entry.exportedSymbols.length > 0 ? `<div class="muted">Exports : ${escapeHtml(entry.exportedSymbols.join(', '))}</div>` : ''}</li>`
+          )
+          .join('')
+      : '<li>Aucune entrée conventionnelle détectée.</li>';
+  const moduleRows =
+    explanation.architecture.modules.length > 0
+      ? explanation.architecture.modules
+          .map(
+            (module) =>
+              `<tr><td><code>${escapeHtml(module.directory)}</code></td><td>${escapeHtml(module.purpose)}</td><td>${module.fileCount}</td></tr>`
+          )
+          .join('')
+      : '<tr><td>Dépôt minimal</td><td>Aucun module détecté</td><td>0</td></tr>';
+  const diagramHtml = diagramDataUri
+    ? `<img src="${diagramDataUri}" alt="Diagramme local des dépendances">`
+    : `<pre><code>${escapeHtml(explanation.architecture.diagram.mermaid)}</code></pre><p class="muted">Le moteur Mermaid local n’était pas disponible; la source reste exploitable et aucun CDN n’a été chargé.</p>`;
+  const hotspotsHtml =
+    explanation.risks.hotspots.length > 0
+      ? explanation.risks.hotspots.map(renderHtmlHotspot).join('')
+      : '<p class="muted">Aucun point chaud mesurable. Aucun risque n’est inventé.</p>';
+  const commandText = Object.entries(explanation.gettingStarted.commands)
+    .map(([name, command]) => `${name.padEnd(12)} ${command}`)
+    .join('\n');
+  const pathHtml =
+    explanation.gettingStarted.path.length > 0
+      ? explanation.gettingStarted.path
+          .map((filePath) => `<li>Ouvrez <code>${escapeHtml(filePath)}</code>.</li>`)
+          .join('')
+      : '<li>Lisez le manifeste ou ajoutez un README décrivant le projet.</li>';
+  const limitations =
+    explanation.limitations.length > 0
+      ? explanation.limitations.map((limitation) => `<li>${escapeHtml(limitation)}</li>`).join('')
+      : '<li>Aucun repli notable pendant la collecte.</li>';
+
+  const body = `<header class="hero shell">
+    <div class="brand">Code Buddy · Repo Explain</div>
+    <h1>${escapeHtml(explanation.repo.name)}</h1>
+    <p class="dek">${escapeHtml(explanation.repo.purpose)}</p>
+    <div class="meta">
+      <span>${explanation.repo.depth === 'deep' ? 'analyse approfondie' : 'analyse rapide'}</span>
+      <span>${explanation.repo.totalFiles} fichiers</span>
+      <span>${explanation.repo.sourceFiles} source</span>
+      <span>${explanation.repo.testFiles} tests</span>
+      <span>${escapeHtml(explanation.repo.generatedAt)}</span>
+    </div>
+  </header>
+  <nav><div class="shell"><a href="#overview">Vue d’ensemble</a><a href="#architecture">Architecture</a><a href="#risks">Risques</a><a href="#start">Démarrage</a></div></nav>
+  <main class="shell">
+    <section id="overview">
+      <div class="section-number">01</div><h2>À quoi sert ce repo</h2>
+      <p>${escapeHtml(explanation.repo.purpose)}</p>
+      <div class="grid">
+        <div class="card"><strong>Langages</strong><div class="pills">${renderPills(languageValues, 'Non détectés')}</div></div>
+        <div class="card"><strong>Frameworks</strong><div class="pills">${renderPills(frameworkValues, 'Non détectés')}</div></div>
+        <div class="card"><strong>Outillage</strong><p>${escapeHtml(explanation.overview.packageManager ?? 'Gestionnaire non détecté')} · ${escapeHtml(explanation.overview.testFramework ?? 'Tests non identifiés')}</p></div>
+        <div class="card"><strong>Dépendances structurantes</strong><p>${escapeHtml(explanation.overview.dependencies.join(', ') || 'Non détectées')}</p></div>
+      </div>
+      <h3>Entrées principales</h3><ul class="entries">${entryHtml}</ul>
+    </section>
+    <section id="architecture">
+      <div class="section-number">02</div><h2>Architecture</h2>
+      <p>Style détecté : <strong>${escapeHtml(explanation.architecture.style)}</strong>.</p>
+      <table><thead><tr><th>Module / dossier</th><th>Rôle</th><th>Fichiers</th></tr></thead><tbody>${moduleRows}</tbody></table>
+      <h3>Diagramme de dépendances</h3>
+      <p class="muted">${escapeHtml(explanation.architecture.diagram.note)} Source : ${explanation.architecture.diagram.source === 'code-explorer' ? 'Code Explorer' : 'analyse locale'}.</p>
+      <div class="diagram">${diagramHtml}</div>
+    </section>
+    <section id="risks">
+      <div class="section-number">03</div><h2>Points chauds et risques</h2>
+      ${explanation.risks.complexity ? `<p class="muted">${explanation.risks.complexity.totalFunctions ?? 0} fonction(s) mesurée(s) · complexité max ${explanation.risks.complexity.maxComplexity ?? 'n/a'} · note ${escapeHtml(explanation.risks.complexity.overallRating ?? 'n/a')}</p>` : ''}
+      ${hotspotsHtml}
+    </section>
+    <section id="start">
+      <div class="section-number">04</div><h2>Par où commencer</h2>
+      <ol class="steps">${pathHtml}</ol>
+      ${commandText ? `<h3>Commandes utiles</h3><pre class="commands"><code>${escapeHtml(commandText)}</code></pre>` : ''}
+      <div class="grid">
+        <div class="card"><strong>Documentation</strong><p>${escapeHtml(explanation.gettingStarted.docs.join(', ') || 'Aucun fichier évident')}</p></div>
+        <div class="card"><strong>Tests représentatifs</strong><p>${escapeHtml(explanation.gettingStarted.tests.join(', ') || 'Aucun fichier évident')}</p></div>
+      </div>
+      <h3>Limites de cette lecture</h3><ul class="plain-list">${limitations}</ul>
+    </section>
+  </main>
+  <footer><div class="shell"><strong>Code Buddy</strong> · Artefact autonome, généré localement sans appel LLM ni ressource réseau.</div></footer>`;
+
+  return exportStandaloneHtmlDocument({
+    lang: 'fr',
+    title: `${explanation.repo.name} — Comprendre le repo — Code Buddy`,
+    styles: REPO_EXPLANATION_CSS,
+    bodyHtml: body,
+  });
+}

--- a/src/export/session-share.ts
+++ b/src/export/session-share.ts
@@ -1,0 +1,827 @@
+import type { Session, SessionMessage } from '../persistence/session-store.js';
+import type { SessionFacade } from '../agent/facades/session-facade.js';
+import { scrubSecrets, scrubValue } from '../security/secret-scrubber.js';
+import { SessionTimeline, type TimelineEntry } from '../sessions/timeline.js';
+import { logger } from '../utils/logger.js';
+
+const MAX_TITLE_LENGTH = 96;
+const MAX_TOOL_ARGUMENTS_LENGTH = 900;
+const MAX_TOOL_RESULT_LENGTH = 1_800;
+
+type UnknownRecord = Record<string, unknown>;
+
+interface ShareUsage {
+  tokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+}
+
+interface ShareToolCall {
+  name: string;
+  arguments?: unknown;
+  result?: string;
+  ok?: boolean;
+}
+
+interface ShareDiff {
+  path: string;
+  content: string;
+}
+
+interface ShareTurn {
+  number: number;
+  timestamp: string;
+  prompt: string;
+  responses: string[];
+  reasoning: string[];
+  notes: string[];
+  tools: ShareToolCall[];
+  diffs: ShareDiff[];
+  filesTouched: string[];
+  model: string;
+  usage: ShareUsage;
+}
+
+function mergeToolFields(target: ShareToolCall, incoming: ShareToolCall): void {
+  target.arguments ??= incoming.arguments;
+  target.result ??= incoming.result;
+  target.ok ??= incoming.ok;
+}
+
+export interface SessionShareHtmlOptions {
+  exportedAt?: Date;
+}
+
+/** Shared zero-CDN document shell used by standalone Code Buddy artifacts. */
+export interface StandaloneHtmlDocumentOptions {
+  lang?: string;
+  title: string;
+  styles: string;
+  /** Trusted HTML assembled from escaped fields by the calling renderer. */
+  bodyHtml: string;
+}
+
+export interface PersistedSessionShareDependencies {
+  sessionFacade: Pick<SessionFacade, 'loadSession'>;
+  timeline?: Pick<SessionTimeline, 'list'>;
+  exportedAt?: Date;
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const number = asFiniteNumber(value);
+    if (number !== undefined) return number;
+  }
+  return undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = asString(value);
+    if (text !== undefined) return text;
+  }
+  return undefined;
+}
+
+function readUsage(record: UnknownRecord): ShareUsage {
+  const metadata = asRecord(record.metadata);
+  const usage = asRecord(record.usage) ?? asRecord(metadata?.usage);
+  const inputTokens = firstNumber(
+    record.inputTokens,
+    record.promptTokens,
+    metadata?.inputTokens,
+    usage?.inputTokens,
+    usage?.promptTokens
+  );
+  const outputTokens = firstNumber(
+    record.outputTokens,
+    record.completionTokens,
+    metadata?.outputTokens,
+    usage?.outputTokens,
+    usage?.completionTokens
+  );
+  const explicitTokens = firstNumber(
+    record.tokens,
+    record.tokenCount,
+    record.totalTokens,
+    metadata?.tokens,
+    metadata?.tokenCount,
+    usage?.tokens,
+    usage?.totalTokens
+  );
+  const tokens =
+    explicitTokens ??
+    (inputTokens !== undefined || outputTokens !== undefined
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined);
+  const costUsd = firstNumber(
+    record.costUsd,
+    record.cost,
+    record.totalCost,
+    metadata?.costUsd,
+    metadata?.cost,
+    usage?.costUsd,
+    usage?.cost
+  );
+
+  return {
+    ...(tokens !== undefined ? { tokens } : {}),
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+}
+
+function mergeUsage(target: ShareUsage, incoming: ShareUsage): void {
+  target.tokens ??= incoming.tokens;
+  target.inputTokens ??= incoming.inputTokens;
+  target.outputTokens ??= incoming.outputTokens;
+  target.costUsd ??= incoming.costUsd;
+}
+
+function readModel(record: UnknownRecord): string | undefined {
+  const metadata = asRecord(record.metadata);
+  return firstString(record.model, record.modelId, metadata?.model, metadata?.modelId);
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function readToolCall(value: unknown, fallbackName?: string): ShareToolCall | undefined {
+  const record = asRecord(value);
+  if (!record) return fallbackName ? { name: fallbackName } : undefined;
+  const fn = asRecord(record.function);
+  const name = firstString(fn?.name, record.name, record.toolName, fallbackName);
+  if (!name) return undefined;
+  const argumentsValue = fn?.arguments ?? record.arguments ?? record.args ?? record.input;
+  const resultValue = firstString(record.result, record.output, record.error);
+  const ok =
+    typeof record.ok === 'boolean'
+      ? record.ok
+      : typeof record.success === 'boolean'
+        ? record.success
+        : undefined;
+
+  return {
+    name,
+    ...(argumentsValue !== undefined ? { arguments: parseJsonValue(argumentsValue) } : {}),
+    ...(resultValue !== undefined ? { result: resultValue } : {}),
+    ...(ok !== undefined ? { ok } : {}),
+  };
+}
+
+function mergeTool(turn: ShareTurn, incoming: ShareToolCall): void {
+  const existing = turn.tools.find(
+    (tool) =>
+      tool.name === incoming.name &&
+      ((incoming.arguments !== undefined && tool.arguments === undefined) ||
+        (incoming.result !== undefined && tool.result === undefined) ||
+        (incoming.ok !== undefined && tool.ok === undefined))
+  );
+  if (!existing) {
+    turn.tools.push(incoming);
+    return;
+  }
+  mergeToolFields(existing, incoming);
+}
+
+function looksLikeDiff(content: string): boolean {
+  return /^(?:diff --git |\*\*\* Begin Patch|@@ |--- |\+\+\+ )/m.test(content);
+}
+
+function inferDiffPath(content: string): string | undefined {
+  const gitHeader = /^diff --git a\/(.+?) b\/(.+)$/m.exec(content);
+  if (gitHeader?.[2]) return gitHeader[2];
+  const patchHeader = /^\*\*\* (?:Update|Add|Delete) File: (.+)$/m.exec(content);
+  if (patchHeader?.[1]) return patchHeader[1];
+  const fileHeader = /^\+\+\+ (?:b\/)?(.+)$/m.exec(content);
+  return fileHeader?.[1];
+}
+
+function addDiff(turn: ShareTurn, path: string | undefined, content: string): void {
+  const trimmed = content.trim();
+  if (!trimmed) return;
+  const normalizedPath = path?.trim() || inferDiffPath(trimmed) || 'Diff';
+  if (turn.diffs.some((diff) => diff.path === normalizedPath && diff.content === trimmed)) return;
+  turn.diffs.push({ path: normalizedPath, content: trimmed });
+}
+
+function addDiffValue(turn: ShareTurn, value: unknown): void {
+  if (typeof value === 'string') {
+    addDiff(turn, undefined, value);
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) return;
+  const content = firstString(record.diff, record.patch, record.content, record.excerpt);
+  if (!content) return;
+  addDiff(turn, firstString(record.path, record.file, record.filePath), content);
+}
+
+function addDiffCollection(turn: ShareTurn, value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) addDiffValue(turn, item);
+  } else if (value !== undefined) {
+    addDiffValue(turn, value);
+  }
+}
+
+function addUnique(target: string[], value: string | undefined): void {
+  if (!value) return;
+  const trimmed = value.trim();
+  if (trimmed && !target.includes(trimmed)) target.push(trimmed);
+}
+
+function makeTurn(number: number, session: Session, timestamp?: string): ShareTurn {
+  return {
+    number,
+    timestamp: timestamp ?? session.createdAt.toISOString(),
+    prompt: '',
+    responses: [],
+    reasoning: [],
+    notes: [],
+    tools: [],
+    diffs: [],
+    filesTouched: [],
+    model: session.model || 'Modèle non renseigné',
+    usage: {},
+  };
+}
+
+function messageRecord(message: SessionMessage): UnknownRecord {
+  return message as unknown as UnknownRecord;
+}
+
+function addCallsFromRecord(turn: ShareTurn, record: UnknownRecord): void {
+  const calls = Array.isArray(record.toolCalls) ? record.toolCalls : [];
+  for (const value of calls) {
+    const tool = readToolCall(value);
+    if (tool) mergeTool(turn, tool);
+  }
+  const single = readToolCall(record.toolCall);
+  if (single) mergeTool(turn, single);
+}
+
+function addMessageToTurn(turn: ShareTurn, message: SessionMessage): void {
+  const record = messageRecord(message);
+  turn.model = readModel(record) ?? turn.model;
+  mergeUsage(turn.usage, readUsage(record));
+  addCallsFromRecord(turn, record);
+
+  if (message.type === 'assistant') {
+    addUnique(turn.responses, message.content);
+    return;
+  }
+  if (message.type === 'reasoning') {
+    addUnique(turn.reasoning, message.content);
+    return;
+  }
+  if (message.type === 'plan_progress') {
+    addUnique(turn.notes, message.content);
+    return;
+  }
+  if (message.type === 'diff_preview') {
+    const parsed = parseJsonValue(message.content);
+    const parsedRecord = asRecord(parsed);
+    if (parsedRecord) {
+      addDiffCollection(turn, parsedRecord.diffs ?? parsedRecord.diff ?? parsedRecord);
+    } else {
+      addDiff(turn, undefined, message.content);
+    }
+    return;
+  }
+
+  if (message.type === 'tool_call') {
+    const name = message.toolCallName ?? firstString(asRecord(record.toolCall)?.name);
+    if (!name) return;
+    const content = message.content.trim();
+    const argumentsValue =
+      content && content !== 'Executing...' && content !== 'Success'
+        ? parseJsonValue(content)
+        : undefined;
+    mergeTool(turn, {
+      name,
+      ...(argumentsValue !== undefined ? { arguments: argumentsValue } : {}),
+    });
+    return;
+  }
+
+  if (message.type === 'tool_result') {
+    const nestedResult = asRecord(record.toolResult);
+    const name = message.toolCallName ?? readToolCall(record.toolCall)?.name ?? 'outil';
+    const ok =
+      typeof message.toolCallSuccess === 'boolean'
+        ? message.toolCallSuccess
+        : typeof nestedResult?.success === 'boolean'
+          ? nestedResult.success
+          : undefined;
+    const result = firstString(
+      nestedResult?.output,
+      nestedResult?.error,
+      nestedResult?.content,
+      message.content
+    );
+    mergeTool(turn, {
+      name,
+      ...(result ? { result } : {}),
+      ...(ok !== undefined ? { ok } : {}),
+    });
+    if (result && looksLikeDiff(result)) addDiff(turn, undefined, result);
+  }
+}
+
+function applyTimelineEntry(turn: ShareTurn, entry: TimelineEntry): void {
+  const record = entry as unknown as UnknownRecord;
+  turn.timestamp = entry.ts || turn.timestamp;
+  turn.model = readModel(record) ?? turn.model;
+  mergeUsage(turn.usage, readUsage(record));
+
+  const prompt = firstString(record.userPrompt, record.prompt, record.userMessage);
+  const response = firstString(record.assistantResponse, record.response, record.assistantMessage);
+  if (!turn.prompt && prompt) turn.prompt = prompt;
+  addUnique(turn.responses, response);
+  addUnique(turn.reasoning, firstString(record.reasoning, record.thinking));
+
+  if (!turn.prompt && entry.role === 'user') turn.prompt = entry.textPreview;
+  if (turn.responses.length === 0 && entry.role === 'assistant') {
+    addUnique(turn.responses, entry.textPreview);
+  }
+
+  for (const file of entry.filesTouched) addUnique(turn.filesTouched, file);
+  entry.toolCalls.forEach((call, index) => {
+    const tool = readToolCall(call, call.name) ?? { name: call.name, ok: call.ok };
+    tool.ok ??= call.ok;
+    const positionalMatch = turn.tools[index];
+    if (positionalMatch?.name === tool.name) {
+      mergeToolFields(positionalMatch, tool);
+      return;
+    }
+    const namedMatch = turn.tools.find(
+      (candidate, candidateIndex) => candidateIndex >= index && candidate.name === tool.name
+    );
+    if (namedMatch) mergeToolFields(namedMatch, tool);
+    else turn.tools.push(tool);
+  });
+
+  addDiffCollection(turn, record.diffs ?? record.fileDiffs ?? record.diff);
+}
+
+function buildTurns(session: Session, timeline: readonly TimelineEntry[]): ShareTurn[] {
+  const turns: ShareTurn[] = [];
+  let current: ShareTurn | undefined;
+
+  for (const message of session.messages) {
+    if (message.type === 'user' || message.type === 'steer') {
+      if (current) turns.push(current);
+      current = makeTurn(turns.length + 1, session, message.timestamp);
+      current.prompt = message.content;
+      const record = messageRecord(message);
+      current.model = readModel(record) ?? current.model;
+      mergeUsage(current.usage, readUsage(record));
+      continue;
+    }
+
+    current ??= makeTurn(turns.length + 1, session, message.timestamp);
+    addMessageToTurn(current, message);
+  }
+  if (current) turns.push(current);
+
+  const byNumber = new Map(turns.map((turn) => [turn.number, turn]));
+  for (const entry of timeline) {
+    let turn = byNumber.get(entry.turn);
+    if (!turn) {
+      turn = makeTurn(entry.turn, session, entry.ts);
+      turns.push(turn);
+      byNumber.set(entry.turn, turn);
+    }
+    applyTimelineEntry(turn, entry);
+  }
+
+  return turns.sort((left, right) => left.number - right.number);
+}
+
+function redact(text: string): string {
+  return scrubSecrets(text);
+}
+
+function escapeHtml(text: string): string {
+  return redact(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/** Final secret-scrubbing pass shared by every autonomous HTML exporter. */
+export function finalizeStandaloneHtmlDocument(html: string): string {
+  return scrubSecrets(html);
+}
+
+/**
+ * Build a self-contained HTML document with the same fail-closed network CSP
+ * as the session replay exporter. Callers provide inline CSS and escaped body
+ * markup; scripts and remote resources remain forbidden.
+ */
+export function exportStandaloneHtmlDocument(options: StandaloneHtmlDocumentOptions): string {
+  const lang = (options.lang ?? 'fr').replace(/[^A-Za-z0-9-]/g, '') || 'fr';
+  return finalizeStandaloneHtmlDocument(`<!doctype html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; font-src data:; base-uri 'none'; form-action 'none'">
+  <title>${escapeHtml(options.title)}</title>
+  <style>${options.styles}</style>
+</head>
+<body>${options.bodyHtml}</body>
+</html>`);
+}
+
+function truncate(text: string, maxLength: number): string {
+  const safe = redact(text);
+  if (safe.length <= maxLength) return safe;
+  return `${safe.slice(0, maxLength)}\n… [résultat tronqué]`;
+}
+
+function stringifySummary(value: unknown): string {
+  const safeValue = scrubValue(value);
+  let serialized: string;
+  try {
+    serialized = typeof safeValue === 'string' ? safeValue : JSON.stringify(safeValue, null, 2);
+  } catch {
+    serialized = String(safeValue);
+  }
+  return truncate(serialized || '{}', MAX_TOOL_ARGUMENTS_LENGTH);
+}
+
+function renderProse(text: string): string {
+  const safe = redact(text);
+  const codeFence = /```([^\n`]*)\n([\s\S]*?)```/g;
+  const parts: string[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  const renderPlain = (plain: string): string => {
+    const escaped = escapeHtml(plain);
+    return escaped.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+  };
+
+  while ((match = codeFence.exec(safe)) !== null) {
+    parts.push(`<div class="prose">${renderPlain(safe.slice(cursor, match.index))}</div>`);
+    const language = (match[1] || 'texte').trim().replace(/[^A-Za-z0-9#+.-]/g, '') || 'texte';
+    parts.push(
+      `<pre class="code"><span class="code-label">${escapeHtml(language)}</span><code>${escapeHtml((match[2] ?? '').trim())}</code></pre>`
+    );
+    cursor = match.index + match[0].length;
+  }
+  parts.push(`<div class="prose">${renderPlain(safe.slice(cursor))}</div>`);
+  return parts.join('');
+}
+
+function diffLineClass(line: string): string {
+  if (/^\+\+\+ /.test(line) || /^--- /.test(line) || /^diff --git /.test(line)) return 'diff-file';
+  if (/^@@/.test(line)) return 'diff-hunk';
+  if (/^\+/.test(line)) return 'diff-add';
+  if (/^-/.test(line)) return 'diff-remove';
+  return 'diff-context';
+}
+
+function renderDiff(diff: ShareDiff): string {
+  const lines = truncate(diff.content, 24_000)
+    .split('\n')
+    .map((line) => `<span class="${diffLineClass(line)}">${escapeHtml(line)}</span>`)
+    .join('\n');
+  return `
+    <div class="diff-block">
+      <div class="diff-path">${escapeHtml(diff.path)}</div>
+      <pre class="diff"><code>${lines}</code></pre>
+    </div>`;
+}
+
+function formatTimestamp(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Horodatage indisponible';
+  return date
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.000Z$/, ' UTC');
+}
+
+function formatCost(cost: number): string {
+  return `$${cost.toFixed(cost < 0.01 ? 4 : 2)}`;
+}
+
+function titleFromSession(session: Session, turns: readonly ShareTurn[]): string {
+  const prompt = turns.find((turn) => turn.prompt.trim())?.prompt;
+  const fallback =
+    firstString(session.metadata?.description, session.name, session.id) ?? 'Session Code Buddy';
+  const normalized = redact(prompt ?? fallback)
+    .replace(/\s+/g, ' ')
+    .trim();
+  return normalized.length > MAX_TITLE_LENGTH
+    ? `${normalized.slice(0, MAX_TITLE_LENGTH - 1)}…`
+    : normalized;
+}
+
+function renderTool(tool: ShareToolCall): string {
+  const status = tool.ok === true ? 'réussi' : tool.ok === false ? 'échoué' : 'statut inconnu';
+  const statusClass = tool.ok === true ? 'ok' : tool.ok === false ? 'failed' : 'unknown';
+  const argumentsHtml =
+    tool.arguments === undefined
+      ? '<p class="empty compact">Arguments non conservés dans cette sauvegarde.</p>'
+      : `<pre class="tool-data"><code>${escapeHtml(stringifySummary(tool.arguments))}</code></pre>`;
+  const resultHtml =
+    tool.result === undefined
+      ? '<p class="empty compact">Résultat détaillé non conservé.</p>'
+      : `<pre class="tool-data result"><code>${escapeHtml(truncate(tool.result, MAX_TOOL_RESULT_LENGTH))}</code></pre>`;
+
+  return `
+    <div class="tool-card">
+      <div class="tool-heading">
+        <code>${escapeHtml(tool.name)}</code>
+        <span class="status ${statusClass}">${status}</span>
+      </div>
+      <div class="tool-columns">
+        <div><div class="eyebrow">Arguments résumés</div>${argumentsHtml}</div>
+        <div><div class="eyebrow">Résultat</div>${resultHtml}</div>
+      </div>
+    </div>`;
+}
+
+function renderTurn(turn: ShareTurn): string {
+  const usageBadges = [
+    turn.model ? `<span>${escapeHtml(turn.model)}</span>` : '',
+    turn.usage.tokens !== undefined ? `<span>${Math.round(turn.usage.tokens)} tokens</span>` : '',
+    turn.usage.costUsd !== undefined ? `<span>${formatCost(turn.usage.costUsd)}</span>` : '',
+  ]
+    .filter(Boolean)
+    .join('');
+  const responses =
+    turn.responses.length > 0
+      ? turn.responses
+          .map((response) => renderProse(response))
+          .join('<div class="response-separator"></div>')
+      : '<p class="empty">Réponse complète non disponible; seule la sauvegarde de timeline peut subsister.</p>';
+  const prompt = turn.prompt
+    ? renderProse(turn.prompt)
+    : '<p class="empty">Message utilisateur non conservé dans la timeline disponible.</p>';
+  const reasoning =
+    turn.reasoning.length > 0
+      ? `<details class="detail-card"><summary>Raisonnement enregistré <span>${turn.reasoning.length}</span></summary>${turn.reasoning.map(renderProse).join('<div class="response-separator"></div>')}</details>`
+      : '';
+  const notes =
+    turn.notes.length > 0
+      ? `<details class="detail-card"><summary>Progression <span>${turn.notes.length}</span></summary>${turn.notes.map(renderProse).join('')}</details>`
+      : '';
+  const tools =
+    turn.tools.length > 0
+      ? `<details class="detail-card" open><summary>Appels d’outils <span>${turn.tools.length}</span></summary>${turn.tools.map(renderTool).join('')}</details>`
+      : '';
+  const diffs =
+    turn.diffs.length > 0
+      ? `<details class="detail-card" open><summary>Diffs <span>${turn.diffs.length}</span></summary>${turn.diffs.map(renderDiff).join('')}</details>`
+      : '';
+  const files =
+    turn.filesTouched.length > 0
+      ? `<div class="files"><span class="eyebrow">Fichiers touchés</span>${turn.filesTouched.map((file) => `<code>${escapeHtml(file)}</code>`).join('')}</div>`
+      : '';
+
+  return `
+  <article class="turn" id="tour-${turn.number}">
+    <div class="turn-rail"><span>${String(turn.number).padStart(2, '0')}</span></div>
+    <div class="turn-body">
+      <header class="turn-header">
+        <div><div class="eyebrow">Tour ${turn.number}</div><time>${escapeHtml(formatTimestamp(turn.timestamp))}</time></div>
+        <div class="badges">${usageBadges}</div>
+      </header>
+      <section class="message user-message">
+        <div class="message-label"><span class="avatar user-avatar">U</span><strong>Vous</strong></div>
+        ${prompt}
+      </section>
+      <section class="message assistant-message">
+        <div class="message-label"><span class="avatar buddy-avatar">B</span><strong>Code Buddy</strong></div>
+        ${responses}
+      </section>
+      ${reasoning}${tools}${diffs}${notes}${files}
+    </div>
+  </article>`;
+}
+
+/**
+ * Render one canonical saved session, enriched by its optional time-travel
+ * timeline, as a single self-contained HTML document.
+ */
+export function exportSessionShareHtml(
+  session: Session,
+  timeline: readonly TimelineEntry[] = [],
+  options: SessionShareHtmlOptions = {}
+): string {
+  const turns = buildTurns(session, timeline);
+  const title = titleFromSession(session, turns);
+  const exportedAt = options.exportedAt ?? new Date();
+  const toolCount = turns.reduce((count, turn) => count + turn.tools.length, 0);
+  const fileCount = new Set(turns.flatMap((turn) => turn.filesTouched)).size;
+  const totalTokens = asFiniteNumber(session.metadata?.tokenCount);
+  const totalCost = asFiniteNumber(session.metadata?.totalCost);
+  const summaryBadges = [
+    `<span>${turns.length} tour${turns.length === 1 ? '' : 's'}</span>`,
+    `<span>${toolCount} outil${toolCount === 1 ? '' : 's'}</span>`,
+    `<span>${fileCount} fichier${fileCount === 1 ? '' : 's'}</span>`,
+    totalTokens !== undefined ? `<span>${Math.round(totalTokens)} tokens</span>` : '',
+    totalCost !== undefined ? `<span>${formatCost(totalCost)}</span>` : '',
+  ]
+    .filter(Boolean)
+    .join('');
+  const content =
+    turns.length > 0
+      ? turns.map(renderTurn).join('')
+      : '<div class="empty-state"><strong>Session vide</strong><p>Aucun message ni tour de timeline n’a été conservé.</p></div>';
+
+  const html = `<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; font-src data:; base-uri 'none'; form-action 'none'">
+  <title>${escapeHtml(title)} — Code Buddy</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --page: #090b10;
+      --panel: #11151d;
+      --panel-soft: #171c26;
+      --line: #2a3240;
+      --text: #edf2f7;
+      --muted: #8d99aa;
+      --cyan: #54d6ff;
+      --violet: #a78bfa;
+      --green: #64e6a7;
+      --red: #ff7b88;
+      --amber: #f8c76a;
+      --shadow: 0 28px 80px rgba(0, 0, 0, .34);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 12% -10%, rgba(84, 214, 255, .12), transparent 34rem),
+        radial-gradient(circle at 90% 8%, rgba(167, 139, 250, .13), transparent 30rem),
+        var(--page);
+      font: 15px/1.65 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+    .hero { padding: 72px 0 44px; }
+    .brand { display: flex; align-items: center; gap: 12px; color: var(--cyan); font-size: 13px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+    .brand-mark { display: grid; place-items: center; width: 32px; height: 32px; border: 1px solid rgba(84, 214, 255, .48); border-radius: 10px; background: rgba(84, 214, 255, .08); }
+    h1 { max-width: 850px; margin: 24px 0 16px; font-size: clamp(32px, 6vw, 64px); line-height: 1.05; letter-spacing: -.045em; text-wrap: balance; }
+    .dek { max-width: 720px; margin: 0; color: var(--muted); font-size: 17px; }
+    .session-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
+    .session-meta span, .badges span { border: 1px solid var(--line); border-radius: 999px; padding: 5px 10px; color: #b8c2d0; background: rgba(17, 21, 29, .72); font: 12px/1.2 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .session-id { margin-top: 14px; color: #687486; font: 12px/1.4 ui-monospace, SFMono-Regular, Consolas, monospace; overflow-wrap: anywhere; }
+    main { padding-bottom: 64px; }
+    .turn { display: grid; grid-template-columns: 54px minmax(0, 1fr); position: relative; }
+    .turn:not(:last-child) .turn-rail::after { content: ""; position: absolute; top: 48px; bottom: -4px; left: 26px; width: 1px; background: linear-gradient(var(--line), rgba(42, 50, 64, .2)); }
+    .turn-rail { position: relative; display: flex; justify-content: center; }
+    .turn-rail > span { z-index: 1; display: grid; place-items: center; width: 38px; height: 38px; border: 1px solid rgba(84, 214, 255, .38); border-radius: 50%; color: var(--cyan); background: #0d1118; font: 700 12px/1 ui-monospace, SFMono-Regular, Consolas, monospace; box-shadow: 0 0 24px rgba(84, 214, 255, .08); }
+    .turn-body { min-width: 0; padding: 0 0 54px 16px; }
+    .turn-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin: 4px 0 14px; }
+    .eyebrow { color: var(--muted); font-size: 11px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+    time { color: #697587; font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .badges { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 6px; }
+    .message, .detail-card, .files { border: 1px solid var(--line); border-radius: 18px; background: linear-gradient(145deg, rgba(23, 28, 38, .92), rgba(14, 18, 25, .94)); box-shadow: var(--shadow); }
+    .message { position: relative; padding: 22px; margin-bottom: 12px; overflow: hidden; }
+    .message::before { content: ""; position: absolute; inset: 0 auto 0 0; width: 3px; background: var(--cyan); }
+    .assistant-message::before { background: var(--violet); }
+    .message-label { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+    .message-label strong { font-size: 13px; letter-spacing: .02em; }
+    .avatar { display: grid; place-items: center; width: 27px; height: 27px; border-radius: 9px; font: 800 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .user-avatar { color: #061118; background: var(--cyan); }
+    .buddy-avatar { color: #100c1d; background: var(--violet); }
+    .prose { white-space: pre-wrap; overflow-wrap: anywhere; }
+    .prose:empty { display: none; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace; }
+    .prose code { border: 1px solid #313a49; border-radius: 6px; padding: 1px 5px; color: #d9e6f2; background: #0b0f15; font-size: .91em; }
+    pre { margin: 12px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+    .code { position: relative; padding: 38px 16px 16px; border: 1px solid #283140; border-radius: 12px; color: #d7e0eb; background: #090d13; overflow-x: auto; }
+    .code-label { position: absolute; top: 10px; right: 12px; color: #647083; font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
+    .response-separator { height: 1px; margin: 20px 0; background: var(--line); }
+    .empty { margin: 0; color: #748094; font-style: italic; }
+    .empty.compact { font-size: 13px; }
+    .detail-card { margin-top: 12px; overflow: hidden; box-shadow: none; }
+    summary { display: flex; align-items: center; gap: 9px; padding: 15px 18px; cursor: pointer; color: #d6deea; font-size: 13px; font-weight: 750; user-select: none; }
+    summary::marker { color: var(--cyan); }
+    summary span { margin-left: auto; min-width: 24px; border-radius: 999px; padding: 2px 7px; color: var(--muted); background: #0b0f15; text-align: center; font: 11px/1.4 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    details > .prose { padding: 0 18px 18px; color: #bdc7d4; }
+    .tool-card { padding: 16px 18px; border-top: 1px solid var(--line); }
+    .tool-heading { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+    .tool-heading code { color: var(--amber); font-weight: 750; }
+    .status { border-radius: 999px; padding: 3px 8px; font-size: 10px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+    .status.ok { color: var(--green); background: rgba(100, 230, 167, .1); }
+    .status.failed { color: var(--red); background: rgba(255, 123, 136, .1); }
+    .status.unknown { color: var(--muted); background: rgba(141, 153, 170, .1); }
+    .tool-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+    .tool-data { max-height: 260px; overflow: auto; padding: 12px; border: 1px solid #293240; border-radius: 10px; color: #bac6d5; background: #090d13; font-size: 12px; }
+    .tool-data.result { color: #a9d9c2; }
+    .diff-block { border-top: 1px solid var(--line); }
+    .diff-path { padding: 12px 18px; color: #c2ccd9; background: rgba(8, 11, 16, .48); font: 12px/1.4 ui-monospace, SFMono-Regular, Consolas, monospace; overflow-wrap: anywhere; }
+    .diff { max-height: 520px; margin: 0; padding: 15px 18px; overflow: auto; color: #aeb9c8; background: #090d13; font-size: 12px; line-height: 1.55; }
+    .diff span { display: block; min-width: max-content; }
+    .diff-add { color: #8ce8b8; background: rgba(44, 168, 104, .1); }
+    .diff-remove { color: #ff9ba5; background: rgba(203, 66, 78, .1); }
+    .diff-hunk { color: #9bb9ff; }
+    .diff-file { color: #f5c978; font-weight: 700; }
+    .files { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 12px; padding: 14px 16px; box-shadow: none; }
+    .files code { border: 1px solid #303947; border-radius: 7px; padding: 3px 7px; color: #aebccc; background: #0b0f15; font-size: 11px; overflow-wrap: anywhere; }
+    .empty-state { padding: 48px; border: 1px dashed var(--line); border-radius: 20px; color: var(--muted); text-align: center; }
+    footer { padding: 26px 0 46px; border-top: 1px solid rgba(42, 50, 64, .7); color: #697587; font-size: 12px; }
+    footer strong { color: #9ca8b8; }
+    @media (max-width: 720px) {
+      .shell { width: min(100% - 20px, 1120px); }
+      .hero { padding-top: 42px; }
+      .turn { grid-template-columns: 34px minmax(0, 1fr); }
+      .turn-rail > span { width: 30px; height: 30px; }
+      .turn:not(:last-child) .turn-rail::after { left: 16px; top: 38px; }
+      .turn-body { padding-left: 8px; }
+      .turn-header { display: block; }
+      .badges { justify-content: flex-start; margin-top: 8px; }
+      .message { padding: 17px; border-radius: 14px; }
+      .tool-columns { grid-template-columns: 1fr; }
+    }
+    @media print {
+      :root { color-scheme: light; --page: #fff; --panel: #fff; --panel-soft: #fff; --line: #d8dde5; --text: #17202b; --muted: #5d6877; --shadow: none; }
+      body { background: #fff; }
+      .hero { padding-top: 24px; }
+      .turn, .message, .detail-card, .diff-block { break-inside: avoid; }
+      .message, .detail-card, .files { background: #fff; }
+      details { display: block; }
+      details > * { display: block; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero shell">
+    <div class="brand"><span class="brand-mark">CB</span> Session Replay</div>
+    <h1>${escapeHtml(title)}</h1>
+    <p class="dek">Un replay autonome de la conversation, des outils et des modifications enregistrées.</p>
+    <div class="session-meta">${summaryBadges}</div>
+    <div class="session-id">Session ${escapeHtml(session.id)} · ${escapeHtml(formatTimestamp(session.createdAt))}</div>
+  </header>
+  <main class="shell">${content}</main>
+  <footer class="shell"><strong>Code Buddy</strong> · Export généré le ${escapeHtml(formatTimestamp(exportedAt))} · HTML autonome, sans ressource réseau.</footer>
+</body>
+</html>`;
+
+  // Final defence in depth: catch any future interpolated field that forgot to
+  // pass through the local redaction helpers above.
+  return finalizeStandaloneHtmlDocument(html);
+}
+
+/** Load through SessionFacade and enrich from timeline regardless of the recording gate. */
+export async function exportPersistedSessionShareHtml(
+  sessionId: string,
+  dependencies: PersistedSessionShareDependencies
+): Promise<string | null> {
+  const session = await dependencies.sessionFacade.loadSession(sessionId);
+  if (!session) return null;
+
+  let entries: TimelineEntry[] = [];
+  try {
+    entries = await (dependencies.timeline ?? new SessionTimeline()).list(sessionId);
+  } catch (error) {
+    logger.warn('[session-share] timeline unavailable; exporting saved message history', {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return exportSessionShareHtml(session, entries, { exportedAt: dependencies.exportedAt });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3464,6 +3464,17 @@ addLazyCommand(
   },
 );
 
+// Repo explainer — one Markdown/HTML orientation artifact for an unfamiliar repository
+addLazyCommand(
+  program,
+  'explain',
+  'Explain an unfamiliar repository in one Markdown or self-contained HTML artifact',
+  async () => {
+    const { createExplainCommand } = await import('./commands/explain.js');
+    return createExplainCommand();
+  },
+);
+
 // AI-Scientist-lite (Phases 0-3) — human-gated, sandboxed experiment: single pass or bounded discovery loop (opt-in)
 addLazyCommand(
   program,

--- a/tests/analytics/repo-explainer.test.ts
+++ b/tests/analytics/repo-explainer.test.ts
@@ -1,0 +1,235 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  explainRepository,
+  type RepoExplanationInput,
+  type RepoFileInput,
+} from '../../src/analytics/repo-explainer.js';
+import {
+  renderRepoExplanationHtml,
+  renderRepoExplanationMarkdown,
+} from '../../src/export/repo-explanation.js';
+
+const fixtureRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/repo-explainer'
+);
+
+async function fixtureFiles(directory = fixtureRoot, prefix = ''): Promise<RepoFileInput[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry): Promise<RepoFileInput[]> => {
+      const relativePath = path.posix.join(prefix, entry.name);
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return fixtureFiles(absolutePath, relativePath);
+      const stat = await fs.stat(absolutePath);
+      return [{ path: relativePath, sizeBytes: stat.size }];
+    })
+  );
+  return files.flat().sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function fixtureInput(): Promise<RepoExplanationInput> {
+  return {
+    rootPath: fixtureRoot,
+    rootName: 'repo-explainer',
+    depth: 'quick',
+    generatedAt: '2026-08-16T10:00:00.000Z',
+    files: await fixtureFiles(),
+    profile: {
+      name: 'fixture-service',
+      description: 'A small TypeScript HTTP service used to validate repository orientation.',
+      languages: ['TypeScript'],
+      packageManager: 'npm',
+      testFramework: 'Vitest',
+      entryPoints: ['dist/index.js'],
+      commands: { build: 'npm run build', test: 'npm test' },
+      topDependencies: ['fastify'],
+    },
+    cartography: {
+      architecture: {
+        style: 'Layered',
+        layers: [
+          { name: 'Source', directory: 'src', fileCount: 3 },
+          { name: 'Tests', directory: 'tests', fileCount: 1 },
+        ],
+      },
+      fileStats: {
+        totalSourceFiles: 3,
+        totalTestFiles: 1,
+        largestFiles: [{ path: 'src/risky.ts', lines: 420 }],
+      },
+      importGraph: {
+        hotModules: [{ module: 'src/service.ts', importedBy: 4 }],
+        circularRisks: [],
+      },
+      importEdges: [
+        ['src/index.ts', 'src/service.ts'],
+        ['src/service.ts', 'src/risky.ts'],
+      ],
+    },
+    complexity: {
+      files: [
+        {
+          filePath: path.join(fixtureRoot, 'src/risky.ts'),
+          maxComplexity: 24,
+          averageComplexity: 12,
+          totalLinesOfCode: 420,
+          maintainabilityIndex: 42,
+        },
+        {
+          filePath: path.join(fixtureRoot, 'src/service.ts'),
+          maxComplexity: 3,
+          averageComplexity: 2,
+          totalLinesOfCode: 24,
+          maintainabilityIndex: 88,
+        },
+      ],
+      hotspots: [
+        {
+          filePath: path.join(fixtureRoot, 'src/risky.ts'),
+          name: 'evaluateRequest',
+          cyclomaticComplexity: 24,
+          cognitiveComplexity: 18,
+          linesOfCode: 40,
+        },
+      ],
+      summary: {
+        totalFiles: 2,
+        totalFunctions: 2,
+        averageComplexity: 7,
+        maxComplexity: 24,
+        overallRating: 'C',
+      },
+    },
+    heatmap: {
+      files: [
+        {
+          filePath: 'src/risky.ts',
+          commits: 20,
+          additions: 600,
+          deletions: 300,
+          churnScore: 900,
+          heatLevel: 'hot',
+        },
+        {
+          filePath: 'src/service.ts',
+          commits: 2,
+          additions: 20,
+          deletions: 4,
+          churnScore: 24,
+          heatLevel: 'cold',
+        },
+      ],
+    },
+    documentation: {
+      modules: [
+        {
+          path: 'src/index.ts',
+          entries: [{ name: 'service', kind: 'variable' }],
+        },
+      ],
+      totalEntries: 1,
+    },
+    codeExplorer: { indexed: false },
+    git: { available: true },
+  };
+}
+
+describe('repository explainer', () => {
+  it('detects the fixture orientation and ranks injected risk signals', async () => {
+    const explanation = explainRepository(await fixtureInput());
+
+    expect(explanation.repo.name).toBe('fixture-service');
+    expect(explanation.repo.purpose).toContain('TypeScript HTTP service');
+    expect(explanation.overview.languages[0]).toMatchObject({ name: 'TypeScript', files: 4 });
+    expect(explanation.overview.frameworks).toContain('Fastify');
+    expect(explanation.overview.entryPoints[0]).toMatchObject({ path: 'src/index.ts' });
+    expect(explanation.overview.entryPoints[0]?.exportedSymbols).toContain('service');
+    expect(explanation.architecture.modules.map((module) => module.directory)).toEqual([
+      'src',
+      'tests',
+    ]);
+    expect(explanation.architecture.diagram.mermaid).toContain('flowchart LR');
+    expect(explanation.risks.hotspots[0]?.path).toBe('src/risky.ts');
+    expect(explanation.risks.hotspots[0]?.reasons.join(' ')).toContain('churn');
+    expect(explanation.gettingStarted.docs[0]).toBe('README.md');
+    expect(explanation.gettingStarted.tests).toContain('tests/service.test.ts');
+    expect(explanation.limitations).toContain(
+      'Code Explorer non indexé : diagramme construit depuis les imports/fichiers disponibles.'
+    );
+  });
+
+  it('uses an injected Code Explorer Mermaid graph when available', async () => {
+    const input = await fixtureInput();
+    input.codeExplorer = {
+      indexed: true,
+      target: 'createService',
+      mermaid: 'flowchart LR\n  Entry --> Service',
+    };
+
+    const diagram = explainRepository(input).architecture.diagram;
+
+    expect(diagram.source).toBe('code-explorer');
+    expect(diagram.mermaid).toContain('Entry --> Service');
+  });
+
+  it('rejects network-capable Mermaid from an index and falls back locally', async () => {
+    const input = await fixtureInput();
+    input.codeExplorer = {
+      indexed: true,
+      mermaid: 'flowchart LR\n  Entry --> Service\n  click Service "https://example.test"',
+    };
+
+    const explanation = explainRepository(input);
+
+    expect(explanation.architecture.diagram.source).toBe('file-analysis');
+    expect(explanation.architecture.diagram.mermaid).not.toContain('https://');
+    expect(explanation.limitations.join(' ')).toContain('non exploitable ou non sûr');
+  });
+
+  it('always returns a useful explanation for an empty non-Git repository', () => {
+    const explanation = explainRepository({
+      rootName: 'empty-repo',
+      depth: 'quick',
+      generatedAt: '2026-08-16T10:00:00.000Z',
+      files: [],
+      git: { available: false },
+      codeExplorer: { indexed: false },
+    });
+
+    expect(explanation.repo.purpose).toContain('Dépôt minimal ou vide');
+    expect(explanation.architecture.diagram.mermaid).toContain('empty-repo');
+    expect(explanation.limitations.join(' ')).toContain('Historique Git indisponible');
+  });
+});
+
+describe('repository explanation renderers', () => {
+  it('renders the four required Markdown sections', async () => {
+    const markdown = renderRepoExplanationMarkdown(explainRepository(await fixtureInput()));
+
+    expect(markdown.length).toBeGreaterThan(500);
+    expect(markdown).toContain('## 1. À quoi sert ce repo');
+    expect(markdown).toContain('## 2. Architecture');
+    expect(markdown).toContain('## 3. Points chauds et risques');
+    expect(markdown).toContain('## 4. Par où commencer');
+    expect(markdown).toContain('```mermaid');
+  });
+
+  it('renders autonomous HTML without a network resource URL', async () => {
+    const html = renderRepoExplanationHtml(explainRepository(await fixtureInput()), {
+      diagramDataUri: 'data:image/png;base64,aGVsbG8=',
+    });
+
+    expect(html.length).toBeGreaterThan(1_000);
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Content-Security-Policy');
+    expect(html).toContain("default-src 'none'");
+    expect(html).toContain('data:image/png;base64,aGVsbG8=');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<link');
+    expect(html).not.toMatch(/<(?:script|link|img)[^>]+(?:src|href)=["']https?:/i);
+  });
+});

--- a/tests/commands/explain.test.ts
+++ b/tests/commands/explain.test.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RepoExplanationInput } from '../../src/analytics/repo-explainer.js';
+import { createExplainCommand } from '../../src/commands/explain.js';
+
+describe('buddy explain command', () => {
+  let tempDirectory: string;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'buddy-explain-test-'));
+    repoPath = path.join(tempDirectory, 'minimal-repo');
+    await fs.mkdir(repoPath);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDirectory, { recursive: true, force: true });
+  });
+
+  it('produces useful Markdown for a minimal non-Git repo without mutating it', async () => {
+    const outputPath = path.join(tempDirectory, 'minimal.md');
+    const command = createExplainCommand({
+      cwd: tempDirectory,
+      now: () => new Date('2026-08-16T10:00:00.000Z'),
+    });
+
+    await command.parseAsync(['node', 'explain', 'minimal-repo', '--out', outputPath]);
+
+    const markdown = await fs.readFile(outputPath, 'utf8');
+    expect(markdown).toContain('# Comprendre minimal-repo');
+    expect(markdown).toContain('Dépôt minimal ou vide');
+    expect(markdown).toContain('Historique Git absent');
+    expect(await fs.readdir(repoPath)).toEqual([]);
+  });
+
+  it('honors deep HTML output and keeps the artifact zero-CDN when Mermaid fails open', async () => {
+    const outputPath = path.join(tempDirectory, 'orientation.html');
+    const collect = vi.fn(
+      async (): Promise<RepoExplanationInput> => ({
+        rootPath: repoPath,
+        rootName: 'sample',
+        depth: 'deep',
+        generatedAt: '2026-08-16T10:00:00.000Z',
+        files: [
+          { path: 'README.md', sizeBytes: 20 },
+          { path: 'src/index.ts', sizeBytes: 80 },
+        ],
+        profile: {
+          name: 'sample',
+          description: 'A sample command-line application.',
+          entryPoints: ['src/index.ts'],
+        },
+        git: { available: false },
+        codeExplorer: { indexed: false },
+      })
+    );
+    const renderMermaid = vi.fn(async () => null);
+    const command = createExplainCommand({
+      cwd: tempDirectory,
+      collect,
+      renderMermaid,
+    });
+
+    await command.parseAsync([
+      'node',
+      'explain',
+      'minimal-repo',
+      '--depth',
+      'deep',
+      '--html',
+      '--out',
+      outputPath,
+    ]);
+
+    const html = await fs.readFile(outputPath, 'utf8');
+    expect(collect).toHaveBeenCalledWith(
+      expect.objectContaining({ depth: 'deep', rootPath: repoPath })
+    );
+    expect(renderMermaid).toHaveBeenCalledOnce();
+    expect(html).toContain('Le moteur Mermaid local n’était pas disponible');
+    expect(html).not.toMatch(/<(?:script|link|img)[^>]+(?:src|href)=["']https?:/i);
+  });
+
+  it('still writes an orientation artifact when the whole collector rejects', async () => {
+    const outputPath = path.join(tempDirectory, 'fallback.md');
+    const command = createExplainCommand({
+      cwd: tempDirectory,
+      collect: async () => {
+        throw new Error('synthetic collection failure');
+      },
+    });
+
+    await expect(
+      command.parseAsync(['node', 'explain', 'minimal-repo', '--out', outputPath])
+    ).resolves.toBeDefined();
+
+    const markdown = await fs.readFile(outputPath, 'utf8');
+    expect(markdown).toContain('Collecte globale incomplète');
+    expect(markdown).toContain('## 4. Par où commencer');
+  });
+});

--- a/tests/fixtures/repo-explainer/README.md
+++ b/tests/fixtures/repo-explainer/README.md
@@ -1,0 +1,5 @@
+# Fixture Service
+
+A small TypeScript HTTP service that exposes a health endpoint and delegates work to a domain service.
+
+See `docs/architecture.md` before changing the request flow.

--- a/tests/fixtures/repo-explainer/docs/architecture.md
+++ b/tests/fixtures/repo-explainer/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+`src/index.ts` creates the service. The service delegates request classification to `src/risky.ts`.

--- a/tests/fixtures/repo-explainer/package.json
+++ b/tests/fixtures/repo-explainer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fixture-service",
+  "description": "A small TypeScript HTTP service used to validate repository orientation.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "fastify": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/tests/fixtures/repo-explainer/src/index.ts
+++ b/tests/fixtures/repo-explainer/src/index.ts
@@ -1,0 +1,3 @@
+import { createService } from './service.js';
+
+export const service = createService();

--- a/tests/fixtures/repo-explainer/src/risky.ts
+++ b/tests/fixtures/repo-explainer/src/risky.ts
@@ -1,0 +1,6 @@
+export function evaluateRequest(value: number): string {
+  if (value < 0) return 'invalid';
+  if (value === 0) return 'empty';
+  if (value > 100) return 'large';
+  return 'accepted';
+}

--- a/tests/fixtures/repo-explainer/src/service.ts
+++ b/tests/fixtures/repo-explainer/src/service.ts
@@ -1,0 +1,7 @@
+import { evaluateRequest } from './risky.js';
+
+export function createService(): { handle(value: number): string } {
+  return {
+    handle: (value) => evaluateRequest(value),
+  };
+}

--- a/tests/fixtures/repo-explainer/tests/service.test.ts
+++ b/tests/fixtures/repo-explainer/tests/service.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { createService } from '../src/service.js';
+
+describe('service', () => {
+  it('handles a value', () => {
+    expect(createService().handle(1)).toBe('accepted');
+  });
+});


### PR DESCRIPTION
## Périmètre

Découpe (c) de la PR parapluie #70 (`feat/mysoulmate-media-pipeline`). La PR #104 a déjà extrait `cost` / `changelog` / `import` et avait écarté `explain` (moteurs absents de `main` à l'époque).

Livré :

- `buddy explain [chemin]` — artefact d'orientation Markdown (défaut) ou HTML autonome `--html` (`--out`, `--depth quick|deep`)
- moteur pur `src/analytics/repo-explainer.ts` (zéro I/O)
- collecteur best-effort `src/analytics/repo-explainer-collector.ts`
- rendu `src/export/repo-explanation.ts` + coquille HTML `exportStandaloneHtmlDocument` dans `src/export/session-share.ts` (aucun équivalent sur `main`)
- tests + fixture `tests/fixtures/repo-explainer/**`
- câblage **minimal** dans `src/index.ts` : 1 × `addLazyCommand` calqué sur `cost` / `changelog` / `import` (#104)

## Adapté aux API actuelles de `main`

- `RepoProfiler.inspect()` n'existe pas : `getProfile()` + `CODEBUDDY_REPO_PROFILE_READONLY=true` pour ne pas écrire `.codebuddy/`
- `CodeExplorerManager.generateDiagram()` n'existe pas : appel CLI best-effort `code-explorer`/`gitnexus diagram`, sinon diagramme local ; `getFreshness(runGit)` sans option `{ autoIndex }`
- `complexity-analyzer` est présent mais son `import { glob } from 'fast-glob'` n'est pas chargeable en ESM (`tsx`) : import dynamique, dégradation explicite (« Analyse de complexité indisponible ») plutôt que de modifier le module existant
- `src/export/repo-explanation.ts` n'était pas dans la liste de checkout initiale mais est requis par `explain.ts` et les tests

## Écarté

- ne pas porter `inspect()` ni `generateDiagram()` dans les modules existants de `main`
- ne pas corriger l'import ESM de `complexity-analyzer.ts` (casse `tests/unit/complexity-analyzer.test.ts` qui mocke `{ glob }`)
- hors lot : média/LoRA, `mcp serve`, first-run, LSP, mentions, etc.

## Vérification

```
npx tsc --noEmit
# exit 0

npx eslint src/commands/explain.ts src/analytics/repo-explainer.ts src/analytics/repo-explainer-collector.ts src/export/session-share.ts src/export/repo-explanation.ts src/index.ts tests/commands/explain.test.ts tests/analytics/repo-explainer.test.ts
# 0 error (1 warning préexistant @typescript-eslint/no-explicit-any src/index.ts:1511)

npx vitest run tests/commands/explain.test.ts tests/analytics/repo-explainer.test.ts
# Test Files 2 passed / Tests 9 passed

npx tsx src/index.ts explain --help
# Usage: buddy explain [options] [chemin]

npx tsx src/index.ts explain .
# INFO Explication du repo générée : …/codebuddy-explain-code-buddy-pr70c.md
# exit 0, pas de stacktrace ; artefact ~5 Ko, 4 sections + limite complexité
```

Ne pas merger depuis cette PR sans relecture humaine. La PR #70 parapluie reste ouverte jusqu'aux autres lots.
