### PR TITLE
fix(providers): audit batch 1 — lot providers/context (découpe de #68)

### DIFF
--- a/src/codebuddy/abort-signal.ts
+++ b/src/codebuddy/abort-signal.ts
@@ -1,0 +1,35 @@
+/** Create a fetch-compatible cancellation error. */
+export function createAbortError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
+ * Combine caller cancellation with provider timeouts. `AbortSignal.any` is
+ * used when available; the listener fallback keeps Node 18 compatibility.
+ */
+export function combineAbortSignals(
+  ...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (activeSignals.length === 0) return undefined;
+  if (activeSignals.length === 1) return activeSignals[0];
+
+  const AbortSignalWithAny = AbortSignal as typeof AbortSignal & {
+    any?: (signals: AbortSignal[]) => AbortSignal;
+  };
+  if (typeof AbortSignalWithAny.any === 'function') {
+    return AbortSignalWithAny.any(activeSignals);
+  }
+
+  const controller = new AbortController();
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+  }
+  return controller.signal;
+}

--- a/src/codebuddy/client.ts
+++ b/src/codebuddy/client.ts
@@ -15,6 +15,7 @@ import { ChatGptResponsesProvider } from "./providers/provider-chatgpt-responses
 import { GeminiCliProvider } from "./providers/provider-gemini-cli.js";
 import { AgyCliProvider } from './providers/provider-agy-cli.js';
 import { withStreamRetry } from "./stream-retry.js";
+import { createAbortError } from './abort-signal.js';
 import {
   recordRuntimeFallbackFailure,
   recordRuntimeFallbackSuccess,
@@ -598,6 +599,9 @@ export class CodeBuddyClient {
     try {
       return await this.dispatchChat(messages, tools, opts, searchOptions);
     } catch (error) {
+      if (opts.signal?.aborted) {
+        throw createAbortError('Chat request aborted by caller');
+      }
       return await this.chatWithProviderFallback(error, messages, tools, opts, searchOptions);
     }
   }
@@ -673,6 +677,9 @@ export class CodeBuddyClient {
         recordRuntimeFallbackSuccess(fallback);
         return response;
       } catch (fallbackError) {
+        if (opts.signal?.aborted) {
+          throw createAbortError('Chat request aborted by caller');
+        }
         recordRuntimeFallbackFailure(fallback, fallbackError);
         logger.warn('Fallback provider failed', {
           source: 'CodeBuddyClient',
@@ -708,7 +715,7 @@ export class CodeBuddyClient {
     const primaryFactory = (): AsyncGenerator<ChatCompletionChunk, void, unknown> =>
       this.dispatchChatStream(messages, tools, opts, searchOptions);
     const primaryStream = retryEnabled
-      ? withStreamRetry(primaryFactory, retryOpts)
+      ? withStreamRetry(primaryFactory, { ...retryOpts, signal: opts.signal })
       : primaryFactory();
 
     let yieldedAnyChunk = false;
@@ -718,6 +725,9 @@ export class CodeBuddyClient {
         yield chunk;
       }
     } catch (error) {
+      if (opts.signal?.aborted) {
+        throw createAbortError('Chat stream aborted by caller');
+      }
       if (yieldedAnyChunk) {
         throw error;
       }
@@ -798,6 +808,9 @@ export class CodeBuddyClient {
         recordRuntimeFallbackSuccess(fallback);
         return;
       } catch (fallbackError) {
+        if (opts.signal?.aborted) {
+          throw createAbortError('Chat stream aborted by caller');
+        }
         recordRuntimeFallbackFailure(fallback, fallbackError);
         logger.warn('Fallback provider stream failed', {
           source: 'CodeBuddyClient',

--- a/src/codebuddy/providers/provider-openai-compat.ts
+++ b/src/codebuddy/providers/provider-openai-compat.ts
@@ -43,7 +43,7 @@ import { getCircuitBreaker, CircuitOpenError } from '../../providers/circuit-bre
 import type { CircuitBreakerConfig } from '../../providers/circuit-breaker.js';
 import { parseRateLimitHeaders, storeRateLimitInfo } from '../../utils/rate-limit-display.js';
 import { mapProviderError } from '../../errors/index.js';
-import { preserveProviderErrorMetadata } from '../provider-error-classifier.js';
+import { classifyProviderError, preserveProviderErrorMetadata } from '../provider-error-classifier.js';
 import { getModelInfo } from '../../utils/model-utils.js';
 import {
   injectAnthropicCacheBreakpoints,
@@ -224,6 +224,7 @@ export class OpenAICompatProvider implements Provider {
   private toolSupportProbed: boolean = false;
   private toolSupportDetected: boolean | null = null;
   private probePromise: Promise<boolean> | null = null;
+  private probeGeneration = 0;
 
   // Prompt cache stats (OpenAI/xAI surface `cached_tokens`; provider-specific)
   private _promptCacheHits: number = 0;
@@ -267,7 +268,12 @@ export class OpenAICompatProvider implements Provider {
   }
 
   setModel(model: string): void {
+    if (model === this.currentModel) return;
     this.currentModel = model;
+    this.toolSupportProbed = false;
+    this.toolSupportDetected = null;
+    this.probePromise = null;
+    this.probeGeneration++;
   }
 
   /**
@@ -442,12 +448,24 @@ export class OpenAICompatProvider implements Provider {
 
     // Synchronous assignment of probePromise BEFORE any await closes the race
     // window — concurrent callers see the same in-flight promise.
-    const probe = this.performToolProbe();
+    const model = this.currentModel;
+    const generation = this.probeGeneration;
+    const probe = this.performToolProbe(model, generation).finally(() => {
+      if (this.probePromise === probe) {
+        this.probePromise = null;
+      }
+    });
     this.probePromise = probe;
     return probe;
   }
 
-  private async performToolProbe(): Promise<boolean> {
+  private cacheToolSupport(result: boolean, model: string, generation: number): void {
+    if (generation !== this.probeGeneration || model !== this.currentModel) return;
+    this.toolSupportProbed = true;
+    this.toolSupportDetected = result;
+  }
+
+  private async performToolProbe(model: string, generation: number): Promise<boolean> {
     try {
       const testTool: CodeBuddyTool = {
         type: 'function',
@@ -463,7 +481,7 @@ export class OpenAICompatProvider implements Provider {
       };
 
       const probePayload: ChatCompletionCreateParamsNonStreaming = {
-        model: this.currentModel,
+        model,
         messages: [{ role: 'user', content: 'What time is it? Use the get_current_time tool.' }],
         tools: [testTool as unknown as OpenAI.ChatCompletionTool],
         tool_choice: 'auto',
@@ -474,25 +492,25 @@ export class OpenAICompatProvider implements Provider {
 
       if (!response.choices || response.choices.length === 0) {
         logger.warn('Tool support probe returned empty choices array');
-        this.toolSupportProbed = true;
-        this.toolSupportDetected = false;
+        this.cacheToolSupport(false, model, generation);
         return false;
       }
 
       const message = response.choices[0]?.message;
       const hasToolCall = !!(message?.tool_calls && message.tool_calls.length > 0);
 
-      this.toolSupportProbed = true;
-      this.toolSupportDetected = hasToolCall;
+      this.cacheToolSupport(hasToolCall, model, generation);
 
       if (hasToolCall) {
         logger.debug('Tool support detected: model supports function calling');
       }
 
       return hasToolCall;
-    } catch (_error) {
-      this.toolSupportProbed = true;
-      this.toolSupportDetected = false;
+    } catch (error) {
+      const classification = classifyProviderError(error);
+      if (classification.status === 400 || classification.status === 422) {
+        this.cacheToolSupport(false, model, generation);
+      }
       return false;
     }
   }

--- a/src/codebuddy/providers/provider-openai-compat.ts
+++ b/src/codebuddy/providers/provider-openai-compat.ts
@@ -766,7 +766,7 @@ export class OpenAICompatProvider implements Provider {
     searchOptions?: SearchOptions,
   ): Promise<CodeBuddyResponse> {
     try {
-      const useTools = !this.isLocalInference() && tools && tools.length > 0;
+      const useTools = !this.isLocalInference() && (tools?.length ?? 0) > 0;
 
       // Strict-template local runtimes (Ollama/LM Studio/vLLM) require a single
       // leading system message — merge any late/duplicate system injections.
@@ -780,8 +780,7 @@ export class OpenAICompatProvider implements Provider {
       const requestPayload: ChatRequestPayload = {
         model: opts.model || this.currentModel,
         messages: finalMessages,
-        tools: useTools ? tools : [],
-        tool_choice: useTools ? 'auto' : undefined,
+        ...(useTools ? { tools, tool_choice: 'auto' as const } : {}),
         temperature: opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? this.defaultMaxTokens,
       };
@@ -932,7 +931,7 @@ export class OpenAICompatProvider implements Provider {
     searchOptions?: SearchOptions,
   ): AsyncGenerator<ChatCompletionChunk, void, unknown> {
     try {
-      const useTools = !this.isLocalInference() && tools && tools.length > 0;
+      const useTools = !this.isLocalInference() && (tools?.length ?? 0) > 0;
 
       // Strict-template local runtimes (Ollama/LM Studio/vLLM) require a single
       // leading system message — merge any late/duplicate system injections
@@ -955,8 +954,7 @@ export class OpenAICompatProvider implements Provider {
       const requestPayload = {
         model: opts.model || this.currentModel,
         messages: finalMessages,
-        tools: useTools ? tools : [],
-        tool_choice: useTools ? 'auto' as const : undefined,
+        ...(useTools ? { tools, tool_choice: 'auto' as const } : {}),
         temperature: opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? this.defaultMaxTokens,
       };

--- a/src/codebuddy/providers/provider-openai-compat.ts
+++ b/src/codebuddy/providers/provider-openai-compat.ts
@@ -787,9 +787,11 @@ export class OpenAICompatProvider implements Provider {
       const useTools = !this.isLocalInference() && (tools?.length ?? 0) > 0;
 
       // Strict-template local runtimes (Ollama/LM Studio/vLLM) require a single
-      // leading system message — merge any late/duplicate system injections.
-      let finalMessages: CodeBuddyMessage[] = this.normalizeMessagesForRuntime(messages);
-      // Inject Anthropic prompt-cache breakpoints (Manus AI #20).
+      // leading system message — merge any late/duplicate system injections
+      // before the tool-role conversion below.
+      let finalMessages = this.convertToolMessagesForLocalModels(
+        this.normalizeMessagesForRuntime(messages),
+      );
       const modelInfo = getModelInfo(this.currentModel);
       if (modelInfo.provider === 'anthropic') {
         finalMessages = injectAnthropicCacheBreakpoints(finalMessages) as CodeBuddyMessage[];

--- a/src/context/context-manager-v2.ts
+++ b/src/context/context-manager-v2.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CodeBuddyMessage } from '../codebuddy/client.js';
 import { redactSecrets } from '../fleet/privacy-lint.js';
-import { createTokenCounter, TokenCounter } from './token-counter.js';
+import { createTokenCounter, estimateImageUrlTokens, TokenCounter } from './token-counter.js';
 import { logger } from '../utils/logger.js';
 import { getModelToolConfig } from '../config/model-tools.js';
 import { RunStore } from '../observability/run-store.js';
@@ -334,10 +334,14 @@ export class ContextManagerV2 {
     // Map CodeBuddyMessage to the format expected by TokenCounter
     const tokenMessages = messages.map(msg => ({
       role: msg.role,
-      content: typeof msg.content === 'string' ? msg.content : null,
+      content: typeof msg.content === 'string' || Array.isArray(msg.content) ? msg.content : null,
       tool_calls: 'tool_calls' in msg ? msg.tool_calls : undefined,
     }));
-    return this.tokenCounter.countMessageTokens(tokenMessages);
+    const imageTokens = messages.reduce(
+      (total, message) => total + estimateImageUrlTokens(message.content),
+      0,
+    );
+    return this.tokenCounter.countMessageTokens(tokenMessages) + imageTokens;
   }
 
   /**

--- a/src/context/enhanced-compression.ts
+++ b/src/context/enhanced-compression.ts
@@ -196,8 +196,9 @@ export class EnhancedContextCompressor {
     // Classify messages by content type
     const classified = this.classifyMessages(messages);
 
-    // Separate system message
-    const systemMsg = messages.find(m => m.role === 'system');
+    // Preserve every system message. The context pipeline injects multiple
+    // independent blocks (base prompt, lessons, todo, decisions, etc.).
+    const systemMsgs = messages.filter(m => m.role === 'system');
     const conversationMsgs = messages.filter(m => m.role !== 'system');
 
     let compressed: CodeBuddyMessage[] = [...conversationMsgs];
@@ -246,9 +247,9 @@ export class EnhancedContextCompressor {
       strategiesApplied.push('hard_truncation');
     }
 
-    // Reconstruct with system message
-    if (systemMsg) {
-      compressed = [systemMsg, ...compressed];
+    // Reconstruct with all system messages first, in their original order.
+    if (systemMsgs.length > 0) {
+      compressed = [...systemMsgs, ...compressed];
     }
 
     return this.createResult(

--- a/src/context/enhanced-compression.ts
+++ b/src/context/enhanced-compression.ts
@@ -11,7 +11,7 @@
  */
 
 import { CodeBuddyMessage } from '../codebuddy/client.js';
-import { TokenCounter } from './token-counter.js';
+import { estimateImageUrlTokens, TokenCounter } from './token-counter.js';
 import {
   CompressionResult,
   ContentType,
@@ -876,10 +876,14 @@ export class EnhancedContextCompressor {
   private countTokens(messages: CodeBuddyMessage[]): number {
     const tokenMessages = messages.map(msg => ({
       role: msg.role,
-      content: typeof msg.content === 'string' ? msg.content : null,
+      content: typeof msg.content === 'string' || Array.isArray(msg.content) ? msg.content : null,
       tool_calls: 'tool_calls' in msg ? msg.tool_calls : undefined,
     }));
-    return this.tokenCounter.countMessageTokens(tokenMessages);
+    const imageTokens = messages.reduce(
+      (total, message) => total + estimateImageUrlTokens(message.content),
+      0,
+    );
+    return this.tokenCounter.countMessageTokens(tokenMessages) + imageTokens;
   }
 
   /**

--- a/src/context/token-counter.ts
+++ b/src/context/token-counter.ts
@@ -29,6 +29,28 @@ export type { TokenCounterMessage } from '../utils/token-counter.js';
 /** Re-exported for callers that used the context/ interface name. */
 export type TokenCounter = CanonicalTokenCounter;
 
+/** Conservative context-budget estimate for one OpenAI-style image part. */
+export const IMAGE_URL_TOKEN_ESTIMATE = 1100;
+
+/** Count the fixed token budget contributed by multimodal `image_url` parts. */
+export function estimateImageUrlTokens(content: unknown): number {
+  if (!Array.isArray(content)) return 0;
+
+  let imageCount = 0;
+  for (const part of content) {
+    if (!part || typeof part !== 'object') continue;
+    const candidate = part as { type?: unknown; image_url?: unknown };
+    if (candidate.type !== 'image_url' || !candidate.image_url || typeof candidate.image_url !== 'object') {
+      continue;
+    }
+    const imageUrl = candidate.image_url as { url?: unknown };
+    if (typeof imageUrl.url === 'string' && imageUrl.url.length > 0) {
+      imageCount++;
+    }
+  }
+  return imageCount * IMAGE_URL_TOKEN_ESTIMATE;
+}
+
 /**
  * Create a token counter instance.
  * Returns the canonical lazy-loaded counter from utils/token-counter.ts
@@ -103,6 +125,7 @@ function tokensForMessage(message: TokenCounterMessage, model: string): number {
           n += countTokens((part as { text: string }).text, model);
         }
       }
+      n += estimateImageUrlTokens(message.content);
     }
   }
   if (message.tool_calls) {

--- a/src/context/transcript-repair.ts
+++ b/src/context/transcript-repair.ts
@@ -96,6 +96,7 @@ export function repairToolCallPairs(messages: CodeBuddyMessage[]): CodeBuddyMess
           result.push({
             role: 'tool',
             tool_call_id: tc.id,
+            name: tc.function.name,
             content: '[result lost during compaction]',
           } as CodeBuddyMessage);
           injectedSynthetics++;

--- a/src/services/prompt-builder.ts
+++ b/src/services/prompt-builder.ts
@@ -81,6 +81,8 @@ const ALL_BLOCKS: Required<BuildOptions> = {
   includeVariation: true,
 };
 
+const CODING_STYLE_CACHE_TTL_MS = 10 * 60 * 1000;
+
 const EXTERNAL_PROMPT_MANAGER_TOOLS = [
   'view_file',
   'str_replace_editor',
@@ -120,6 +122,7 @@ export class PromptBuilder {
    * re-injected when a tool later touches a file in the same tree.
    */
   private contextRegistry: ContextRegistry | null = null;
+  private codingStyleCache: { cwd: string; styleBlock: string; analyzedAt: number } | null = null;
 
   constructor(
     private config: PromptBuilderConfig,
@@ -690,15 +693,25 @@ Output formatting discipline:
       // Inject auto-detected coding style conventions
       if (gates.includeCodingStyle) {
         try {
-          const { getCodingStyleAnalyzer } = await import('../memory/coding-style-analyzer.js');
-          const analyzer = getCodingStyleAnalyzer();
-          const profile = await analyzer.analyzeDirectory(this.config.cwd);
-          if (profile) {
-            const styleBlock = analyzer.buildPromptSnippet(profile);
-            if (styleBlock) {
-              systemPrompt += `\n\n${styleBlock}`;
-              logger.debug('Injected coding style conventions into system prompt');
-            }
+          const now = Date.now();
+          const cached = this.codingStyleCache;
+          let styleBlock: string;
+          if (
+            cached &&
+            cached.cwd === this.config.cwd &&
+            now - cached.analyzedAt < CODING_STYLE_CACHE_TTL_MS
+          ) {
+            styleBlock = cached.styleBlock;
+          } else {
+            const { getCodingStyleAnalyzer } = await import('../memory/coding-style-analyzer.js');
+            const analyzer = getCodingStyleAnalyzer();
+            const profile = await analyzer.analyzeDirectory(this.config.cwd);
+            styleBlock = profile ? analyzer.buildPromptSnippet(profile) : '';
+            this.codingStyleCache = { cwd: this.config.cwd, styleBlock, analyzedAt: now };
+          }
+          if (styleBlock) {
+            systemPrompt += `\n\n${styleBlock}`;
+            logger.debug('Injected coding style conventions into system prompt');
           }
         } catch { /* coding-style module optional */ }
       }

--- a/tests/codebuddy/client-provider-fallback.test.ts
+++ b/tests/codebuddy/client-provider-fallback.test.ts
@@ -118,6 +118,39 @@ describe('CodeBuddyClient provider fallback', () => {
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
 
+  it('does not start a chat fallback after caller cancellation', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    mockCreate.mockRejectedValueOnce(error);
+
+    const client = new CodeBuddyClient('primary-key', 'grok-code-fast-1', 'https://api.x.ai/v1', {
+      fallbackProviders: [
+        {
+          provider: 'openai',
+          label: 'OpenAI',
+          apiMode: 'openai-compatible',
+          authMode: 'api-key',
+          apiKey: 'fallback-openai-key',
+          baseURL: 'https://api.openai.com/v1',
+          defaultModel: 'gpt-4o',
+          source: 'override',
+          model: 'gpt-4o',
+          rawSpec: 'openai:gpt-4o',
+          fallbackSource: 'environment',
+        },
+      ],
+    });
+
+    await expect(client.chat(
+      [{ role: 'user', content: 'hello' }],
+      [],
+      { signal: controller.signal },
+    )).rejects.toMatchObject({ name: 'AbortError' });
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
   it('tries same-provider credential pools before cross-provider fallbacks', async () => {
     const markFailed = vi.fn();
     const markSuccess = vi.fn();
@@ -264,5 +297,40 @@ describe('CodeBuddyClient provider fallback', () => {
 
     expect(chunks).toHaveLength(1);
     expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a stream fallback after caller cancellation', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    mockCreate.mockRejectedValueOnce(error);
+
+    const client = new CodeBuddyClient('primary-key', 'grok-code-fast-1', 'https://api.x.ai/v1', {
+      fallbackProviders: [
+        {
+          provider: 'openai',
+          label: 'OpenAI',
+          apiMode: 'openai-compatible',
+          authMode: 'api-key',
+          apiKey: 'fallback-openai-key',
+          baseURL: 'https://api.openai.com/v1',
+          defaultModel: 'gpt-4o',
+          source: 'override',
+          model: 'gpt-4o',
+          rawSpec: 'openai:gpt-4o',
+          fallbackSource: 'environment',
+        },
+      ],
+    });
+
+    await expect(async () => {
+      for await (const _chunk of client.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        [],
+        { signal: controller.signal },
+      )) { /* drain */ }
+    }).rejects.toMatchObject({ name: 'AbortError' });
+    expect(mockCreate).toHaveBeenCalledOnce();
   });
 });

--- a/tests/codebuddy/providers/provider-gemini-native-body.test.ts
+++ b/tests/codebuddy/providers/provider-gemini-native-body.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ChatOptions,
+  CodeBuddyMessage,
+  CodeBuddyTool,
+} from '../../../src/codebuddy/client.js';
+import { GeminiNativeProvider } from '../../../src/codebuddy/providers/provider-gemini-native.js';
+
+interface GeminiRequestBody {
+  contents?: Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+  systemInstruction?: { parts: Array<{ text: string }> };
+}
+
+function buildBody(
+  provider: GeminiNativeProvider,
+  messages: CodeBuddyMessage[],
+  tools?: CodeBuddyTool[],
+  opts?: ChatOptions,
+): GeminiRequestBody {
+  const buildGeminiBody = (
+    provider as unknown as {
+      buildGeminiBody: (
+        inputMessages: CodeBuddyMessage[],
+        inputTools?: CodeBuddyTool[],
+        inputOpts?: ChatOptions,
+      ) => Record<string, unknown>;
+    }
+  ).buildGeminiBody.bind(provider);
+
+  return buildGeminiBody(messages, tools, opts) as GeminiRequestBody;
+}
+
+function createProvider(): GeminiNativeProvider {
+  return new GeminiNativeProvider({
+    apiKey: 'test-key',
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+    model: 'gemini-2.5-flash',
+    defaultMaxTokens: 8192,
+    geminiRequestTimeoutMs: 60_000,
+  });
+}
+
+describe('GeminiNativeProvider request body', () => {
+  it('preserves every system message as a separate systemInstruction part', () => {
+    const body = buildBody(createProvider(), [
+      { role: 'system', content: 'main execution rules' },
+      { role: 'system', content: '<context type="lessons">lessons</context>' },
+      { role: 'system', content: '<context type="todo">todo</context>' },
+      { role: 'user', content: 'continue' },
+    ]);
+
+    expect(body.systemInstruction?.parts).toEqual([
+      { text: 'main execution rules' },
+      { text: '<context type="lessons">lessons</context>' },
+      { text: '<context type="todo">todo</context>' },
+    ]);
+  });
+
+  it('drops an orphan function response', () => {
+    const body = buildBody(createProvider(), [
+      { role: 'user', content: 'continue' },
+      {
+        role: 'tool',
+        tool_call_id: 'call-orphan',
+        name: 'read_file',
+        content: 'orphaned result',
+      } as unknown as CodeBuddyMessage,
+    ]);
+
+    const parts = body.contents?.flatMap(content => content.parts) ?? [];
+    expect(parts.some(part => 'functionResponse' in part)).toBe(false);
+    expect(body.contents?.map(content => content.role)).toEqual(['user']);
+  });
+
+  it('inserts a user turn when the transcript starts with the model', () => {
+    const body = buildBody(createProvider(), [
+      { role: 'assistant', content: 'previous answer' },
+    ]);
+
+    expect(body.contents?.map(content => content.role)).toEqual(['user', 'model']);
+    expect(body.contents?.[0]?.parts).toEqual([
+      { text: '(continuing previous conversation)' },
+    ]);
+  });
+});

--- a/tests/codebuddy/providers/provider-openai-compat.test.ts
+++ b/tests/codebuddy/providers/provider-openai-compat.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const providerMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  getModelInfo: vi.fn(() => ({ provider: 'xai' })),
+}));
+
+vi.mock('openai', () => {
+  class MockOpenAI {
+    chat = { completions: { create: providerMocks.create } };
+  }
+
+  return { default: MockOpenAI };
+});
+
+vi.mock('../../../src/utils/model-utils.js', () => ({
+  getModelInfo: providerMocks.getModelInfo,
+}));
+
+vi.mock('../../../src/utils/retry.js', () => ({
+  retry: vi.fn((fn: () => Promise<unknown>) => fn()),
+  RetryStrategies: { llmApi: {} },
+  RetryPredicates: { llmApiError: vi.fn(() => false) },
+}));
+
+vi.mock('../../../src/agent/extended-thinking.js', () => ({
+  getExtendedThinking: () => ({ getThinkingConfig: () => ({}) }),
+}));
+
+import { OpenAICompatProvider } from '../../../src/codebuddy/providers/provider-openai-compat.js';
+
+function createProvider(): OpenAICompatProvider {
+  return new OpenAICompatProvider({
+    apiKey: 'test-key',
+    baseURL: 'https://api.x.ai/v1',
+    model: 'grok-code-fast-1',
+    defaultMaxTokens: 8192,
+    getCircuitBreakerConfig: () => undefined,
+  });
+}
+
+function successResponse() {
+  return {
+    choices: [{
+      message: { role: 'assistant', content: 'ok' },
+      finish_reason: 'stop',
+    }],
+  };
+}
+
+async function* successStream() {
+  yield {
+    id: 'chunk-1',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'grok-code-fast-1',
+    choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: null }],
+  };
+}
+
+beforeEach(() => {
+  providerMocks.create.mockReset();
+  providerMocks.getModelInfo.mockReset().mockReturnValue({ provider: 'xai' });
+});
+
+describe('OpenAICompatProvider request payloads', () => {
+  it('omits tools and tool_choice from non-streaming requests without tools', async () => {
+    providerMocks.create.mockResolvedValueOnce(successResponse());
+
+    await createProvider().chat([{ role: 'user', content: 'hello' }], []);
+
+    const payload = providerMocks.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('tools');
+    expect(payload).not.toHaveProperty('tool_choice');
+  });
+
+  it('omits tools and tool_choice from streaming requests without tools', async () => {
+    providerMocks.create.mockResolvedValueOnce(successStream());
+
+    for await (const _chunk of createProvider().chatStream(
+      [{ role: 'user', content: 'hello' }],
+      [],
+    )) { /* drain */ }
+
+    const payload = providerMocks.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('tools');
+    expect(payload).not.toHaveProperty('tool_choice');
+  });
+});

--- a/tests/codebuddy/providers/provider-openai-compat.test.ts
+++ b/tests/codebuddy/providers/provider-openai-compat.test.ts
@@ -87,3 +87,48 @@ describe('OpenAICompatProvider request payloads', () => {
     expect(payload).not.toHaveProperty('tool_choice');
   });
 });
+
+describe('OpenAICompatProvider tool-support probe', () => {
+  it('re-probes after a transient failure instead of caching false', async () => {
+    providerMocks.getModelInfo.mockReturnValue({ provider: 'unknown' });
+    const networkError = new Error('socket hang up');
+    Object.assign(networkError, { code: 'ECONNRESET' });
+    providerMocks.create
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({
+        choices: [{
+          message: {
+            tool_calls: [{ id: 'call-1', function: { name: 'get_current_time', arguments: '{}' } }],
+          },
+        }],
+      });
+    const provider = createProvider('https://example.test/v1', 'plain-model-a');
+
+    await expect(provider.probeToolSupport()).resolves.toBe(false);
+    await expect(provider.probeToolSupport()).resolves.toBe(true);
+
+    expect(providerMocks.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the cached result when the model changes', async () => {
+    providerMocks.getModelInfo.mockReturnValue({ provider: 'unknown' });
+    providerMocks.create
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'no tool call' } }] })
+      .mockResolvedValueOnce({
+        choices: [{
+          message: {
+            tool_calls: [{ id: 'call-2', function: { name: 'get_current_time', arguments: '{}' } }],
+          },
+        }],
+      });
+    const provider = createProvider('https://example.test/v1', 'plain-model-a');
+
+    await expect(provider.probeToolSupport()).resolves.toBe(false);
+    provider.setModel('plain-model-b');
+    await expect(provider.probeToolSupport()).resolves.toBe(true);
+
+    expect(providerMocks.create).toHaveBeenCalledTimes(2);
+    expect((providerMocks.create.mock.calls[1]?.[0] as Record<string, unknown>).model)
+      .toBe('plain-model-b');
+  });
+});

--- a/tests/codebuddy/providers/provider-openai-compat.test.ts
+++ b/tests/codebuddy/providers/provider-openai-compat.test.ts
@@ -29,11 +29,14 @@ vi.mock('../../../src/agent/extended-thinking.js', () => ({
 
 import { OpenAICompatProvider } from '../../../src/codebuddy/providers/provider-openai-compat.js';
 
-function createProvider(): OpenAICompatProvider {
+function createProvider(
+  baseURL = 'https://api.x.ai/v1',
+  model = 'grok-code-fast-1',
+): OpenAICompatProvider {
   return new OpenAICompatProvider({
     apiKey: 'test-key',
-    baseURL: 'https://api.x.ai/v1',
-    model: 'grok-code-fast-1',
+    baseURL,
+    model,
     defaultMaxTokens: 8192,
     getCircuitBreakerConfig: () => undefined,
   });

--- a/tests/codebuddy/providers/provider-openai-compat.test.ts
+++ b/tests/codebuddy/providers/provider-openai-compat.test.ts
@@ -132,3 +132,42 @@ describe('OpenAICompatProvider tool-support probe', () => {
       .toBe('plain-model-b');
   });
 });
+
+describe('OpenAICompatProvider local transcript conversion', () => {
+  it('normalizes tool messages in non-streaming chat requests', async () => {
+    providerMocks.getModelInfo.mockReturnValue({ provider: 'lmstudio' });
+    providerMocks.create.mockResolvedValueOnce(successResponse());
+    const messages = [
+      { role: 'user', content: 'read the file' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'read_file', arguments: '{"path":"a.ts"}' },
+        }],
+      },
+      { role: 'tool', tool_call_id: 'call-1', name: 'read_file', content: 'file contents' },
+    ];
+
+    await createProvider('http://127.0.0.1:1234/v1', 'plain-local').chat(
+      messages as Parameters<OpenAICompatProvider['chat']>[0],
+      [],
+    );
+
+    const payload = providerMocks.create.mock.calls[0]?.[0] as {
+      messages: Array<{ role: string; content: string | null; tool_calls?: unknown[] }>;
+    };
+    expect(payload.messages.every(message => message.role !== 'tool')).toBe(true);
+    expect(payload.messages[1]).toMatchObject({
+      role: 'assistant',
+      content: '[Tools Used]\nCalled read_file({"path":"a.ts"})',
+    });
+    expect(payload.messages[1]).not.toHaveProperty('tool_calls');
+    expect(payload.messages[2]).toEqual({
+      role: 'user',
+      content: '[Tool Result]\nfile contents',
+    });
+  });
+});

--- a/tests/context/context-manager-v2-gaps.test.ts
+++ b/tests/context/context-manager-v2-gaps.test.ts
@@ -9,6 +9,7 @@
 import { ContextManagerV2, createContextManager } from '../../src/context/context-manager-v2';
 import type { CodeBuddyMessage } from '../../src/codebuddy/client';
 import { RunStore } from '../../src/observability/run-store';
+import { IMAGE_URL_TOKEN_ESTIMATE } from '../../src/context/token-counter.js';
 
 describe('ContextManagerV2 (gap coverage)', () => {
   // Helper: create a manager with small limits for fast tests
@@ -289,6 +290,30 @@ describe('ContextManagerV2 (gap coverage)', () => {
   // --------------------------------------------------------------------------
   // shouldAutoCompact()
   // --------------------------------------------------------------------------
+
+  describe('multimodal token counting', () => {
+    it('counts text parts and a conservative budget for each image_url part', () => {
+      const mgr = createManager({ autoCompactThreshold: 999999 });
+      const textOnly = [{
+        role: 'user',
+        content: [{ type: 'text', text: 'describe this image' }],
+      }] as unknown as CodeBuddyMessage[];
+      const withImage = [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe this image' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      }] as unknown as CodeBuddyMessage[];
+
+      const textTokens = mgr.countTokens(textOnly);
+      const multimodalTokens = mgr.countTokens(withImage);
+
+      expect(textTokens).toBeGreaterThan(0);
+      expect(multimodalTokens - textTokens).toBeGreaterThanOrEqual(IMAGE_URL_TOKEN_ESTIMATE);
+      mgr.dispose();
+    });
+  });
 
   describe('shouldAutoCompact()', () => {
     it('should return true when tokens exceed autoCompactThreshold', () => {

--- a/tests/context/enhanced-compression.test.ts
+++ b/tests/context/enhanced-compression.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { CodeBuddyMessage } from '../../src/codebuddy/client.js';
+import { EnhancedContextCompressor } from '../../src/context/enhanced-compression.js';
+import { createTokenCounter } from '../../src/context/token-counter.js';
+
+describe('EnhancedContextCompressor', () => {
+  it('preserves every system message in order during compression', () => {
+    const compressor = new EnhancedContextCompressor(createTokenCounter('gpt-4'), {
+      enableArchiving: false,
+      slidingWindow: {
+        windowSize: 3,
+        overlapSize: 1,
+        summarizeOldMessages: false,
+      },
+    });
+    const messages: CodeBuddyMessage[] = [
+      { role: 'system', content: 'base prompt' },
+      { role: 'system', content: '<context type="lessons">rule A</context>' },
+      { role: 'system', content: '<context type="todo">next step</context>' },
+    ];
+    for (let index = 0; index < 20; index++) {
+      messages.push({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `turn ${index}: ${'x'.repeat(160)}`,
+      });
+    }
+
+    const result = compressor.compress(messages, 180);
+    const systemContents = result.messages
+      .filter(message => message.role === 'system')
+      .map(message => message.content);
+
+    expect(result.compressed).toBe(true);
+    expect(systemContents).toEqual([
+      'base prompt',
+      '<context type="lessons">rule A</context>',
+      '<context type="todo">next step</context>',
+    ]);
+    expect(result.messages.slice(0, 3).every(message => message.role === 'system')).toBe(true);
+  });
+});

--- a/tests/context/enhanced-compression.test.ts
+++ b/tests/context/enhanced-compression.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import type { CodeBuddyMessage } from '../../src/codebuddy/client.js';
 import { EnhancedContextCompressor } from '../../src/context/enhanced-compression.js';
-import { createTokenCounter } from '../../src/context/token-counter.js';
+import {
+  createTokenCounter,
+  IMAGE_URL_TOKEN_ESTIMATE,
+} from '../../src/context/token-counter.js';
 
 describe('EnhancedContextCompressor', () => {
+  it('includes image_url parts in original token metrics', () => {
+    const compressor = new EnhancedContextCompressor(createTokenCounter('gpt-4'), {
+      enableArchiving: false,
+    });
+    const textOnly = [{
+      role: 'user',
+      content: [{ type: 'text', text: 'describe this image' }],
+    }] as unknown as CodeBuddyMessage[];
+    const withImage = [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'describe this image' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+      ],
+    }] as unknown as CodeBuddyMessage[];
+
+    const textResult = compressor.compress(textOnly, 100_000);
+    const imageResult = compressor.compress(withImage, 100_000);
+
+    expect(imageResult.metrics.originalTokens - textResult.metrics.originalTokens)
+      .toBeGreaterThanOrEqual(IMAGE_URL_TOKEN_ESTIMATE);
+  });
+
   it('preserves every system message in order during compression', () => {
     const compressor = new EnhancedContextCompressor(createTokenCounter('gpt-4'), {
       enableArchiving: false,

--- a/tests/context/transcript-repair.test.ts
+++ b/tests/context/transcript-repair.test.ts
@@ -85,6 +85,7 @@ describe('repairToolCallPairs', () => {
     );
     expect(syntheticResult).toBeDefined();
     expect(syntheticResult!.content).toBe('[result lost during compaction]');
+    expect((syntheticResult as { name?: string }).name).toBe('read_file');
   });
 
   it('should handle both orphaned results and missing results simultaneously', () => {

--- a/tests/services/prompt-builder.test.ts
+++ b/tests/services/prompt-builder.test.ts
@@ -70,6 +70,18 @@ vi.mock('../../src/identity/identity-manager.js', () => ({
   }),
 }));
 
+const codingStyleMocks = vi.hoisted(() => ({
+  analyzeDirectoryMock: vi.fn(async () => ({ language: 'typescript' })),
+  buildPromptSnippetMock: vi.fn(() => '<coding_style>use single quotes</coding_style>'),
+}));
+
+vi.mock('../../src/memory/coding-style-analyzer.js', () => ({
+  getCodingStyleAnalyzer: () => ({
+    analyzeDirectory: codingStyleMocks.analyzeDirectoryMock,
+    buildPromptSnippet: codingStyleMocks.buildPromptSnippetMock,
+  }),
+}));
+
 // ---- imports under test (after mocks) --------------------------------
 
 import {
@@ -188,6 +200,12 @@ describe('PromptBuilder — Phase T4', () => {
       .mockReturnValue({ contextWindow: 128_000, maxOutputTokens: 8_000 });
     identityMock.loadMock.mockReset().mockResolvedValue([]);
     identityMock.getPromptInjectionMock.mockReset().mockReturnValue('');
+    codingStyleMocks.analyzeDirectoryMock
+      .mockReset()
+      .mockResolvedValue({ language: 'typescript' });
+    codingStyleMocks.buildPromptSnippetMock
+      .mockReset()
+      .mockReturnValue('<coding_style>use single quotes</coding_style>');
   });
 
   afterEach(() => {
@@ -775,6 +793,21 @@ describe('PromptBuilder — Phase T4', () => {
       const lastCall = promptMocks.getSystemPromptForModeMock.mock.calls.at(-1)!;
       expect(lastCall[0]).toBe('yolo');
       expect(lastCall[3]).toBe('extra');
+    });
+  });
+
+  describe('coding style cache', () => {
+    it('scans a cwd only once across successive prompt builds', async () => {
+      const { builder } = buildBuilder({ config: { cwd: '/tmp/project-a' } });
+
+      const first = await builder.buildSystemPrompt(undefined, 'grok-3', null);
+      const second = await builder.buildSystemPrompt(undefined, 'grok-3', null);
+
+      expect(first).toContain('<coding_style>use single quotes</coding_style>');
+      expect(second).toContain('<coding_style>use single quotes</coding_style>');
+      expect(codingStyleMocks.analyzeDirectoryMock).toHaveBeenCalledOnce();
+      expect(codingStyleMocks.analyzeDirectoryMock).toHaveBeenCalledWith('/tmp/project-a');
+      expect(codingStyleMocks.buildPromptSnippetMock).toHaveBeenCalledOnce();
     });
   });
 

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -659,12 +659,11 @@ describe('CodeBuddyClient', () => {
 
       await client.chat(messages, tools);
 
-      // Tools should be empty for local inference
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tools: [],
-        })
-      );
+      // Tools are disabled for local inference: the payload omits `tools`
+      // entirely (an empty array would still be rejected by some runtimes).
+      const localPayload = mockCreate.mock.calls.at(-1)?.[0];
+      expect(localPayload).toBeDefined();
+      expect(localPayload).not.toHaveProperty('tools');
     });
 
     it('should enable tools when GROK_FORCE_TOOLS is set', async () => {
@@ -1032,11 +1031,10 @@ describe('CodeBuddyClient', () => {
 
       await client.chat([{ role: 'user', content: 'Hi' }], []);
 
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tools: [],
-        })
-      );
+      // An empty tools array is omitted from the payload.
+      const emptyToolsPayload = mockCreate.mock.calls.at(-1)?.[0];
+      expect(emptyToolsPayload).toBeDefined();
+      expect(emptyToolsPayload).not.toHaveProperty('tools');
     });
 
     it('should handle null content in assistant message', async () => {

--- a/tests/unit/codebuddy-client.test.ts
+++ b/tests/unit/codebuddy-client.test.ts
@@ -1535,9 +1535,8 @@ describe('CodeBuddyClient', () => {
 
       await client.chat([{ role: 'user', content: 'Hi' }], tools);
 
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ tools: [] })
-      );
+      const payload = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(payload).not.toHaveProperty('tools');
     });
 
     it('should enable tools when GROK_FORCE_TOOLS is set for LM Studio', async () => {


### PR DESCRIPTION
## Contenu (découpe du lot b « providers/context » de la PR #68, re-portée sur `main` actuel)

Ce lot extrait et porte les correctifs de la zone providers et context issus de l'audit Fable 5 batch 1 (#68).

### Tableau des fixes

| Fix d'origine (#68) | SHA d'origine | Statut | Détails |
|---|---|---|---|
| `fix(context): preserve system messages in enhanced compression` | `6b6eec45` | **Porté** | Préserve l'intégralité des messages système (au lieu du premier uniquement) lors de la compression de contexte. |
| `perf(context): cache coding style prompt analysis` | `a069f5bb` | **Porté** | Cache l'analyse du style de code par répertoire de travail (TTL 10 min) dans le PromptBuilder. |
| `fix(providers): omit empty tool payloads` | `0ffaf660` | **Porté** | Omet les propriétés `tools` et `tool_choice` quand aucun outil n'est activé (évite les erreurs 400 sur backends stricts / inférence locale). |
| `fix(providers): refresh tool support probes` | `42470952` | **Porté** | Réinitialise la sonde d'outils au changement de modèle (`setModel`) et ne met en cache que les erreurs 400/422 (pas les erreurs réseau transitoires). |
| `fix(context): count multimodal images in context usage` | `64db4573` | **Porté** | Compte forfaitairement les images (`image_url`, 1100 tokens) dans le `TokenCounter`, `ContextManagerV2` et la compression de contexte. |
| `fix(context): preserve tool names in transcript repair` | `3977805b` | **Porté** | Préserve `name: tc.function.name` sur les résultats d'outils synthétiques injectés par la réparation de transcript. |
| `fix(providers): align provider request transformations` | `36ee15bd` | **Porté** | Normalise les messages d'outils pour modèles locaux en mode non-streaming `chat()` (aligné avec `chatStream()`) + tests Gemini body. |
| `fix(providers): propagate barge-in cancellation` | `3c30c61d` | **Porté (adapté)** | Transports Gemini native et ChatGPT Responses déjà sur main ; complété avec gestion `opts.signal?.aborted` dans `client.ts` pour empêcher les fallbacks intempestifs sur annulation. |
| `fix(providers): preserve Gemini system instructions` | `7719c1b7` | **Déjà sur main** | Code déjà intégré (`systemInstruction.parts.push`) ; tests de non-régression ajoutés. |
| `fix(providers): adapt OpenAI reasoning parameters` | `76c482d8` | **Déjà sur main** | Porté via PR #99 (`ccfe4cc0`). |
| `fix(providers): surface ChatGPT Responses usage` | `a4c51b8d` | **Déjà sur main** | Porté via PR #99 (`72090dec`). |

## Vérifications

- `npx tsc --noEmit` : **0 erreur**
- `npx eslint <fichiers>` : **0 erreur**
- `npx vitest run tests/codebuddy tests/context tests/services/prompt-builder.test.ts tests/unit/codebuddy-client.test.ts` : **59 fichiers / 993 tests passés** (vs 55 fichiers / 868 tests avant).