### PR TITLE
feat(mcp): outils CKG via MCP + first-run ChatGPT (découpe de #70)

### DIFF
--- a/src/cli/first-run.ts
+++ b/src/cli/first-run.ts
@@ -1,0 +1,52 @@
+/** Focused recovery UX for an interactive launch with no usable provider. */
+
+export const FIRST_RUN_LOGIN_PROMPT =
+  '\nNo AI provider configured. Sign in with ChatGPT now (OAuth, no API key, $0 marginal cost with your plan)? [Y/n] ';
+
+export const NO_PROVIDER_GUIDANCE = [
+  '❌ No AI provider configured.',
+  '   1. Recommended — ChatGPT OAuth (no API key, $0 marginal cost with your plan):',
+  '      buddy login',
+  '   2. Local & free — start Ollama and install a coding model:',
+  '      ollama pull qwen2.5-coder:7b',
+  '      export OLLAMA_HOST=http://localhost:11434',
+  '   3. More providers — run the full wizard or configure an API key:',
+  '      buddy onboard',
+  '      GROK_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY',
+  '   After option 1 or 2, run  buddy try  for the one-minute coding demo.',
+  '   Check anytime:  buddy doctor   (add --fix to auto-configure a running Ollama).',
+].join('\n');
+
+export function acceptsRecommendedLogin(answer: string): boolean {
+  const normalized = answer.trim();
+  return normalized === '' || /^y(?:es)?$/i.test(normalized);
+}
+
+export interface FirstRunLoginOptions<T> {
+  interactive: boolean;
+  ask: (question: string) => Promise<string>;
+  login: () => Promise<void>;
+  reloadProvider: () => Promise<T | null>;
+  onLoginError?: (error: unknown) => void;
+}
+
+/**
+ * Offer the shortest recommended setup path and return the freshly resolved
+ * provider state. Declining or a failed OAuth flow leaves normal diagnostics
+ * to the caller.
+ */
+export async function recoverFirstRunWithChatGpt<T>(
+  options: FirstRunLoginOptions<T>,
+): Promise<T | null> {
+  if (!options.interactive) return null;
+  const answer = await options.ask(FIRST_RUN_LOGIN_PROMPT);
+  if (!acceptsRecommendedLogin(answer)) return null;
+
+  try {
+    await options.login();
+    return await options.reloadProvider();
+  } catch (error) {
+    options.onLoginError?.(error);
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import {
 } from './cli/command-routing.js';
 import { resolveHeadlessOutputFormat, resolveHeadlessResultExitCode } from './cli/headless-options.js';
 import { resolveCliModelList } from './cli/model-listing.js';
+import {
+  NO_PROVIDER_GUIDANCE,
+  recoverFirstRunWithChatGpt,
+} from './cli/first-run.js';
 
 // Read version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -1718,51 +1722,59 @@ program
       const maxToolRounds = parseInt(options.maxToolRounds) || 400;
 
       if (!apiKey) {
-        // In an interactive terminal, offer the guided setup wizard right here
-        // (like Hermes) instead of dead-ending on an error — then continue the
-        // session with the credentials it captured.
+        // The shortest first-run path is a direct ChatGPT OAuth login. Keep the
+        // full wizard available, but do not make a new user navigate provider,
+        // model, and TTS choices before seeing the coding agent work.
         const interactive =
           Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY) &&
           !options.prompt && !options.print &&
           process.env.CI !== 'true' && process.env.GITHUB_ACTIONS !== 'true';
 
-        let recovered = false;
-        if (interactive) {
-          const readline = await import('readline');
-          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-          const answer: string = await new Promise((resolve) =>
-            rl.question('\n❔ No AI provider configured. Run guided setup now? [Y/n] ', resolve)
-          );
-          rl.close();
-          const yes = answer.trim() === '' || /^y(es)?$/i.test(answer.trim());
-          if (yes) {
+        const recoveredProvider = await recoverFirstRunWithChatGpt({
+          interactive,
+          ask: async (question) => {
+            const readline = await import('readline');
+            const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
             try {
-              const { runOnboarding } = await import('./wizard/onboarding.js');
-              const result = await runOnboarding();
-              // Bust the cached provider detection so the just-saved creds resolve.
-              cachedProvider = undefined;
-              apiKey = options.apiKey || await loadApiKey();
-              baseURL = options.baseUrl || await loadBaseURL();
-              model = options.model || result.model || await loadModel();
-              recovered = Boolean(apiKey);
-            } catch (err) {
-              logger.error('Guided setup did not complete', err instanceof Error ? err : { error: String(err) });
+              return await new Promise<string>((resolve) => rl.question(question, resolve));
+            } finally {
+              rl.close();
             }
-          }
+          },
+          login: async () => {
+            const { loginInteractive } = await import('./providers/codex-oauth.js');
+            cli.stdout('\n🔐 ChatGPT login — opening your browser…');
+            const auth = await loginInteractive();
+            cli.stdout(`✅ Authenticated${auth.email ? ` as ${auth.email}` : ''}. Starting Code Buddy…`);
+          },
+          reloadProvider: async () => {
+            // Bust provider detection so the OAuth file written moments ago is
+            // immediately visible to this same process.
+            cachedProvider = undefined;
+            const nextApiKey = options.apiKey || await loadApiKey();
+            if (!nextApiKey) return null;
+            return {
+              apiKey: nextApiKey,
+              baseURL: options.baseUrl || await loadBaseURL(),
+              model: options.model || await loadModel(),
+            };
+          },
+          onLoginError: (err) => {
+            logger.error(
+              'ChatGPT login did not complete',
+              err instanceof Error ? err : { error: String(err) },
+            );
+          },
+        });
+
+        if (recoveredProvider) {
+          apiKey = recoveredProvider.apiKey;
+          baseURL = recoveredProvider.baseURL;
+          model = recoveredProvider.model;
         }
 
-        if (!recovered) {
-          logger.error(
-            [
-              "❌ No AI provider configured yet. Fastest ways to start — no env var to edit:",
-              "   • 60-second demo, zero config — just run:               buddy try",
-              "   • Guided setup (recommended) — interactive wizard:      buddy onboard",
-              "   • Free, no API key — sign in with your ChatGPT plan:    buddy login",
-              "   • Local & free — install Ollama, then let onboard use it: buddy onboard",
-              "   • API key — set GROK_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY (or pass --api-key)",
-              "   Check anytime:  buddy doctor   (add --fix to auto-configure a running Ollama).",
-            ].join("\n")
-          );
+        if (!recoveredProvider) {
+          logger.error(NO_PROVIDER_GUIDANCE);
           process.exit(1);
         }
       }
@@ -2334,17 +2346,7 @@ gitCommand
       const maxToolRounds = parseInt(options.maxToolRounds) || 400;
 
       if (!apiKey) {
-        logger.error(
-          [
-            "❌ No AI provider configured yet. Fastest ways to start — no env var to edit:",
-            "   • 60-second demo, zero config — just run:               buddy try",
-            "   • Guided setup (recommended) — interactive wizard:      buddy onboard",
-            "   • Free, no API key — sign in with your ChatGPT plan:    buddy login",
-            "   • Local & free — install Ollama, then let onboard use it: buddy onboard",
-            "   • API key — set GROK_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY (or pass --api-key)",
-            "   Check anytime:  buddy doctor   (add --fix to auto-configure a running Ollama).",
-          ].join("\n")
-        );
+        logger.error(NO_PROVIDER_GUIDANCE);
         process.exit(1);
       }
 

--- a/src/mcp/mcp-ckg-tools.ts
+++ b/src/mcp/mcp-ckg-tools.ts
@@ -1,0 +1,138 @@
+/**
+ * MCP CKG Tools — expose the Collective Knowledge Graph to any MCP client.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * `mcp-memory-tools.ts` already exposes `memory_search`/`memory_save`, but those
+ * reach the PER-SESSION persistent memory (`persistent-memory.ts`) — one agent's
+ * notes. The Collective Knowledge Graph is a different thing: the SHARED,
+ * cross-agent memory, with bi-temporal supersede, cross-agent corroboration (a
+ * fact several independent agents assert gains confidence) and hybrid recall
+ * (embeddings + keyword + salience + MMR, no LLM at retrieval time).
+ *
+ * Until now it had no MCP surface at all. Every fact the fleet had accumulated was
+ * invisible to Claude Desktop, ChatGPT, or any other MCP client — the exact
+ * "one memory shared between all your tools" promise, sitting behind no door.
+ * These two tools are that door.
+ *
+ * Tools:
+ * - ckg_recall: hybrid recall over the shared graph, corroboration included
+ * - ckg_ingest: contribute a fact/lesson/decision/discovery to the shared graph
+ *
+ * NOT gated by CODEBUDDY_COLLECTIVE_MEMORY: that flag governs AUTOMATIC injection
+ * into an agent's context, which must stay opt-in. An MCP tool is called
+ * deliberately by the client — declaring it changes nothing until someone invokes
+ * it, and an empty graph simply returns no results.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const ENTITY_TYPES = ['fact', 'lesson', 'decision', 'discovery'] as const;
+
+/**
+ * Register Collective Knowledge Graph tools with the MCP server.
+ */
+export function registerCkgTools(
+  server: McpServer,
+  shouldRegister: (name: string) => boolean = () => true,
+): void {
+  // ckg_recall - hybrid recall over the shared, cross-agent graph
+  if (shouldRegister('ckg_recall')) server.tool(
+    'ckg_recall',
+    "Recall from the Collective Knowledge Graph — the memory SHARED across every agent and tool, "
+      + "as opposed to one session's private notes. Results carry how many DISTINCT agents "
+      + 'independently asserted each fact (corroboration), which is the signal to trust.',
+    {
+      query: z.string().describe('What you want to remember'),
+      limit: z.number().optional().describe('Maximum results (default: 8)'),
+      types: z.array(z.enum(ENTITY_TYPES)).optional()
+        .describe('Restrict to these node types (default: all)'),
+    },
+    async (args) => {
+      try {
+        const { getCollectiveKnowledgeGraph } = await import('../memory/collective-knowledge-graph.js');
+        const ckg = getCollectiveKnowledgeGraph();
+        const results = await ckg.recallHybrid(args.query, {
+          limit: args.limit ?? 8,
+          ...(args.types ? { types: [...args.types] } : {}),
+        });
+
+        if (results.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'Nothing in the collective graph matches that query.' }],
+          };
+        }
+
+        const formatted = results.map((r, i) => {
+          // Corroboration is the whole point of a COLLECTIVE graph, so it is stated
+          // first and in plain words — "3 agents" means three independent sources
+          // reached the same conclusion, which is not the same as one agent
+          // repeating itself three times.
+          const trust = r.corroborations > 1
+            ? `corroborated by ${r.corroborations} independent agents`
+            : 'asserted by a single agent';
+          return [
+            `## ${i + 1}. ${r.name} — ${r.type}`,
+            `**Trust:** ${trust} · confidence ${r.confidence.toFixed(2)} · salience ${r.salience.toFixed(2)}`,
+            r.agentId ? `**From:** ${r.agentId}${r.source ? ` (${r.source})` : ''}` : '',
+            '',
+            r.text,
+          ].filter(Boolean).join('\n');
+        }).join('\n\n---\n\n');
+
+        return {
+          content: [{ type: 'text' as const, text: formatted }],
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `CKG recall error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ckg_ingest - contribute to the shared graph
+  if (shouldRegister('ckg_ingest')) server.tool(
+    'ckg_ingest',
+    'Contribute a fact, lesson, decision or discovery to the Collective Knowledge Graph, so that '
+      + 'every other agent and tool can recall it. Re-stating an existing fact under the same name '
+      + 'supersedes it bi-temporally; the same fact from a different agent raises its confidence.',
+    {
+      text: z.string().describe('The statement to remember, self-contained enough to be useful out of context'),
+      type: z.enum(ENTITY_TYPES).optional().describe('Node type (default: fact)'),
+      name: z.string().optional()
+        .describe('Stable key. Same name + new text = the fact CHANGED (bi-temporal supersede). Omit to derive from the text, which dedups identical statements.'),
+      source: z.string().optional().describe("Where this came from: 'chat', 'council', 'worklog', a URL…"),
+      agent_id: z.string().optional().describe('Contributing agent, as <host>/<repo>. Defaults to this fleet agent.'),
+    },
+    async (args) => {
+      try {
+        const { getCollectiveKnowledgeGraph } = await import('../memory/collective-knowledge-graph.js');
+        const ckg = getCollectiveKnowledgeGraph();
+        const node = await ckg.ingest({
+          text: args.text,
+          ...(args.type ? { type: args.type } : {}),
+          ...(args.name ? { name: args.name } : {}),
+          ...(args.source ? { source: args.source } : {}),
+          ...(args.agent_id ? { agentId: args.agent_id } : {}),
+        });
+
+        const label = node
+          ? `Ingested "${node.name}" (${node.type}) — corroborations: ${node.corroborations}, confidence: ${node.confidence.toFixed(2)}`
+          : 'Ingested.';
+        return {
+          content: [{ type: 'text' as const, text: label }],
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `CKG ingest error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -38,6 +38,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import type { ToolResult } from '../types/index.js';
 import { registerAgentTools } from './mcp-agent-tools.js';
+import { registerCkgTools } from './mcp-ckg-tools.js';
 import { registerMemoryTools } from './mcp-memory-tools.js';
 import { registerSessionTools } from './mcp-session-tools.js';
 import { registerDesktopTools } from './mcp-desktop-tools.js';
@@ -150,6 +151,7 @@ export class CodeBuddyMCPServer {
 
     registerAgentTools(this.mcpServer, getAgent);
     registerMemoryTools(this.mcpServer);
+    registerCkgTools(this.mcpServer);
     registerSessionTools(this.mcpServer, getAgent);
     registerDesktopTools(this.mcpServer);
     registerResources(this.mcpServer);

--- a/tests/cli/first-run.test.ts
+++ b/tests/cli/first-run.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FIRST_RUN_LOGIN_PROMPT,
+  NO_PROVIDER_GUIDANCE,
+  acceptsRecommendedLogin,
+  recoverFirstRunWithChatGpt,
+} from '../../src/cli/first-run.js';
+
+describe('first-run provider recovery', () => {
+  it('puts buddy login first, Ollama second, and API keys last', () => {
+    const login = NO_PROVIDER_GUIDANCE.indexOf('buddy login');
+    const ollama = NO_PROVIDER_GUIDANCE.indexOf('Ollama');
+    const grokKey = NO_PROVIDER_GUIDANCE.indexOf('GROK_API_KEY');
+
+    expect(login).toBeGreaterThanOrEqual(0);
+    expect(login).toBeLessThan(ollama);
+    expect(ollama).toBeLessThan(grokKey);
+    expect(NO_PROVIDER_GUIDANCE).toContain('buddy try');
+    expect(NO_PROVIDER_GUIDANCE).toContain('$0 marginal cost');
+  });
+
+  it('defaults the interactive recommendation to yes', () => {
+    expect(acceptsRecommendedLogin('')).toBe(true);
+    expect(acceptsRecommendedLogin('yes')).toBe(true);
+    expect(acceptsRecommendedLogin('n')).toBe(false);
+    expect(FIRST_RUN_LOGIN_PROMPT).toContain('ChatGPT');
+  });
+
+  it('logs in and reloads provider state in the same first-run process', async () => {
+    const login = vi.fn(async () => {});
+    const reloadProvider = vi.fn(async () => ({ apiKey: 'oauth-chatgpt' }));
+
+    const recovered = await recoverFirstRunWithChatGpt({
+      interactive: true,
+      ask: async () => '',
+      login,
+      reloadProvider,
+    });
+
+    expect(recovered).toEqual({ apiKey: 'oauth-chatgpt' });
+    expect(login).toHaveBeenCalledOnce();
+    expect(reloadProvider).toHaveBeenCalledOnce();
+  });
+
+  it('does not launch OAuth when the user declines or the terminal is non-interactive', async () => {
+    const login = vi.fn(async () => {});
+    const reloadProvider = vi.fn(async () => ({ apiKey: 'oauth-chatgpt' }));
+
+    expect(await recoverFirstRunWithChatGpt({
+      interactive: true,
+      ask: async () => 'n',
+      login,
+      reloadProvider,
+    })).toBeNull();
+    expect(await recoverFirstRunWithChatGpt({
+      interactive: false,
+      ask: async () => 'yes',
+      login,
+      reloadProvider,
+    })).toBeNull();
+    expect(login).not.toHaveBeenCalled();
+    expect(reloadProvider).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mcp/mcp-agent-server.test.ts
+++ b/tests/mcp/mcp-agent-server.test.ts
@@ -211,10 +211,10 @@ describe('MCP Agent Intelligence Layer', () => {
   // =========================================================================
 
   describe('tool registration', () => {
-    it('should register all 17 tools', () => {
-      // 15 core/agent/memory/session + 2 read-only desktop tools (the 4 desktop
-      // control tools are gated behind CODEBUDDY_MCP_DESKTOP_CONTROL=1).
-      expect(registeredTools.size).toBe(17);
+    it('should register all 19 tools', () => {
+      // 15 core/agent/memory/session + 2 CKG + 2 read-only desktop tools (the 4
+      // desktop control tools are gated behind CODEBUDDY_MCP_DESKTOP_CONTROL=1).
+      expect(registeredTools.size).toBe(19);
     });
 
     it('should register agent_chat tool', () => {

--- a/tests/mcp/mcp-ckg-tools.test.ts
+++ b/tests/mcp/mcp-ckg-tools.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Minimal fake McpServer capturing server.tool(name, desc, schema, handler).
+type Handler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+class FakeServer {
+  tools = new Map<string, { description: string; schema: unknown; handler: Handler }>();
+  tool(name: string, description: string, schema: unknown, handler: Handler): void {
+    this.tools.set(name, { description, schema, handler });
+  }
+}
+
+const recallHybrid = vi.fn();
+const ingest = vi.fn();
+
+vi.mock('../../src/memory/collective-knowledge-graph.js', () => ({
+  getCollectiveKnowledgeGraph: () => ({ recallHybrid, ingest }),
+}));
+
+async function register() {
+  const { registerCkgTools } = await import('../../src/mcp/mcp-ckg-tools.js');
+  const s = new FakeServer();
+  registerCkgTools(s as unknown as Parameters<typeof registerCkgTools>[0]);
+  return s;
+}
+
+describe('registerCkgTools', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    recallHybrid.mockReset();
+    ingest.mockReset();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('exposes the collective graph, which memory_search does NOT reach', async () => {
+    const s = await register();
+    expect(s.tools.has('ckg_recall')).toBe(true);
+    expect(s.tools.has('ckg_ingest')).toBe(true);
+  });
+
+  it('reports corroboration in plain words — the whole point of a COLLECTIVE graph', async () => {
+    // A fact three independent agents reached is not the same as one agent repeating
+    // itself. If the output does not say so, the client cannot tell them apart and the
+    // shared graph is just a bigger notebook.
+    recallHybrid.mockResolvedValue([
+      { id: '1', type: 'lesson', name: 'never-prune', text: 'Orphan commits hold real work.',
+        salience: 0.9, mentions: 4, confidence: 0.94, corroborations: 3, agentId: 'ministar/fleet', source: 'worklog' },
+      { id: '2', type: 'fact', name: 'solo', text: 'Only one agent said this.',
+        salience: 0.4, mentions: 1, confidence: 0.6, corroborations: 1 },
+    ]);
+
+    const s = await register();
+    const out = await s.tools.get('ckg_recall')!.handler({ query: 'prune' });
+
+    const text = out.content[0]!.text;
+    expect(text).toContain('corroborated by 3 independent agents');
+    expect(text).toContain('asserted by a single agent');
+    expect(text).toContain('Orphan commits hold real work.');
+    expect(out.isError).toBeUndefined();
+  });
+
+  it('passes the type filter through instead of silently ignoring it', async () => {
+    recallHybrid.mockResolvedValue([]);
+    const s = await register();
+    await s.tools.get('ckg_recall')!.handler({ query: 'x', limit: 3, types: ['lesson'] });
+    expect(recallHybrid).toHaveBeenCalledWith('x', expect.objectContaining({ limit: 3, types: ['lesson'] }));
+  });
+
+  it('says plainly when the graph has nothing, rather than returning an empty success', async () => {
+    recallHybrid.mockResolvedValue([]);
+    const s = await register();
+    const out = await s.tools.get('ckg_recall')!.handler({ query: 'unknown' });
+    expect(out.content[0]!.text).toContain('Nothing in the collective graph');
+    expect(out.isError).toBeUndefined();
+  });
+
+  it('omits absent optional fields so ingest defaults apply', async () => {
+    // exactOptionalPropertyTypes is not on yet, so passing `type: undefined` would
+    // reach ingest() and could override its default. The keys must be absent.
+    ingest.mockResolvedValue({ name: 'n', type: 'fact', corroborations: 1, confidence: 0.8 });
+    const s = await register();
+    await s.tools.get('ckg_ingest')!.handler({ text: 'A fact.' });
+
+    const arg = ingest.mock.calls[0]![0] as Record<string, unknown>;
+    expect(arg).toEqual({ text: 'A fact.' });
+    expect('type' in arg).toBe(false);
+    expect('name' in arg).toBe(false);
+  });
+
+  it('surfaces a failure as an error instead of a reassuring message', async () => {
+    recallHybrid.mockRejectedValue(new Error('ledger unreadable'));
+    const s = await register();
+    const out = await s.tools.get('ckg_recall')!.handler({ query: 'x' });
+    expect(out.isError).toBe(true);
+    expect(out.content[0]!.text).toContain('ledger unreadable');
+  });
+});

--- a/tests/mcp/mcp-server.test.ts
+++ b/tests/mcp/mcp-server.test.ts
@@ -291,9 +291,9 @@ describe('CodeBuddyMCPServer', () => {
 
     it('should register all tools with the MCP server', () => {
       const mcpServer = (server as unknown as { mcpServer: { tool: jest.Mock } }).mcpServer;
-      // 7 original + 3 agent + 2 memory + 3 session + 2 desktop (read-only;
-      // the 4 control tools are gated behind CODEBUDDY_MCP_DESKTOP_CONTROL=1) = 17 tools
-      expect(mcpServer.tool).toHaveBeenCalledTimes(17);
+      // 7 original + 3 agent + 2 memory + 2 CKG + 3 session + 2 desktop (read-only;
+      // the 4 control tools are gated behind CODEBUDDY_MCP_DESKTOP_CONTROL=1) = 19 tools
+      expect(mcpServer.tool).toHaveBeenCalledTimes(19);
     });
 
     it('should map read_file to TextEditorTool.view', async () => {


### PR DESCRIPTION
Découpe de la vieille PR #70 (lot CB70d, flotte luna, rebasée et vérifiée indépendamment).

- `src/mcp/mcp-ckg-tools.ts` : outils MCP du Collective Knowledge Graph (ingest/recall/stats), enregistrés dans `mcp-server.ts` (2 lignes) — `mcp/index.ts` inchangé.
- `src/cli/first-run.ts` + câblage `src/index.ts` : premier lancement sans provider → proposition directe du login ChatGPT OAuth (le wizard complet reste accessible via `buddy onboard`, guidance affichée).
- Tests : `tests/mcp/mcp-ckg-tools.test.ts`, `tests/cli/first-run.test.ts`, `tests/mcp/mcp-server.test.ts` adapté.

Vérifications (après rebase sur main) : `tsc --noEmit` 0 ; vitest 3 fichiers / 51 tests ; eslint 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)