### PR TITLE
feat(video): modules studio (ComfyUI, Google Flow, quality gates, long-form plans) — découpe de #70

### DIFF
--- a/src/tools/video/approved-media-source.ts
+++ b/src/tools/video/approved-media-source.ts
@@ -1,0 +1,76 @@
+/** Read an immutable, digest-pinned image from an explicitly approved root. */
+
+import { createHash } from 'crypto';
+import { constants, promises as fs } from 'fs';
+import path from 'path';
+
+export interface ApprovedImageSource {
+  bytes: Buffer;
+  contentType: 'image/jpeg' | 'image/png' | 'image/webp';
+  realPath: string;
+  sha256: string;
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function detectImageContentType(bytes: Buffer): ApprovedImageSource['contentType'] | null {
+  if (
+    bytes.length >= 8 &&
+    bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  ) {
+    return 'image/png';
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    bytes.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+export async function loadApprovedImageSource(
+  filename: string,
+  approvedRoot: string,
+  expectedSha256: string,
+  maximumBytes = 25 * 1024 * 1024,
+): Promise<ApprovedImageSource> {
+  if (!path.isAbsolute(filename) || !path.isAbsolute(approvedRoot)) {
+    throw new Error('Approved image source and root must be absolute paths');
+  }
+  if (!/^[a-f0-9]{64}$/u.test(expectedSha256)) {
+    throw new Error('Approved image source requires a lowercase SHA-256 digest');
+  }
+  const root = await fs.realpath(approvedRoot);
+  const sourceLstat = await fs.lstat(filename);
+  if (sourceLstat.isSymbolicLink() || !sourceLstat.isFile()) {
+    throw new Error('Approved image source must be a regular non-symlink file');
+  }
+  const realPath = await fs.realpath(filename);
+  if (!isInsideRoot(root, realPath)) {
+    throw new Error('Approved image source escapes the configured asset root');
+  }
+
+  const handle = await fs.open(filename, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size <= 0 || stat.size > maximumBytes) {
+      throw new Error(`Approved image source size must be between 1 and ${maximumBytes} bytes`);
+    }
+    const bytes = await handle.readFile();
+    const sha256 = createHash('sha256').update(bytes).digest('hex');
+    if (sha256 !== expectedSha256) throw new Error('Approved image source digest does not match the plan');
+    const contentType = detectImageContentType(bytes);
+    if (!contentType) throw new Error('Approved image source has an unsupported file signature');
+    return { bytes, contentType, realPath, sha256 };
+  } finally {
+    await handle.close();
+  }
+}

--- a/src/tools/video/book-manuscript-source.ts
+++ b/src/tools/video/book-manuscript-source.ts
@@ -1,0 +1,341 @@
+/** Deterministic, local-only extraction of book manuscript material for trailers. */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { ManuscriptSource } from './cinematic-trailer-plan.js';
+
+const HARD_MAX_FILE_BYTES = 2 * 1024 * 1024;
+const DEFAULT_EXCERPT_LIMIT = 24;
+const MAX_EXCERPT_CHARACTERS = 360;
+
+export interface BookChapter {
+  file: string;
+  heading: string;
+  text: string;
+}
+
+export interface BookManuscript {
+  title: string;
+  chapters: BookChapter[];
+  coverPath?: string;
+}
+
+interface ManuscriptDirectoryEntry {
+  name: string;
+  isFile(): boolean;
+}
+
+interface ManuscriptFileInfo {
+  size: number;
+  isFile(): boolean;
+}
+
+export interface BookManuscriptFileSystem {
+  readdir(directory: string, options: { withFileTypes: true }): Promise<ManuscriptDirectoryEntry[]>;
+  lstat(filename: string): Promise<ManuscriptFileInfo>;
+  readFile(filename: string, encoding: 'utf8'): Promise<string>;
+}
+
+export interface LoadBookManuscriptOptions {
+  /** May lower, but never raise, the hard 2 MiB per-file ceiling. */
+  maxBytesPerFile?: number;
+  fileSystem?: BookManuscriptFileSystem;
+}
+
+export interface CandidateExcerpt {
+  id: string;
+  text: string;
+  chapterIndex: number;
+  lineStart: number;
+  lineEnd: number;
+  manuscriptSource: ManuscriptSource;
+}
+
+export interface ExtractCandidateExcerptsOptions {
+  limit?: number;
+  minCharacters?: number;
+}
+
+const defaultFileSystem: BookManuscriptFileSystem = {
+  readdir: (directory, options) => fs.readdir(directory, options),
+  lstat: (filename) => fs.lstat(filename),
+  readFile: (filename, encoding) => fs.readFile(filename, encoding),
+};
+
+function naturalCompare(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function unquoteYamlScalar(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1).trim();
+    }
+  }
+  return trimmed;
+}
+
+function frontmatterTitle(text: string): string | undefined {
+  const normalized = text.replace(/^\uFEFF/u, '');
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---(?:[ \t]*\r?\n|$)/u.exec(normalized);
+  if (!match?.[1]) return undefined;
+  const titleLine = match[1].split(/\r?\n/u).find((line) => /^title\s*:/iu.test(line));
+  if (!titleLine) return undefined;
+  const value = unquoteYamlScalar(titleLine.replace(/^title\s*:/iu, ''));
+  return value || undefined;
+}
+
+function firstHeading(text: string): string | undefined {
+  const match = /^\s*#\s+(.+?)\s*#*\s*$/mu.exec(text);
+  return match?.[1]?.trim() || undefined;
+}
+
+function fallbackHeading(filename: string): string {
+  return path.basename(filename, path.extname(filename)).replace(/[-_]+/gu, ' ').trim();
+}
+
+function resolveReadLimit(value: number | undefined): number {
+  if (value === undefined) return HARD_MAX_FILE_BYTES;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error('The manuscript per-file byte limit must be a positive integer');
+  }
+  return Math.min(value, HARD_MAX_FILE_BYTES);
+}
+
+/** Load naturally ordered Markdown chapters without performing any network I/O. */
+export async function loadBookManuscript(
+  bookDir: string,
+  options: LoadBookManuscriptOptions = {},
+): Promise<BookManuscript> {
+  if (!bookDir.trim()) throw new Error('Book directory is required');
+  const directory = path.resolve(bookDir);
+  const io = options.fileSystem ?? defaultFileSystem;
+  const maxBytes = resolveReadLimit(options.maxBytesPerFile);
+  const entries = await io.readdir(directory, { withFileTypes: true });
+  if (entries.length === 0) throw new Error(`Book directory is empty: ${directory}`);
+
+  const markdownEntries = entries
+    .filter((entry) => entry.isFile() && /\.md$/iu.test(entry.name))
+    .sort((left, right) => naturalCompare(left.name, right.name));
+  if (markdownEntries.length === 0) {
+    throw new Error(`Book directory contains no Markdown chapters: ${directory}`);
+  }
+
+  let title: string | undefined;
+  const chapters: BookChapter[] = [];
+  for (const entry of markdownEntries) {
+    const filename = path.join(directory, entry.name);
+    const info = await io.lstat(filename);
+    if (!info.isFile()) throw new Error(`Manuscript chapter is not a regular file: ${entry.name}`);
+    if (info.size > maxBytes) {
+      throw new Error(`Manuscript chapter exceeds the ${maxBytes}-byte limit: ${entry.name}`);
+    }
+    const text = await io.readFile(filename, 'utf8');
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`Manuscript chapter exceeds the ${maxBytes}-byte limit after reading: ${entry.name}`);
+    }
+    const yamlTitle = frontmatterTitle(text);
+    const heading = firstHeading(text);
+    title ??= yamlTitle ?? heading;
+    chapters.push({
+      file: entry.name,
+      heading: heading ?? fallbackHeading(entry.name),
+      text,
+    });
+  }
+
+  const coverEntry = entries
+    .filter((entry) => entry.isFile() && /^(?:cover|couverture)(?:[-_. ].*)?\.(?:jpe?g|png|webp)$/iu.test(entry.name))
+    .sort((left, right) => naturalCompare(left.name, right.name))[0];
+  let coverPath: string | undefined;
+  if (coverEntry) {
+    const candidate = path.join(directory, coverEntry.name);
+    const info = await io.lstat(candidate);
+    if (info.isFile()) coverPath = candidate;
+  }
+
+  return {
+    title: title ?? path.basename(directory),
+    chapters,
+    ...(coverPath ? { coverPath } : {}),
+  };
+}
+
+interface SourceRange {
+  start: number;
+  end: number;
+  lineStart: number;
+  lineEnd: number;
+}
+
+interface ScoredExcerpt extends Omit<CandidateExcerpt, 'id'> {
+  score: number;
+  offset: number;
+}
+
+function proseRanges(text: string): SourceRange[] {
+  const ranges: SourceRange[] = [];
+  let blockStart = -1;
+  let blockEnd = -1;
+  let blockLineStart = -1;
+  let blockLineEnd = -1;
+  let offset = 0;
+  let lineNumber = 1;
+  let inFrontmatter = text.replace(/^\uFEFF/u, '').startsWith('---');
+  let inFence = false;
+
+  const flush = (): void => {
+    if (blockStart >= 0 && blockEnd > blockStart) {
+      ranges.push({ start: blockStart, end: blockEnd, lineStart: blockLineStart, lineEnd: blockLineEnd });
+    }
+    blockStart = -1;
+    blockEnd = -1;
+    blockLineStart = -1;
+    blockLineEnd = -1;
+  };
+
+  const lines = text.match(/.*(?:\r?\n|$)/gu) ?? [];
+  for (const rawLine of lines) {
+    if (!rawLine) continue;
+    const content = rawLine.replace(/\r?\n$/u, '');
+    const trimmed = content.trim();
+    const isDelimiter = trimmed === '---';
+    if (lineNumber === 1 && inFrontmatter && isDelimiter) {
+      flush();
+      offset += rawLine.length;
+      lineNumber += 1;
+      continue;
+    }
+    if (inFrontmatter) {
+      flush();
+      if (isDelimiter) inFrontmatter = false;
+      offset += rawLine.length;
+      lineNumber += 1;
+      continue;
+    }
+    if (/^```/u.test(trimmed)) {
+      flush();
+      inFence = !inFence;
+    } else if (inFence || !trimmed || /^#{1,6}\s/u.test(trimmed)) {
+      flush();
+    } else {
+      const leading = content.length - content.trimStart().length;
+      const trailing = content.length - content.trimEnd().length;
+      if (blockStart < 0) {
+        blockStart = offset + leading;
+        blockLineStart = lineNumber;
+      }
+      blockEnd = offset + content.length - trailing;
+      blockLineEnd = lineNumber;
+    }
+    offset += rawLine.length;
+    lineNumber += 1;
+  }
+  flush();
+  return ranges;
+}
+
+function sentenceRanges(text: string, range: SourceRange): SourceRange[] {
+  const source = text.slice(range.start, range.end);
+  const matches = [...source.matchAll(/[^.!?…]+(?:[.!?…]+(?:[”»"']+)?(?=\s|$)|$)/gu)];
+  return matches.flatMap((match) => {
+    const raw = match[0];
+    const relativeStart = (match.index ?? 0) + raw.length - raw.trimStart().length;
+    const relativeEnd = (match.index ?? 0) + raw.trimEnd().length;
+    if (relativeEnd <= relativeStart) return [];
+    const prefix = source.slice(0, relativeStart);
+    const body = source.slice(relativeStart, relativeEnd);
+    const lineStart = range.lineStart + (prefix.match(/\n/gu)?.length ?? 0);
+    const lineEnd = lineStart + (body.match(/\n/gu)?.length ?? 0);
+    return [{
+      start: range.start + relativeStart,
+      end: range.start + relativeEnd,
+      lineStart,
+      lineEnd,
+    }];
+  });
+}
+
+const ACTION_WORDS = /\b(?:court|courut|fuit|frappe|ouvre|ferme|tombe|saisit|arrache|brise|tourne|avance|recule|crie|hurle|chuchote|découvre|voit|entend|runs?|flees?|strikes?|opens?|closes?|falls?|grabs?|tears?|breaks?|turns?|walks?|screams?|whispers?|discovers?|sees?|hears?)\b/giu;
+const TENSION_WORDS = /\b(?:sang|ombre|nuit|silence|peur|danger|mort|secret|mensonge|disparu|interdit|urgence|blood|shadow|night|silence|fear|danger|death|secret|lie|missing|forbidden|urgent)\b/giu;
+const CONCRETE_WORDS = /\b(?:porte|fenêtre|route|forêt|maison|chambre|visage|main|couteau|lettre|photo|voiture|train|mer|feu|pluie|door|window|road|forest|house|room|face|hand|knife|letter|photo|car|train|sea|fire|rain)\b/giu;
+
+function matchCount(text: string, pattern: RegExp): number {
+  pattern.lastIndex = 0;
+  return [...text.matchAll(pattern)].length;
+}
+
+function imageTensionScore(text: string): number {
+  const dialogue = /(?:^|\s)[—–]|[«“"]/u.test(text) ? 6 : 0;
+  const action = Math.min(matchCount(text, ACTION_WORDS), 3) * 3;
+  const tension = Math.min(matchCount(text, TENSION_WORDS), 3) * 3;
+  const concrete = Math.min(matchCount(text, CONCRETE_WORDS), 4) * 2;
+  const properNouns = Math.min([...(text.matchAll(/\b\p{Lu}[\p{L}'’-]{2,}\b/gu))].length, 3);
+  const lengthFit = text.length >= 45 && text.length <= 280 ? 3 : 0;
+  return dialogue + action + tension + concrete + properNouns + lengthFit;
+}
+
+function chunkSentences(text: string, sentences: SourceRange[]): SourceRange[] {
+  const chunks: SourceRange[] = [];
+  for (let index = 0; index < sentences.length;) {
+    const first = sentences[index]!;
+    let endIndex = index;
+    while (endIndex + 1 < sentences.length && endIndex - index < 2) {
+      const next = sentences[endIndex + 1]!;
+      if (next.end - first.start > MAX_EXCERPT_CHARACTERS) break;
+      endIndex += 1;
+    }
+    const last = sentences[endIndex]!;
+    chunks.push({ start: first.start, end: last.end, lineStart: first.lineStart, lineEnd: last.lineEnd });
+    index = endIndex + 1;
+  }
+  return chunks;
+}
+
+/** Select short, image-bearing passages with exact manuscript line provenance. */
+export function extractCandidateExcerpts(
+  manuscript: BookManuscript,
+  options: ExtractCandidateExcerptsOptions = {},
+): CandidateExcerpt[] {
+  const limit = options.limit ?? DEFAULT_EXCERPT_LIMIT;
+  const minCharacters = options.minCharacters ?? 24;
+  if (!Number.isInteger(limit) || limit <= 0) throw new Error('Excerpt limit must be a positive integer');
+  if (!Number.isInteger(minCharacters) || minCharacters < 1) {
+    throw new Error('Excerpt minimum length must be a positive integer');
+  }
+
+  const candidates: ScoredExcerpt[] = [];
+  manuscript.chapters.forEach((chapter, chapterIndex) => {
+    for (const paragraph of proseRanges(chapter.text)) {
+      for (const chunk of chunkSentences(chapter.text, sentenceRanges(chapter.text, paragraph))) {
+        const excerptText = chapter.text.slice(chunk.start, chunk.end).trim();
+        if (excerptText.length < minCharacters || excerptText.length > MAX_EXCERPT_CHARACTERS) continue;
+        candidates.push({
+          text: excerptText,
+          chapterIndex,
+          lineStart: chunk.lineStart,
+          lineEnd: chunk.lineEnd,
+          manuscriptSource: {
+            file: chapter.file,
+            locator: `chapter:${chapterIndex + 1};lines:${chunk.lineStart}-${chunk.lineEnd}`,
+          },
+          score: imageTensionScore(excerptText),
+          offset: chunk.start,
+        });
+      }
+    }
+  });
+
+  return candidates
+    .sort((left, right) =>
+      right.score - left.score || left.chapterIndex - right.chapterIndex || left.offset - right.offset)
+    .slice(0, limit)
+    .map(({ score: _score, offset: _offset, ...excerpt }, index) => ({
+      id: `excerpt-${String(index + 1).padStart(3, '0')}`,
+      ...excerpt,
+    }));
+}

--- a/src/tools/video/character-in-location.ts
+++ b/src/tools/video/character-in-location.ts
@@ -1,0 +1,232 @@
+/** Qwen-Image-Edit contract and deterministic patching for person/scene composition. */
+
+import {
+  assertAllSeedsPinned,
+  loadWorkflowTemplate,
+  patchWorkflow,
+  type ComfyWorkflowGraph,
+  type TemplateContract,
+} from './comfy-workflow-template.js';
+
+/** Canonical empty-environment ids used by character-in-location insertion. */
+export const SIGNATURE_LOCATION_IDS = [
+  'european-street-goldenhour',
+  'stone-staircase',
+  'balustrade-terrace',
+  'cozy-loft-interior',
+  'corner-cafe',
+  'rooftop-dusk',
+] as const;
+
+export type SignatureLocationId = (typeof SIGNATURE_LOCATION_IDS)[number];
+
+export interface SignatureLocation {
+  readonly locationId: SignatureLocationId;
+  readonly label?: string;
+  readonly description?: string;
+  readonly lightingSpec?: string;
+  readonly paletteTag?: string;
+}
+
+const KNOWN_LOCATION_IDS: ReadonlySet<string> = new Set(SIGNATURE_LOCATION_IDS);
+
+export type InsertionLocation = SignatureLocation | SignatureLocationId | 'custom-plate';
+
+export interface InsertionPromptOptions {
+  /** Preserve the source pose. Enabled by default. */
+  preservePose?: boolean;
+  /** Preserve the subject's apparent scale. Enabled by default. */
+  preserveScale?: boolean;
+  /** Require a measurable frontal face when a distant placement is unsafe. */
+  frontalMedium?: boolean;
+}
+
+export interface CharacterInLocationWorkflowInput {
+  characterImage: string;
+  locationImage: string;
+  location: InsertionLocation;
+  seed: number;
+  outputPrefix: string;
+  promptOptions?: InsertionPromptOptions;
+}
+
+export interface FaceProtectedCharacterInLocationWorkflowInput
+  extends CharacterInLocationWorkflowInput {
+  /** White where Qwen may sample; black over the canonical face. */
+  editMaskImage: string;
+}
+
+export const INSERT_QWEN_TEMPLATE_CONTRACT: TemplateContract = Object.freeze({
+  id: 'insert-qwen-edit',
+  required: Object.freeze([
+    { classType: 'LoadImage', count: 2 },
+    { classType: 'TextEncodeQwenImageEditPlus', count: 1 },
+    { classType: 'UnetLoaderGGUF', count: 1 },
+    { classType: 'KSampler', count: 1 },
+    { classType: 'SaveImage', count: 1 },
+  ]),
+  roles: Object.freeze({
+    characterImage: [{ classType: 'LoadImage', input: 'image', title: 'Character' }],
+    locationImage: [{ classType: 'LoadImage', input: 'image', title: 'Location' }],
+    insertPrompt: [{ classType: 'TextEncodeQwenImageEditPlus', input: 'prompt' }],
+    seed: [{ classType: 'KSampler', input: 'seed' }],
+    outputPrefix: [{ classType: 'SaveImage', input: 'filename_prefix' }],
+  }),
+});
+
+/** Operator-exported variant whose connected graph applies BiRefNet + IC-Light fbc. */
+export const INSERT_QWEN_RELIGHT_TEMPLATE_CONTRACT: TemplateContract = Object.freeze({
+  ...INSERT_QWEN_TEMPLATE_CONTRACT,
+  id: 'insert-qwen-edit-relight',
+  required: Object.freeze([
+    ...INSERT_QWEN_TEMPLATE_CONTRACT.required,
+    { classType: 'RembgByBiRefNet', count: 1 },
+    { classType: 'LoadAndApplyICLightUnet', count: 1 },
+  ]),
+});
+
+function locationIdOf(location: InsertionLocation): SignatureLocationId | 'custom-plate' {
+  return typeof location === 'string' ? location : location.locationId;
+}
+
+function assertKnownLocation(location: InsertionLocation): void {
+  const locationId = locationIdOf(location);
+  if (locationId !== 'custom-plate' && !KNOWN_LOCATION_IDS.has(locationId)) {
+    throw new Error(`Unknown signature location: ${locationId}`);
+  }
+}
+
+/**
+ * Build a deliberately scene-agnostic edit instruction. The location argument
+ * is validated, but no catalog prose is copied into the prompt: image 2 is the
+ * only source of decor, lighting, and perspective.
+ */
+export function buildInsertionPrompt(
+  location: InsertionLocation,
+  options: InsertionPromptOptions = {},
+): string {
+  assertKnownLocation(location);
+  const identityParts = ['identity'];
+  if (options.preservePose !== false) identityParts.push('pose');
+  if (options.preserveScale !== false) identityParts.push('scale');
+  return [
+    'place the woman from image 1 into the scene from image 2',
+    `keep her ${identityParts.join('/')}`,
+    ...(options.frontalMedium
+      ? ['show her clearly in a frontal medium shot looking directly at camera']
+      : []),
+    'match the scene lighting and perspective',
+    'photorealistic',
+  ].join(', ');
+}
+
+/** Validate an operator export, patch every addressable role, and pin all seeds. */
+export function buildCharacterInLocationWorkflow(
+  templateJson: unknown,
+  input: CharacterInLocationWorkflowInput,
+  contract: TemplateContract = INSERT_QWEN_TEMPLATE_CONTRACT,
+): ComfyWorkflowGraph {
+  const template = loadWorkflowTemplate(templateJson, contract);
+  const graph = patchWorkflow(template, [
+    { role: 'characterImage', value: input.characterImage },
+    { role: 'locationImage', value: input.locationImage },
+    { role: 'insertPrompt', value: buildInsertionPrompt(input.location, input.promptOptions) },
+    { role: 'seed', value: input.seed },
+    { role: 'outputPrefix', value: input.outputPrefix },
+  ]);
+  assertAllSeedsPinned(graph);
+  return graph;
+}
+
+function uniqueNodeId(graph: ComfyWorkflowGraph, classType: string): string {
+  const matches = Object.entries(graph)
+    .filter(([, node]) => node.class_type === classType)
+    .map(([nodeId]) => nodeId);
+  if (matches.length !== 1) {
+    throw new Error(`Face-protected insertion requires exactly 1 ${classType} node; found ${matches.length}`);
+  }
+  return matches[0]!;
+}
+
+function nextNodeIds(graph: ComfyWorkflowGraph, count: number): string[] {
+  const numericIds = Object.keys(graph)
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value >= 0);
+  let candidate = numericIds.length > 0 ? Math.max(...numericIds) + 1 : 1;
+  const values: string[] = [];
+  while (values.length < count) {
+    const id = String(candidate);
+    if (!graph[id]) values.push(id);
+    candidate += 1;
+  }
+  return values;
+}
+
+/**
+ * Add the same latent-mask + exact recomposition discipline as wardrobe repair.
+ * The supplied location image is already a draft containing canonical face
+ * pixels.  Qwen may resample every white part of editMaskImage, but the final
+ * ImageCompositeMasked restores the black face region from that draft.
+ */
+export function buildFaceProtectedCharacterInLocationWorkflow(
+  templateJson: unknown,
+  input: FaceProtectedCharacterInLocationWorkflowInput,
+  contract: TemplateContract = INSERT_QWEN_TEMPLATE_CONTRACT,
+): ComfyWorkflowGraph {
+  const graph = buildCharacterInLocationWorkflow(templateJson, input, contract);
+  const locationNodeId = Object.entries(graph).find(([, node]) => (
+    node.class_type === 'LoadImage' && node._meta?.title === 'Location'
+  ))?.[0];
+  if (!locationNodeId) throw new Error('Face-protected insertion cannot resolve the Location image');
+  const encoderId = uniqueNodeId(graph, 'TextEncodeQwenImageEditPlus');
+  const vaeEncodeId = uniqueNodeId(graph, 'VAEEncode');
+  const samplerId = uniqueNodeId(graph, 'KSampler');
+  const vaeDecodeId = uniqueNodeId(graph, 'VAEDecode');
+  const saveId = uniqueNodeId(graph, 'SaveImage');
+  const [maskImageId, imageToMaskId, latentMaskId, finalMaskId, compositeId] = nextNodeIds(graph, 5);
+  graph[maskImageId!] = {
+    class_type: 'LoadImage',
+    inputs: { image: input.editMaskImage },
+    _meta: { title: 'Face Edit Mask' },
+  };
+  graph[imageToMaskId!] = {
+    class_type: 'ImageToMask',
+    inputs: { image: [maskImageId, 0], channel: 'red' },
+    _meta: { title: 'White permits sampling; black protects canonical face' },
+  };
+  graph[latentMaskId!] = {
+    class_type: 'SetLatentNoiseMask',
+    inputs: { samples: [vaeEncodeId, 0], mask: [imageToMaskId, 0] },
+    _meta: { title: 'Never sample canonical face' },
+  };
+  graph[samplerId]!.inputs.latent_image = [latentMaskId, 0];
+  graph[finalMaskId!] = {
+    class_type: 'GrowMask',
+    inputs: {
+      mask: [imageToMaskId, 0],
+      expand: -16,
+      tapered_corners: true,
+    },
+    _meta: { title: 'Restore a clean margin around canonical face' },
+  };
+  graph[compositeId!] = {
+    class_type: 'ImageCompositeMasked',
+    inputs: {
+      destination: [locationNodeId, 0],
+      source: [vaeDecodeId, 0],
+      x: 0,
+      y: 0,
+      resize_source: false,
+      mask: [finalMaskId, 0],
+    },
+    _meta: { title: 'Restore canonical face after decode' },
+  };
+  graph[saveId]!.inputs.images = [compositeId, 0];
+  const prompt = graph[encoderId]!.inputs.prompt;
+  graph[encoderId]!.inputs.prompt =
+    `${typeof prompt === 'string' ? prompt : ''}, ` +
+    'the face inside the protected region is final, keep both eyes/eyebrows/forehead/cheeks/mouth unobstructed, ' +
+    'adapt hair/body/lighting around it without changing it or drawing a box/halo around it';
+  assertAllSeedsPinned(graph);
+  return graph;
+}

--- a/src/tools/video/cinematic-trailer-plan.ts
+++ b/src/tools/video/cinematic-trailer-plan.ts
@@ -1,0 +1,737 @@
+/**
+ * Cinematic book-trailer grammar + typed plan contract + fail-closed validation.
+ *
+ * This is an *editorial* contract, not a rendering engine. It never generates
+ * media, spends credits or contacts a service. Its only bridge to execution is a
+ * PREVIEW compilation into the existing {@link HybridVideoRequest} shape so the
+ * shared {@link routeHybridVideoBatch} router can estimate/distribute work —
+ * the preview always reports `executionAuthorized: false`.
+ *
+ * Both entry points accept `unknown`: {@link validateCinematicTrailerPlan} and
+ * {@link compileTrailerPreview} defensively coerce a malformed or partial value
+ * into a safe shape and surface the damage as blockers instead of throwing. A
+ * malformed plan collapses to `INCOMPLETE` with explicit `malformed-plan[:…]`
+ * blockers; it never masks the narrative/business problems that survive coercion.
+ *
+ * The vocabulary mirrors `bandes-annonces/FLOW-STORYBOARD-TEMPLATE.md` and
+ * `FLOW-CINEMATIC-GRAMMAR.md` in the livres-codex pack, but carries no runtime
+ * dependency on that repository.
+ *
+ * @module tools/video/cinematic-trailer-plan
+ */
+
+import {
+  routeHybridVideoBatch,
+  type ContentTier,
+  type HybridVideoCapacity,
+  type HybridVideoRequest,
+  type HybridVideoRoute,
+  type HybridVideoUseCase,
+} from './hybrid-video-router.js';
+
+/** Stable narrative-function tokens (English, matching the storyboard template). */
+export const NARRATIVE_TOKENS = [
+  'hook',
+  'world',
+  'protagonist',
+  'revelation',
+  'escalation',
+  'price',
+  'false-resolution',
+  'withheld',
+  'brand',
+  'cta',
+] as const;
+export type NarrativeToken = (typeof NARRATIVE_TOKENS)[number];
+
+/**
+ * Minimal contract: the six/eight functions every trailer must cover.
+ * `revelation` and `false-resolution` stay optional dramatic devices.
+ */
+export const REQUIRED_NARRATIVE_TOKENS: readonly NarrativeToken[] = [
+  'hook',
+  'world',
+  'protagonist',
+  'escalation',
+  'price',
+  'withheld',
+  'brand',
+  'cta',
+];
+
+/** Tokens whose shots are purely editorial (cover/title) — no manuscript source. */
+const EDITORIAL_TOKENS: ReadonlySet<string> = new Set<string>(['brand', 'cta']);
+
+/** Approval ladder — a higher state is never inferred from the previous one. */
+export type TrailerStatus =
+  | 'INCOMPLETE'
+  | 'READY_FOR_PREFLIGHT'
+  | 'APPROVED_FOR_GENERATION'
+  | 'APPROVED_FOR_PUBLICATION';
+
+const STATUS_ORDER: readonly TrailerStatus[] = [
+  'INCOMPLETE',
+  'READY_FOR_PREFLIGHT',
+  'APPROVED_FOR_GENERATION',
+  'APPROVED_FOR_PUBLICATION',
+];
+
+export interface ManuscriptSource {
+  /** Manuscript file inside the book pack. */
+  file: string;
+  /** Scene or line locator within that file. */
+  locator: string;
+}
+
+export interface TrailerCharacterRef {
+  /** Character id referenced by shots. */
+  id: string;
+  /** Pinned identity / LoRA version for continuity across shots. */
+  identityVersion: string;
+  /** Approved reference asset path. */
+  reference: string;
+  /** SHA-256 of the approved reference (64 hex chars). */
+  referenceSha256: string;
+  /** Explicit human casting approval — never inferred from cover art. */
+  castingApproved: boolean;
+}
+
+export interface TrailerOverlay {
+  timecodeSeconds: number;
+  text: string;
+  /** Provenance of the words. */
+  source: 'manuscript' | 'editorial';
+  /** Text sits inside the shared 9:16 / 16:9 safe zone. */
+  safeZone: boolean;
+}
+
+export interface TrailerShot {
+  id: string;
+  token: NarrativeToken;
+  /** Manuscript evidence — required for every narrative (non-editorial) shot. */
+  manuscriptSource?: ManuscriptSource;
+  /** The single new information this shot conveys. */
+  information: string;
+  /** The single human action verb. */
+  action: string;
+  /** The single camera move (or `static`). */
+  cameraMove: string;
+  durationSeconds: number;
+  /** Recurring characters visible in the shot (ids into `characters`). */
+  characters: string[];
+  /** 12–18 stable frames at the head for a real editing handle. */
+  entryHandle: boolean;
+  /** 12–18 stable frames at the tail. */
+  exitHandle: boolean;
+  /** Text baked into the generated image is forbidden — must stay false. */
+  burnedInText: boolean;
+  rejectionConditions: string[];
+  /** Fleet routing hint. */
+  useCase: HybridVideoUseCase;
+  requiresLipSync?: boolean;
+  premium?: boolean;
+}
+
+export interface TrailerRetentionHypotheses {
+  hookA: string;
+  hookB: string;
+  promise: string;
+  proofWithinThreeSeconds: string;
+  deeperPayoff: string;
+  singleAbVariable: string;
+}
+
+export interface TrailerCost {
+  /** The credit cost was shown in the UI before any approval. */
+  displayedInUi: boolean;
+  estimatedFlowCredits: number;
+  approvedCeilingFlowCredits: number;
+  /** Who approved the ceiling (empty ⇒ not approved). */
+  approvedBy?: string;
+}
+
+/** Separate human approvals — each must be granted explicitly. */
+export interface TrailerApprovals {
+  narrativeReviewed: boolean;
+  castingReviewed: boolean;
+  costApproved: boolean;
+  publicationApproved: boolean;
+}
+
+export interface TrailerPublication {
+  visibility: 'private';
+  autoPublish: false;
+  containsSyntheticMedia: true;
+  humanReviewRequired: true;
+}
+
+export interface CinematicTrailerPlan {
+  schemaVersion: 1;
+  /** Status the author claims — validation downgrades it fail-closed. */
+  status: TrailerStatus;
+  /** Book trailers are advertiser-facing; only `safe` is permitted. */
+  contentTier: ContentTier;
+  book: {
+    title: string;
+    genre: string;
+    /** "We move from <A> to <B>, seen from <POV>, without revealing <answer>." */
+    stagingSentence: string;
+    spoilerLimit: string;
+    commercialAction: string;
+  };
+  /** Master cut target in seconds (60–90s per method). Derivatives are remixed. */
+  masterDurationSeconds: number;
+  characters: TrailerCharacterRef[];
+  shots: TrailerShot[];
+  overlays: TrailerOverlay[];
+  sound: {
+    /** Four separated layers: ambience, foley, motif, speech. */
+    layers: string[];
+    /** Rendered master deliverables (one layer never doubled across masters). */
+    masters: string[];
+  };
+  retention: TrailerRetentionHypotheses;
+  cost: TrailerCost;
+  approvals: TrailerApprovals;
+  publication: TrailerPublication;
+}
+
+export interface TrailerValidation {
+  /** Effective status = min(claimed, qualified). Fail-closed, never promoted. */
+  status: TrailerStatus;
+  claimedStatus: TrailerStatus;
+  /** Highest gate the plan actually qualifies for. */
+  qualifiedStatus: TrailerStatus;
+  /**
+   * Reasons the plan is not sound. Structural (`malformed-plan…`) and narrative
+   * blockers are ALWAYS listed — they are diagnostic and never hidden, even when
+   * the claimed status is `INCOMPLETE`. Generation- and publication-gate reasons
+   * are listed only when the *claimed* status reaches that rung of the ladder,
+   * so `blockers` answers "why is the claim not met" without ever suppressing a
+   * structural defect.
+   */
+  blockers: string[];
+  warnings: string[];
+}
+
+const SHA256_RE = /^[a-f0-9]{64}$/i;
+function isSha256(value: string): boolean {
+  return SHA256_RE.test(value.trim());
+}
+
+// Temporal connectors that betray more than one action/move packed in a field.
+const SEQUENCE_CONNECTOR = /(\bpuis\b|\bthen\b|\bensuite\b|\bpendant que\b|\bwhile\b|\bmeanwhile\b|\band then\b|\s&\s|\s\+\s)/iu;
+function packsMultiple(text: string): boolean {
+  return SEQUENCE_CONNECTOR.test(text.trim());
+}
+
+function statusIndex(status: TrailerStatus): number {
+  return STATUS_ORDER.indexOf(status);
+}
+
+function isTrailerStatus(value: unknown): value is TrailerStatus {
+  return typeof value === 'string' && (STATUS_ORDER as readonly string[]).includes(value);
+}
+
+// ── Defensive coercion of an untrusted plan ───────────────────────────────
+// The public entry points accept `unknown`. These helpers coerce each field to
+// a safe shape (never throwing) and the caller records `malformed-plan[:…]`
+// blockers for anything missing or mistyped, so a broken plan degrades to
+// INCOMPLETE + diagnostics rather than a crash.
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+function asNumber(value: unknown): number {
+  return typeof value === 'number' ? value : Number.NaN;
+}
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function asStringArray(value: unknown): string[] {
+  return asArray(value).map(asString);
+}
+
+interface SafeCharacter {
+  id: string;
+  identityVersion: string;
+  reference: string;
+  referenceSha256: string;
+  castingApproved: boolean;
+}
+interface SafeShot {
+  id: string;
+  token: string;
+  hasManuscriptSource: boolean;
+  manuscriptFile: string;
+  manuscriptLocator: string;
+  information: string;
+  action: string;
+  cameraMove: string;
+  durationSeconds: number;
+  characters: string[];
+  entryHandle: boolean;
+  exitHandle: boolean;
+  burnedInText: boolean;
+  rejectionConditions: string[];
+  useCase: string;
+  requiresLipSync: boolean;
+  premium: boolean;
+}
+interface SafeOverlay {
+  timecodeSeconds: number;
+  text: string;
+  source: string;
+  safeZone: boolean;
+}
+interface SafePlan {
+  schemaVersion: number;
+  status: TrailerStatus;
+  contentTier: string;
+  book: { title: string; genre: string; stagingSentence: string; spoilerLimit: string; commercialAction: string };
+  masterDurationSeconds: number;
+  characters: SafeCharacter[];
+  shots: SafeShot[];
+  overlays: SafeOverlay[];
+  sound: { layers: string[]; masters: string[] };
+  retention: { hookA: string; hookB: string; promise: string; proofWithinThreeSeconds: string; deeperPayoff: string; singleAbVariable: string };
+  cost: { displayedInUi: boolean; estimatedFlowCredits: number; approvedCeilingFlowCredits: number; approvedBy: string };
+  approvals: { narrativeReviewed: boolean; castingReviewed: boolean; costApproved: boolean; publicationApproved: boolean };
+  publication: { visibility: unknown; autoPublish: unknown; containsSyntheticMedia: unknown; humanReviewRequired: unknown };
+}
+
+function normalizeCharacter(value: unknown): SafeCharacter {
+  const r = isRecord(value) ? value : {};
+  return {
+    id: asString(r.id),
+    identityVersion: asString(r.identityVersion),
+    reference: asString(r.reference),
+    referenceSha256: asString(r.referenceSha256),
+    castingApproved: asBoolean(r.castingApproved),
+  };
+}
+
+function normalizeShot(value: unknown): SafeShot {
+  const r = isRecord(value) ? value : {};
+  const src = isRecord(r.manuscriptSource) ? r.manuscriptSource : null;
+  return {
+    id: asString(r.id),
+    token: asString(r.token),
+    hasManuscriptSource: src !== null,
+    manuscriptFile: src ? asString(src.file) : '',
+    manuscriptLocator: src ? asString(src.locator) : '',
+    information: asString(r.information),
+    action: asString(r.action),
+    cameraMove: asString(r.cameraMove),
+    durationSeconds: asNumber(r.durationSeconds),
+    characters: asStringArray(r.characters),
+    entryHandle: asBoolean(r.entryHandle),
+    exitHandle: asBoolean(r.exitHandle),
+    burnedInText: asBoolean(r.burnedInText),
+    rejectionConditions: asStringArray(r.rejectionConditions),
+    useCase: asString(r.useCase),
+    requiresLipSync: asBoolean(r.requiresLipSync),
+    premium: asBoolean(r.premium),
+  };
+}
+
+function normalizeOverlay(value: unknown): SafeOverlay {
+  const r = isRecord(value) ? value : {};
+  return {
+    timecodeSeconds: asNumber(r.timecodeSeconds),
+    text: asString(r.text),
+    source: asString(r.source),
+    safeZone: asBoolean(r.safeZone),
+  };
+}
+
+/**
+ * Coerce an untrusted value into a {@link SafePlan}. Records one
+ * `malformed-plan[:section]` blocker per missing/mistyped structural piece so
+ * the malformed shape is explicit, while still exposing every business problem
+ * that survives coercion (per-section defaults keep the narrative checks alive).
+ */
+function normalizePlan(input: unknown): { plan: SafePlan; structural: string[] } {
+  const structural: string[] = [];
+  const root = isRecord(input) ? input : null;
+  if (!root) structural.push('malformed-plan');
+  const o: Record<string, unknown> = root ?? {};
+
+  if (root && !isTrailerStatus(o.status)) structural.push('invalid-status');
+  const status: TrailerStatus = isTrailerStatus(o.status) ? o.status : 'INCOMPLETE';
+
+  const bookRec = isRecord(o.book) ? o.book : null;
+  if (root && !bookRec) structural.push('malformed-plan:book');
+  const b: Record<string, unknown> = bookRec ?? {};
+
+  const soundRec = isRecord(o.sound) ? o.sound : null;
+  if (root && !soundRec) structural.push('malformed-plan:sound');
+  const s: Record<string, unknown> = soundRec ?? {};
+
+  const retentionRec = isRecord(o.retention) ? o.retention : null;
+  if (root && !retentionRec) structural.push('malformed-plan:retention');
+  const ret: Record<string, unknown> = retentionRec ?? {};
+
+  const costRec = isRecord(o.cost) ? o.cost : null;
+  if (root && !costRec) structural.push('malformed-plan:cost');
+  const c: Record<string, unknown> = costRec ?? {};
+
+  const approvalsRec = isRecord(o.approvals) ? o.approvals : null;
+  if (root && !approvalsRec) structural.push('malformed-plan:approvals');
+  const a: Record<string, unknown> = approvalsRec ?? {};
+
+  const publicationRec = isRecord(o.publication) ? o.publication : null;
+  if (root && !publicationRec) structural.push('malformed-plan:publication');
+  const p: Record<string, unknown> = publicationRec ?? {};
+
+  if (root && !Array.isArray(o.characters)) structural.push('malformed-plan:characters');
+  if (root && !Array.isArray(o.shots)) structural.push('malformed-plan:shots');
+  if (root && !Array.isArray(o.overlays)) structural.push('malformed-plan:overlays');
+
+  const plan: SafePlan = {
+    schemaVersion: asNumber(o.schemaVersion),
+    status,
+    contentTier: asString(o.contentTier),
+    book: {
+      title: asString(b.title),
+      genre: asString(b.genre),
+      stagingSentence: asString(b.stagingSentence),
+      spoilerLimit: asString(b.spoilerLimit),
+      commercialAction: asString(b.commercialAction),
+    },
+    masterDurationSeconds: asNumber(o.masterDurationSeconds),
+    characters: asArray(o.characters).map(normalizeCharacter),
+    shots: asArray(o.shots).map(normalizeShot),
+    overlays: asArray(o.overlays).map(normalizeOverlay),
+    sound: { layers: asStringArray(s.layers), masters: asStringArray(s.masters) },
+    retention: {
+      hookA: asString(ret.hookA),
+      hookB: asString(ret.hookB),
+      promise: asString(ret.promise),
+      proofWithinThreeSeconds: asString(ret.proofWithinThreeSeconds),
+      deeperPayoff: asString(ret.deeperPayoff),
+      singleAbVariable: asString(ret.singleAbVariable),
+    },
+    cost: {
+      displayedInUi: asBoolean(c.displayedInUi),
+      estimatedFlowCredits: asNumber(c.estimatedFlowCredits),
+      approvedCeilingFlowCredits: asNumber(c.approvedCeilingFlowCredits),
+      approvedBy: asString(c.approvedBy),
+    },
+    approvals: {
+      narrativeReviewed: asBoolean(a.narrativeReviewed),
+      castingReviewed: asBoolean(a.castingReviewed),
+      costApproved: asBoolean(a.costApproved),
+      publicationApproved: asBoolean(a.publicationApproved),
+    },
+    publication: {
+      visibility: p.visibility,
+      autoPublish: p.autoPublish,
+      containsSyntheticMedia: p.containsSyntheticMedia,
+      humanReviewRequired: p.humanReviewRequired,
+    },
+  };
+  return { plan, structural };
+}
+
+/**
+ * Pure, fail-closed validation. Accepts an untrusted value: a malformed plan
+ * degrades to `INCOMPLETE` with explicit `malformed-plan[:…]` blockers instead
+ * of throwing. Returns categorised reasons; never throws for malformed narrative
+ * content (only surfaces it as blockers/warnings).
+ */
+export function validateCinematicTrailerPlan(input: unknown): TrailerValidation {
+  const { plan, structural } = normalizePlan(input);
+
+  // Blockers that gate READY_FOR_PREFLIGHT (narrative completeness + safety).
+  const narrative: string[] = [];
+  // Extra blockers that gate APPROVED_FOR_GENERATION (casting + cost).
+  const generation: string[] = [];
+  // Extra blockers that gate APPROVED_FOR_PUBLICATION.
+  const publication: string[] = [];
+  const warnings: string[] = [];
+
+  if (plan.schemaVersion !== 1) narrative.push('unsupported-schema');
+
+  // ── Editorial contract ──────────────────────────────────────────────
+  if (!plan.book.title.trim() || !plan.book.genre.trim()) narrative.push('missing-book-metadata');
+  if (!plan.book.stagingSentence.trim()) narrative.push('missing-staging-sentence');
+  if (!plan.book.spoilerLimit.trim()) narrative.push('missing-spoiler-limit');
+  if (!plan.book.commercialAction.trim()) narrative.push('missing-commercial-action');
+
+  // Book trailers are advertiser-safe by contract.
+  if (plan.contentTier !== 'safe') narrative.push(`non-safe-trailer-tier:${plan.contentTier}`);
+
+  if (!(plan.masterDurationSeconds >= 60 && plan.masterDurationSeconds <= 90)) {
+    narrative.push('master-duration-out-of-range');
+  }
+
+  // ── Character declarations (integrity — always visible) ─────────────
+  const declaredIds = new Set<string>();
+  const declared = new Map<string, SafeCharacter>();
+  for (const character of plan.characters) {
+    const id = character.id.trim();
+    if (!id) {
+      narrative.push('empty-character-id');
+      continue;
+    }
+    if (declaredIds.has(id)) {
+      narrative.push(`duplicate-character-declaration:${id}`);
+      continue;
+    }
+    declaredIds.add(id);
+    declared.set(id, character);
+  }
+
+  // ── Shots / plan grammar ────────────────────────────────────────────
+  const shotIds = new Set<string>();
+  const covered = new Set<string>();
+  const characterAppearances = new Map<string, number>();
+  let timeline = 0;
+  for (const shot of plan.shots) {
+    if (!shot.id.trim() || shotIds.has(shot.id)) narrative.push('duplicate-or-empty-shot-id');
+    shotIds.add(shot.id);
+    covered.add(shot.token);
+
+    if (!(shot.durationSeconds > 0 && shot.durationSeconds <= 12)) {
+      narrative.push(`invalid-shot-duration:${shot.id}`);
+    }
+    if (Number.isFinite(shot.durationSeconds)) timeline += shot.durationSeconds;
+
+    // One information / one action / one camera move per shot.
+    if (packsMultiple(shot.information)) narrative.push(`multiple-information:${shot.id}`);
+    if (packsMultiple(shot.action)) narrative.push(`multiple-action:${shot.id}`);
+    if (packsMultiple(shot.cameraMove)) narrative.push(`multiple-camera-move:${shot.id}`);
+
+    // Every narrative shot needs a manuscript source; editorial shots do not.
+    if (!EDITORIAL_TOKENS.has(shot.token)) {
+      if (!shot.hasManuscriptSource) {
+        narrative.push(`missing-manuscript-source:${shot.id}`);
+      } else if (!shot.manuscriptFile.trim() || !shot.manuscriptLocator.trim()) {
+        narrative.push(`incomplete-manuscript-source:${shot.id}`);
+      }
+    }
+
+    // Text baked into the frame is forbidden.
+    if (shot.burnedInText) narrative.push(`burned-in-text-forbidden:${shot.id}`);
+
+    if (!shot.entryHandle || !shot.exitHandle) warnings.push(`missing-editing-handle:${shot.id}`);
+    if (!shot.rejectionConditions.length) warnings.push(`no-rejection-conditions:${shot.id}`);
+
+    // Count a character at most once per shot: a repeated id inside one shot is
+    // not "recurring across shots", so it must not fake up the recurring gate.
+    const uniqueInShot = new Set(shot.characters.map((ch) => ch.trim()).filter(Boolean));
+    for (const character of uniqueInShot) {
+      characterAppearances.set(character, (characterAppearances.get(character) ?? 0) + 1);
+    }
+  }
+
+  for (const token of REQUIRED_NARRATIVE_TOKENS) {
+    if (!covered.has(token)) narrative.push(`missing-function:${token}`);
+  }
+
+  // Timeline continuity: the shots must sum to the declared master duration.
+  if (plan.shots.length && Math.abs(timeline - plan.masterDurationSeconds) > 0.5) {
+    narrative.push('timeline-duration-mismatch');
+  }
+
+  // ── Overlays ────────────────────────────────────────────────────────
+  for (const overlay of plan.overlays) {
+    if (!overlay.text.trim()) narrative.push('empty-overlay');
+    // A finite timecode bounded by the master duration — otherwise the overlay
+    // cannot be placed on the timeline at all.
+    if (
+      !Number.isFinite(overlay.timecodeSeconds) ||
+      overlay.timecodeSeconds < 0 ||
+      overlay.timecodeSeconds > plan.masterDurationSeconds
+    ) {
+      narrative.push(`overlay-timecode-out-of-range:${overlay.timecodeSeconds}`);
+    }
+    if (!overlay.safeZone) warnings.push(`overlay-outside-safe-zone:${overlay.timecodeSeconds}`);
+  }
+
+  // ── Sound ───────────────────────────────────────────────────────────
+  // At least four DISTINCT non-empty layers (ambience, foley, motif, speech):
+  // four copies of the same word is not a four-layer mix.
+  const distinctLayers = new Set(plan.sound.layers.map((l) => l.trim().toLowerCase()).filter(Boolean));
+  if (distinctLayers.size < 4) narrative.push('incomplete-sound-layers');
+  if (!plan.sound.masters.filter((m) => m.trim()).length) narrative.push('missing-sound-master');
+
+  // ── Retention hypotheses ────────────────────────────────────────────
+  const r = plan.retention;
+  if (
+    !r.hookA.trim() || !r.hookB.trim() || !r.promise.trim() ||
+    !r.proofWithinThreeSeconds.trim() || !r.deeperPayoff.trim() || !r.singleAbVariable.trim()
+  ) {
+    narrative.push('incomplete-retention-hypotheses');
+  }
+
+  // ── Publication safety (fail-closed, always enforced) ───────────────
+  if (
+    plan.publication.visibility !== 'private' ||
+    plan.publication.autoPublish !== false ||
+    plan.publication.containsSyntheticMedia !== true ||
+    plan.publication.humanReviewRequired !== true
+  ) {
+    narrative.push('unsafe-publication-gate');
+  }
+
+  // ── Generation gate: casting + recurring identity + cost ────────────
+  if (!plan.approvals.narrativeReviewed) generation.push('narrative-not-reviewed');
+  if (!plan.approvals.castingReviewed) generation.push('casting-not-reviewed');
+
+  for (const [id, appearances] of characterAppearances) {
+    const ref = declared.get(id);
+    if (!ref) {
+      generation.push(`undeclared-character:${id}`);
+      continue;
+    }
+    // Recurring characters (>1 shot) need an approved, hashed reference.
+    if (appearances > 1) {
+      if (!ref.reference.trim()) generation.push(`missing-character-reference:${id}`);
+      if (!isSha256(ref.referenceSha256)) generation.push(`invalid-character-sha:${id}`);
+      if (!ref.identityVersion.trim()) generation.push(`missing-identity-version:${id}`);
+      // Cover art is never casting authority — approval must be explicit.
+      if (!ref.castingApproved) generation.push(`character-casting-not-approved:${id}`);
+    }
+  }
+
+  if (!plan.cost.displayedInUi) generation.push('cost-not-displayed');
+  if (!plan.approvals.costApproved || !plan.cost.approvedBy.trim()) generation.push('cost-not-approved');
+  // Cost figures must be real, finite and non-negative — otherwise a NaN/negative
+  // silently defeats the ceiling comparison instead of blocking generation.
+  const estimate = plan.cost.estimatedFlowCredits;
+  const ceiling = plan.cost.approvedCeilingFlowCredits;
+  if (!Number.isFinite(estimate) || estimate < 0) generation.push('invalid-cost-estimate');
+  if (!Number.isFinite(ceiling) || ceiling < 0) generation.push('invalid-cost-ceiling');
+  if (Number.isFinite(estimate) && Number.isFinite(ceiling) && estimate > ceiling) {
+    generation.push('cost-exceeds-ceiling');
+  }
+
+  // ── Publication gate ────────────────────────────────────────────────
+  if (!plan.approvals.publicationApproved) publication.push('publication-not-approved');
+
+  // ── Ladder: highest gate actually met (each level is cumulative) ────
+  let qualified: TrailerStatus = 'INCOMPLETE';
+  const structuralOk = structural.length === 0;
+  if (structuralOk && narrative.length === 0) qualified = 'READY_FOR_PREFLIGHT';
+  if (structuralOk && narrative.length === 0 && generation.length === 0) qualified = 'APPROVED_FOR_GENERATION';
+  if (structuralOk && narrative.length === 0 && generation.length === 0 && publication.length === 0) {
+    qualified = 'APPROVED_FOR_PUBLICATION';
+  }
+
+  // Structural + narrative blockers are ALWAYS surfaced (diagnostic). Generation
+  // and publication reasons are surfaced only when the *claimed* status reaches
+  // that rung — preserving "blockers = why the claim is not met" for the ladder
+  // while never hiding a structural/narrative defect at INCOMPLETE.
+  const claimed = plan.status;
+  const claimedIdx = statusIndex(claimed);
+  const blockers: string[] = [...structural, ...narrative];
+  if (claimedIdx >= statusIndex('APPROVED_FOR_GENERATION')) blockers.push(...generation);
+  if (claimedIdx >= statusIndex('APPROVED_FOR_PUBLICATION')) blockers.push(...publication);
+
+  // Effective status is never promoted above the claim, nor above what is met.
+  const effectiveIdx = Math.min(claimedIdx, statusIndex(qualified));
+  return {
+    status: STATUS_ORDER[effectiveIdx] ?? 'INCOMPLETE',
+    claimedStatus: claimed,
+    qualifiedStatus: qualified,
+    blockers,
+    warnings,
+  };
+}
+
+export interface TrailerPreviewCompilation {
+  /** A preview NEVER authorizes execution. */
+  executionAuthorized: false;
+  /** A preview NEVER authorizes publication. */
+  publicationAuthorized: false;
+  /**
+   * Gate state: the plan qualifies for generation AND the actually-routed cost
+   * sits within the approved ceiling. Still not an authorization.
+   */
+  readyForGeneration: boolean;
+  /** Gate state: the plan qualifies for publication (and routed cost is in budget). */
+  readyForPublication: boolean;
+  status: TrailerStatus;
+  qualifiedStatus: TrailerStatus;
+  blockers: string[];
+  /** Shots mapped to the existing hybrid-video request shape (one clip each). */
+  requests: HybridVideoRequest[];
+  /** Estimate/distribution from the shared router — no execution triggered. */
+  routing: { routes: HybridVideoRoute[]; estimatedFlowCredits: number };
+}
+
+/**
+ * PREVIEW-only compilation to the existing hybrid-video request/route shapes.
+ * Accepts an untrusted value and NEVER throws: a malformed plan or an
+ * unavailable route yields empty/partial `requests`/`routing` plus a diagnostic
+ * blocker, with `executionAuthorized`/`publicationAuthorized` always `false`.
+ *
+ * The router's own estimate is confronted with `approvedCeilingFlowCredits`: if
+ * the distributed cost exceeds the approved ceiling, generation/publication are
+ * marked not-ready and a `routed-cost-exceeds-ceiling` blocker is surfaced —
+ * even when the plan's *declared* estimate looked within budget.
+ */
+export function compileTrailerPreview(
+  input: unknown,
+  capacity: HybridVideoCapacity,
+): TrailerPreviewCompilation {
+  const validation = validateCinematicTrailerPlan(input);
+  const { plan } = normalizePlan(input);
+  const blockers = [...validation.blockers];
+
+  const requests: HybridVideoRequest[] = plan.shots.map((shot) => ({
+    id: shot.id,
+    useCase: shot.useCase as HybridVideoUseCase,
+    contentTier: plan.contentTier as ContentTier,
+    quantity: 1,
+    requiresLipSync: shot.requiresLipSync,
+    premium: shot.premium,
+  }));
+
+  let routing: { routes: HybridVideoRoute[]; estimatedFlowCredits: number } = {
+    routes: [],
+    estimatedFlowCredits: 0,
+  };
+  let routedCostWithinCeiling = false;
+  try {
+    routing = routeHybridVideoBatch(requests, capacity);
+    if (routing.routes.length > 0) {
+      const routed = routing.estimatedFlowCredits;
+      const ceiling = plan.cost.approvedCeilingFlowCredits;
+      if (Number.isFinite(ceiling) && ceiling >= 0 && Number.isFinite(routed) && routed <= ceiling) {
+        routedCostWithinCeiling = true;
+      } else {
+        blockers.push(`routed-cost-exceeds-ceiling:${routed}>${ceiling}`);
+      }
+    }
+  } catch (err) {
+    // Route unavailability is a real business signal, not something to mask.
+    routing = { routes: [], estimatedFlowCredits: 0 };
+    blockers.push(`routing-unavailable:${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const generationQualified =
+    validation.qualifiedStatus === 'APPROVED_FOR_GENERATION' ||
+    validation.qualifiedStatus === 'APPROVED_FOR_PUBLICATION';
+  const publicationQualified = validation.qualifiedStatus === 'APPROVED_FOR_PUBLICATION';
+
+  return {
+    executionAuthorized: false,
+    publicationAuthorized: false,
+    readyForGeneration: generationQualified && routedCostWithinCeiling,
+    readyForPublication: publicationQualified && routedCostWithinCeiling,
+    status: validation.status,
+    qualifiedStatus: validation.qualifiedStatus,
+    blockers,
+    requests,
+    routing,
+  };
+}

--- a/src/tools/video/comfy-client.ts
+++ b/src/tools/video/comfy-client.ts
@@ -1,0 +1,292 @@
+/** Polling-only headless ComfyUI client for exported API workflows. */
+
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import type { ComfyWorkflowGraph } from './comfy-workflow-template.js';
+
+export interface ComfyDevice {
+  name?: string;
+  type?: string;
+  index?: number;
+  vram_total?: number;
+  vram_free?: number;
+  [key: string]: unknown;
+}
+
+export interface ComfyProbeResult {
+  ok: boolean;
+  devices: ComfyDevice[];
+}
+
+export interface ComfyOutput {
+  nodeId: string;
+  kind: 'image' | 'video' | 'gif';
+  filename: string;
+  subfolder: string;
+  type: string;
+  path: string;
+}
+
+export interface SubmitAndAwaitOptions {
+  clientId: string;
+  timeoutMs: number;
+  pollMs: number;
+  fetchImpl?: typeof fetch;
+  workDir?: string;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface SubmitAndAwaitResult {
+  promptId: string;
+  outputs: ComfyOutput[];
+  workDir: string;
+}
+
+interface ComfyOutputReference {
+  filename: string;
+  subfolder?: string;
+  type?: string;
+}
+
+function endpoint(baseUrl: string, suffix: string): string {
+  return `${baseUrl.replace(/\/+$/u, '')}${suffix}`;
+}
+
+async function responseJson(response: Response, context: string): Promise<Record<string, unknown>> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`${context} returned invalid JSON (${response.status})`);
+  }
+  if (!response.ok) throw new Error(`${context} failed (${response.status}): ${JSON.stringify(body).slice(0, 500)}`);
+  if (!body || typeof body !== 'object' || Array.isArray(body)) throw new Error(`${context} returned a non-object response`);
+  return body as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function describeNodeError(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (!item || typeof item !== 'object') continue;
+      const found = describeNodeError(item);
+      if (found) return found;
+    }
+    for (const item of value) {
+      const found = describeNodeError(item);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ['exception_message', 'message', 'error', 'details']) {
+    const found = describeNodeError(record[key]);
+    if (found) {
+      const nodeId = stringField(record, 'node_id') ?? stringField(record, 'nodeId');
+      return nodeId ? `node ${nodeId}: ${found}` : found;
+    }
+  }
+  for (const nested of Object.values(record)) {
+    const found = describeNodeError(nested);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function outputReferences(outputs: unknown): Array<{ nodeId: string; kind: ComfyOutput['kind']; ref: ComfyOutputReference }> {
+  if (!outputs || typeof outputs !== 'object' || Array.isArray(outputs)) return [];
+  const references: Array<{ nodeId: string; kind: ComfyOutput['kind']; ref: ComfyOutputReference }> = [];
+  const categories = [
+    ['images', 'image'],
+    ['videos', 'video'],
+    ['gifs', 'gif'],
+  ] as const;
+  for (const [nodeId, candidate] of Object.entries(outputs as Record<string, unknown>)) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+    const nodeOutput = candidate as Record<string, unknown>;
+    for (const [field, kind] of categories) {
+      const items = nodeOutput[field];
+      if (!Array.isArray(items)) continue;
+      for (const item of items) {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+        const ref = item as Record<string, unknown>;
+        const filename = stringField(ref, 'filename');
+        if (filename) references.push({
+          nodeId,
+          kind,
+          ref: {
+            filename,
+            subfolder: stringField(ref, 'subfolder'),
+            type: stringField(ref, 'type'),
+          },
+        });
+      }
+    }
+  }
+  return references;
+}
+
+function safeOutputName(filename: string, nodeId: string, index: number): string {
+  const basename = path.basename(filename);
+  if (basename !== filename || !basename || basename === '.' || basename === '..') {
+    throw new Error(`ComfyUI returned unsafe output filename: ${filename}`);
+  }
+  return `${nodeId}-${index}-${basename.replace(/[^A-Za-z0-9._-]/gu, '_')}`;
+}
+
+async function defaultSleep(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function fetchWithin(
+  fetchImpl: typeof fetch,
+  input: string,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+  context: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${context} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      fetchImpl(input, { ...init, signal: controller.signal }),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function probeComfy(baseUrl: string, fetchImpl: typeof fetch = fetch): Promise<ComfyProbeResult> {
+  try {
+    const body = await responseJson(
+      await fetchWithin(fetchImpl, endpoint(baseUrl, '/system_stats'), undefined, 10_000, 'ComfyUI /system_stats'),
+      'ComfyUI /system_stats',
+    );
+    const devices = Array.isArray(body.devices)
+      ? body.devices.filter((device): device is ComfyDevice => Boolean(device) && typeof device === 'object' && !Array.isArray(device))
+      : [];
+    return { ok: true, devices };
+  } catch {
+    return { ok: false, devices: [] };
+  }
+}
+
+export async function submitAndAwait(
+  baseUrl: string,
+  graph: ComfyWorkflowGraph,
+  options: SubmitAndAwaitOptions,
+): Promise<SubmitAndAwaitResult> {
+  if (!options.clientId.trim()) throw new Error('ComfyUI clientId is required');
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) throw new Error('ComfyUI timeoutMs must be positive');
+  if (!Number.isFinite(options.pollMs) || options.pollMs < 0) throw new Error('ComfyUI pollMs must be non-negative');
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const startedAt = now();
+  const submission = await responseJson(await fetchWithin(fetchImpl, endpoint(baseUrl, '/prompt'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt: graph, client_id: options.clientId }),
+  }, options.timeoutMs, 'ComfyUI /prompt'), 'ComfyUI /prompt');
+  const promptId = stringField(submission, 'prompt_id');
+  if (!promptId) {
+    const detail = describeNodeError(submission.node_errors ?? submission.error);
+    throw new Error(`ComfyUI rejected workflow without prompt_id${detail ? `: ${detail}` : ''}`);
+  }
+
+  let completedOutputs: unknown;
+  for (;;) {
+    if (now() - startedAt >= options.timeoutMs) {
+      throw new Error(`ComfyUI prompt ${promptId} timed out after ${options.timeoutMs}ms`);
+    }
+    const remainingMs = Math.max(1, options.timeoutMs - (now() - startedAt));
+    const history = await responseJson(
+      await fetchWithin(
+        fetchImpl,
+        endpoint(baseUrl, `/history/${encodeURIComponent(promptId)}`),
+        undefined,
+        remainingMs,
+        `ComfyUI /history/${promptId}`,
+      ),
+      `ComfyUI /history/${promptId}`,
+    );
+    const candidate = history[promptId];
+    if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      const entry = candidate as Record<string, unknown>;
+      const status = entry.status && typeof entry.status === 'object' && !Array.isArray(entry.status)
+        ? entry.status as Record<string, unknown>
+        : undefined;
+      const statusText = typeof status?.status_str === 'string' ? status.status_str.toLowerCase() : '';
+      // status.messages mixes benign lifecycle entries (execution_start/_cached/
+      // _success) with execution_error tuples; only the latter are error sources —
+      // recursing into benign entries surfaces their prompt_id as a phantom error.
+      const errorMessages = Array.isArray(status?.messages)
+        ? (status.messages as unknown[]).filter((item) => Array.isArray(item) && item[0] === 'execution_error')
+        : [];
+      const nodeErrors = entry.node_errors && typeof entry.node_errors === 'object'
+        && Object.keys(entry.node_errors as Record<string, unknown>).length > 0
+        ? entry.node_errors
+        : undefined;
+      const error = describeNodeError(nodeErrors ?? (errorMessages.length > 0 ? errorMessages : undefined) ?? entry.error);
+      if (error || ['error', 'failed', 'cancelled', 'canceled'].includes(statusText)) {
+        throw new Error(`ComfyUI prompt ${promptId} failed${error ? `: ${error}` : ` (${statusText})`}`);
+      }
+      if (entry.outputs && outputReferences(entry.outputs).length > 0) {
+        completedOutputs = entry.outputs;
+        break;
+      }
+      if (status?.completed === true) throw new Error(`ComfyUI prompt ${promptId} completed without downloadable outputs`);
+    }
+    await sleep(options.pollMs);
+  }
+
+  const workDir = options.workDir ?? await fs.mkdtemp(path.join(os.tmpdir(), 'codebuddy-comfy-'));
+  await fs.mkdir(workDir, { recursive: true });
+  const refs = outputReferences(completedOutputs);
+  const outputs: ComfyOutput[] = [];
+  for (const [index, output] of refs.entries()) {
+    const subfolder = output.ref.subfolder ?? '';
+    if (subfolder.split(/[\\/]/u).some((part) => part === '..')) {
+      throw new Error(`ComfyUI returned unsafe output subfolder: ${subfolder}`);
+    }
+    const type = output.ref.type ?? 'output';
+    const query = new URLSearchParams({ filename: output.ref.filename, subfolder, type });
+    const remainingMs = Math.max(1, options.timeoutMs - (now() - startedAt));
+    const response = await fetchWithin(
+      fetchImpl,
+      endpoint(baseUrl, `/view?${query.toString()}`),
+      undefined,
+      remainingMs,
+      `ComfyUI /view ${output.ref.filename}`,
+    );
+    if (!response.ok) throw new Error(`ComfyUI /view failed (${response.status}) for ${output.ref.filename}`);
+    const bytes = Buffer.from(await response.arrayBuffer());
+    const outputPath = path.join(workDir, safeOutputName(output.ref.filename, output.nodeId, index));
+    await fs.writeFile(outputPath, bytes, { flag: 'wx' });
+    outputs.push({
+      nodeId: output.nodeId,
+      kind: output.kind,
+      filename: output.ref.filename,
+      subfolder,
+      type,
+      path: outputPath,
+    });
+  }
+  return { promptId, outputs, workDir };
+}

--- a/src/tools/video/comfy-workflow-template.ts
+++ b/src/tools/video/comfy-workflow-template.ts
@@ -1,0 +1,293 @@
+/** Validation and pure patching for operator-exported ComfyUI API workflows. */
+
+export type WorkflowPatchRole =
+  | 'seed'
+  | 'prompt'
+  | 'insertPrompt'
+  | 'negative'
+  | 'inputImage'
+  | 'characterImage'
+  | 'locationImage'
+  | 'endImage'
+  | 'inputVideo'
+  | 'frames'
+  | 'resolution'
+  | 'outputPrefix';
+
+export interface ComfyWorkflowNode {
+  class_type: string;
+  inputs: Record<string, unknown>;
+  _meta?: { title?: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+export type ComfyWorkflowGraph = Record<string, ComfyWorkflowNode>;
+
+export interface TemplateClassRequirement {
+  classType: string;
+  /** Exact number of nodes of this class required in the exported graph. */
+  count: number;
+}
+
+export interface TemplateRoleSelector {
+  classType: string;
+  input: string;
+  /** Required when the class occurs more than once and only one node is patched. */
+  title?: string;
+  /** Patch every matching node. The contract can still require an exact count. */
+  all?: boolean;
+}
+
+export interface TemplateContract {
+  id:
+    | 'keyframe-flux'
+    | 'insert-qwen-edit'
+    | 'insert-qwen-edit-relight'
+    | 'i2v-wan-lightx2v'
+    | 'i2v-wan-flf2v'
+    | 'upscale-seedvr2'
+    | 'interpolate-rife';
+  required: readonly TemplateClassRequirement[];
+  roles: Readonly<Partial<Record<WorkflowPatchRole, readonly TemplateRoleSelector[]>>>;
+}
+
+export interface TemplateRoleBinding {
+  nodeId: string;
+  input: string;
+}
+
+export interface LoadedWorkflowTemplate {
+  graph: ComfyWorkflowGraph;
+  contract: TemplateContract;
+  roleBindings: Readonly<Partial<Record<WorkflowPatchRole, readonly TemplateRoleBinding[]>>>;
+}
+
+export type WorkflowPatch =
+  | { role: 'seed'; value: number }
+  | {
+      role:
+        | 'prompt'
+        | 'insertPrompt'
+        | 'negative'
+        | 'inputImage'
+        | 'characterImage'
+        | 'locationImage'
+        | 'endImage'
+        | 'inputVideo'
+        | 'outputPrefix';
+      value: string;
+    }
+  | { role: 'frames'; value: number }
+  | { role: 'resolution'; value: { width: number; height: number } | number };
+
+const KEYFRAME_FLUX_CONTRACT: TemplateContract = {
+  id: 'keyframe-flux',
+  required: [
+    { classType: 'CLIPTextEncode', count: 2 },
+    { classType: 'RandomNoise', count: 1 },
+    { classType: 'EmptySD3LatentImage', count: 1 },
+    { classType: 'SaveImage', count: 1 },
+  ],
+  roles: {
+    seed: [{ classType: 'RandomNoise', input: 'noise_seed' }],
+    prompt: [{ classType: 'CLIPTextEncode', input: 'text', title: 'Positive Prompt' }],
+    negative: [{ classType: 'CLIPTextEncode', input: 'text', title: 'Negative Prompt' }],
+    resolution: [
+      { classType: 'EmptySD3LatentImage', input: 'width' },
+      { classType: 'EmptySD3LatentImage', input: 'height' },
+    ],
+    outputPrefix: [{ classType: 'SaveImage', input: 'filename_prefix' }],
+  },
+};
+
+const I2V_BASE_REQUIRED: readonly TemplateClassRequirement[] = [
+  { classType: 'WanVideoModelLoader', count: 2 },
+  { classType: 'WanVideoSampler', count: 2 },
+  { classType: 'WanVideoImageToVideoEncode', count: 1 },
+  { classType: 'WanVideoTextEncode', count: 1 },
+  { classType: 'LoadImage', count: 1 },
+  { classType: 'VHS_VideoCombine', count: 1 },
+];
+
+const I2V_BASE_ROLES: TemplateContract['roles'] = {
+  seed: [{ classType: 'WanVideoSampler', input: 'seed', all: true }],
+  prompt: [{ classType: 'WanVideoTextEncode', input: 'positive_prompt' }],
+  negative: [{ classType: 'WanVideoTextEncode', input: 'negative_prompt' }],
+  inputImage: [{ classType: 'LoadImage', input: 'image' }],
+  frames: [{ classType: 'WanVideoImageToVideoEncode', input: 'num_frames' }],
+  resolution: [
+    { classType: 'WanVideoImageToVideoEncode', input: 'width' },
+    { classType: 'WanVideoImageToVideoEncode', input: 'height' },
+  ],
+  outputPrefix: [{ classType: 'VHS_VideoCombine', input: 'filename_prefix' }],
+};
+
+export const KEYFRAME_FLUX_TEMPLATE_CONTRACT = KEYFRAME_FLUX_CONTRACT;
+export const I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT: TemplateContract = {
+  id: 'i2v-wan-lightx2v', required: I2V_BASE_REQUIRED, roles: I2V_BASE_ROLES,
+};
+export const I2V_WAN_FLF2V_TEMPLATE_CONTRACT: TemplateContract = {
+  id: 'i2v-wan-flf2v',
+  required: I2V_BASE_REQUIRED.map((requirement) => (
+    requirement.classType === 'LoadImage' ? { ...requirement, count: 2 } : requirement
+  )),
+  roles: {
+    ...I2V_BASE_ROLES,
+    inputImage: [{ classType: 'LoadImage', input: 'image', title: 'Start Image' }],
+    endImage: [{ classType: 'LoadImage', input: 'image', title: 'End Image' }],
+  },
+};
+export const UPSCALE_SEEDVR2_TEMPLATE_CONTRACT: TemplateContract = {
+  id: 'upscale-seedvr2',
+  required: [
+    { classType: 'VHS_LoadVideo', count: 1 },
+    { classType: 'SeedVR2LoadDiTModel', count: 1 },
+    { classType: 'SeedVR2LoadVAEModel', count: 1 },
+    { classType: 'SeedVR2VideoUpscaler', count: 1 },
+    { classType: 'VHS_VideoCombine', count: 1 },
+  ],
+  roles: {
+    seed: [{ classType: 'SeedVR2VideoUpscaler', input: 'seed' }],
+    inputVideo: [{ classType: 'VHS_LoadVideo', input: 'video' }],
+    frames: [{ classType: 'SeedVR2VideoUpscaler', input: 'batch_size' }],
+    resolution: [{ classType: 'SeedVR2VideoUpscaler', input: 'resolution' }],
+    outputPrefix: [{ classType: 'VHS_VideoCombine', input: 'filename_prefix' }],
+  },
+};
+export const INTERPOLATE_RIFE_TEMPLATE_CONTRACT: TemplateContract = {
+  id: 'interpolate-rife',
+  required: [
+    { classType: 'VHS_LoadVideo', count: 1 },
+    { classType: 'RIFE VFI', count: 1 },
+    { classType: 'VHS_VideoCombine', count: 1 },
+  ],
+  roles: {
+    inputVideo: [{ classType: 'VHS_LoadVideo', input: 'video' }],
+    frames: [{ classType: 'RIFE VFI', input: 'multiplier' }],
+    outputPrefix: [{ classType: 'VHS_VideoCombine', input: 'filename_prefix' }],
+  },
+};
+
+export const TEMPLATE_CONTRACTS = {
+  'keyframe-flux': KEYFRAME_FLUX_TEMPLATE_CONTRACT,
+  'i2v-wan-lightx2v': I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT,
+  'i2v-wan-flf2v': I2V_WAN_FLF2V_TEMPLATE_CONTRACT,
+  'upscale-seedvr2': UPSCALE_SEEDVR2_TEMPLATE_CONTRACT,
+  'interpolate-rife': INTERPOLATE_RIFE_TEMPLATE_CONTRACT,
+} as const;
+
+function cloneGraph(graph: ComfyWorkflowGraph): ComfyWorkflowGraph {
+  return structuredClone(graph);
+}
+
+function parseGraph(json: unknown): ComfyWorkflowGraph {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error('ComfyUI API workflow must be an object keyed by node id');
+  }
+  const graph = json as Record<string, unknown>;
+  if (Object.keys(graph).length === 0) throw new Error('ComfyUI API workflow must contain nodes');
+  for (const [nodeId, candidate] of Object.entries(graph)) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      throw new Error(`ComfyUI API workflow node ${nodeId} must be an object`);
+    }
+    const node = candidate as Partial<ComfyWorkflowNode>;
+    if (typeof node.class_type !== 'string' || !node.class_type.trim()) {
+      throw new Error(`ComfyUI API workflow node ${nodeId} is missing class_type`);
+    }
+    if (!node.inputs || typeof node.inputs !== 'object' || Array.isArray(node.inputs)) {
+      throw new Error(`ComfyUI API workflow node ${nodeId} is missing inputs`);
+    }
+  }
+  return cloneGraph(graph as ComfyWorkflowGraph);
+}
+
+function nodesOfClass(graph: ComfyWorkflowGraph, classType: string): Array<[string, ComfyWorkflowNode]> {
+  return Object.entries(graph).filter((entry) => entry[1].class_type === classType);
+}
+
+export function loadWorkflowTemplate(json: unknown, contract: TemplateContract): LoadedWorkflowTemplate {
+  const graph = parseGraph(json);
+  for (const requirement of contract.required) {
+    const actual = nodesOfClass(graph, requirement.classType).length;
+    if (actual !== requirement.count) {
+      throw new Error(
+        `Template ${contract.id} requires exactly ${requirement.count} ${requirement.classType} node(s); found ${actual}`,
+      );
+    }
+  }
+
+  const roleBindings: Partial<Record<WorkflowPatchRole, readonly TemplateRoleBinding[]>> = {};
+  for (const [role, selectors] of Object.entries(contract.roles) as Array<[WorkflowPatchRole, readonly TemplateRoleSelector[]]>) {
+    const bindings: TemplateRoleBinding[] = [];
+    for (const selector of selectors) {
+      let candidates = nodesOfClass(graph, selector.classType);
+      if (selector.title) {
+        candidates = candidates.filter(([, node]) => node._meta?.title === selector.title);
+      } else if (!selector.all && candidates.length > 1) {
+        throw new Error(
+          `Template ${contract.id} role ${role} is ambiguous for ${selector.classType}; disambiguate with _meta.title`,
+        );
+      }
+      if (candidates.length === 0) {
+        throw new Error(
+          `Template ${contract.id} cannot resolve role ${role} to ${selector.classType}` +
+          (selector.title ? ` titled "${selector.title}"` : ''),
+        );
+      }
+      for (const [nodeId, node] of candidates) {
+        if (!(selector.input in node.inputs)) {
+          throw new Error(
+            `Template ${contract.id} role ${role} expects input ${selector.input} on node ${nodeId} (${selector.classType})`,
+          );
+        }
+        bindings.push({ nodeId, input: selector.input });
+      }
+    }
+    roleBindings[role] = bindings;
+  }
+  return { graph, contract, roleBindings };
+}
+
+function assertInteger(value: number, role: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${role} patch must be a non-negative safe integer`);
+}
+
+export function patchWorkflow(
+  template: LoadedWorkflowTemplate,
+  patches: readonly WorkflowPatch[],
+): ComfyWorkflowGraph {
+  const graph = cloneGraph(template.graph);
+  for (const patch of patches) {
+    const bindings = template.roleBindings[patch.role];
+    if (!bindings || bindings.length === 0) {
+      throw new Error(`Template ${template.contract.id} does not resolve patch role ${patch.role}`);
+    }
+    if (patch.role === 'seed' || patch.role === 'frames') assertInteger(patch.value, patch.role);
+    if (patch.role === 'resolution') {
+      const dimensions = typeof patch.value === 'number'
+        ? { width: patch.value, height: patch.value }
+        : patch.value;
+      assertInteger(dimensions.width, 'resolution width');
+      assertInteger(dimensions.height, 'resolution height');
+      for (const binding of bindings) {
+        const node = graph[binding.nodeId]!;
+        node.inputs[binding.input] = binding.input === 'height' ? dimensions.height : dimensions.width;
+      }
+      continue;
+    }
+    for (const binding of bindings) graph[binding.nodeId]!.inputs[binding.input] = patch.value;
+  }
+  return graph;
+}
+
+export function assertAllSeedsPinned(graph: ComfyWorkflowGraph): void {
+  for (const [nodeId, node] of Object.entries(graph)) {
+    for (const input of ['seed', 'noise_seed'] as const) {
+      if (!(input in node.inputs)) continue;
+      const value = node.inputs[input];
+      if (!Number.isSafeInteger(value) || (value as number) < 0) {
+        throw new Error(`ComfyUI workflow seed ${nodeId}.${input} must be explicitly pinned to a non-negative integer`);
+      }
+    }
+  }
+}

--- a/src/tools/video/google-flow-driver.ts
+++ b/src/tools/video/google-flow-driver.ts
@@ -1,0 +1,388 @@
+/** Operator-attached Google Flow browser driver. Never launches Chrome or handles login. */
+
+import { mkdir } from 'fs/promises';
+import path from 'path';
+
+import { isLoopbackHost } from '../../security/dev-origins.js';
+
+export const DEFAULT_FLOW_CDP_URL = 'http://127.0.0.1:9222';
+export const GOOGLE_FLOW_URL = 'https://labs.google/fx/tools/flow';
+
+/**
+ * Google changes Flow's UI regularly. Keep every DOM dependency here so an
+ * operator can update and re-run the selector-only dry run before spending.
+ */
+export const FLOW_SELECTORS = {
+  appRoot: '[data-testid="flow-app"], flow-app, main',
+  signIn: 'a[href*="accounts.google.com"], button:has-text("Sign in"), button:has-text("Se connecter")',
+  errorBanner: '[role="alert"], [data-testid*="error"], [class*="error-banner"]',
+  creditBalance: '[data-testid*="credit"], [aria-label*="credit" i], [class*="credit-balance"]',
+  modelMenu: 'button[aria-label*="model" i], [data-testid="model-selector"] button',
+  modelOption: {
+    'veo-3.1-fast': '[role="option"]:has-text("Veo 3.1"):has-text("Fast"), [role="menuitem"]:has-text("Veo 3.1"):has-text("Fast")',
+    'veo-3.1-quality': '[role="option"]:has-text("Veo 3.1"):has-text("Quality"), [role="menuitem"]:has-text("Veo 3.1"):has-text("Quality")',
+  },
+  aspectMenu: 'button[aria-label*="aspect" i], [data-testid="aspect-ratio-selector"] button',
+  aspectOption: {
+    '9:16': '[role="option"]:has-text("9:16"), [role="menuitem"]:has-text("9:16")',
+    '16:9': '[role="option"]:has-text("16:9"), [role="menuitem"]:has-text("16:9")',
+  },
+  ingredientsInput: 'input[type="file"][accept*="image"], [data-testid="ingredients-upload"] input[type="file"]',
+  ingredientsPreview: '[data-testid*="ingredient-preview"], [class*="ingredient-preview"]',
+  ingredientRemoveButton: '[data-testid*="ingredient-preview"] button[aria-label*="remove" i], [class*="ingredient-preview"] button[aria-label*="remove" i]',
+  promptInput: 'textarea[placeholder], [contenteditable="true"][role="textbox"], [data-testid="prompt-input"]',
+  submitButton: 'button[aria-label*="generate" i], button:has-text("Generate"), button:has-text("Générer")',
+  generationProgress: '[role="progressbar"], [data-testid*="generation-progress"], [class*="generating"]',
+  resultReady: '[data-testid*="generation-result"] video, [data-testid*="generation-result"] img, main video',
+  downloadButton: 'button[aria-label*="download" i], [data-testid*="download"] button',
+} as const;
+
+export type FlowModel = keyof typeof FLOW_SELECTORS.modelOption;
+export type FlowAspect = keyof typeof FLOW_SELECTORS.aspectOption;
+
+interface FlowLocator {
+  waitFor(options: { state: 'visible'; timeout: number }): Promise<void>;
+  isVisible(options?: { timeout?: number }): Promise<boolean>;
+  isEnabled(options?: { timeout?: number }): Promise<boolean>;
+  click(options?: { timeout?: number }): Promise<void>;
+  fill(value: string, options?: { timeout?: number }): Promise<void>;
+  setInputFiles(files: string[], options?: { timeout?: number }): Promise<void>;
+  textContent(options?: { timeout?: number }): Promise<string | null>;
+  count(): Promise<number>;
+  getAttribute(name: string, options?: { timeout?: number }): Promise<string | null>;
+  first(): FlowLocator;
+}
+
+/** Playwright Download subset — kept local so the driver stays injectable. */
+export interface FlowDownload {
+  failure(): Promise<string | null>;
+  saveAs(destPath: string): Promise<void>;
+}
+
+export interface FlowPage {
+  url(): string;
+  locator(selector: string): FlowLocator;
+  goto(url: string, options: { waitUntil: 'domcontentloaded'; timeout: number }): Promise<unknown>;
+  waitForTimeout(milliseconds: number): Promise<void>;
+  waitForEvent(event: 'download', options?: { timeout?: number }): Promise<FlowDownload>;
+}
+
+export interface FlowBrowserContext {
+  pages(): FlowPage[];
+  newPage(): Promise<FlowPage>;
+}
+
+export interface FlowBrowser {
+  contexts(): FlowBrowserContext[];
+}
+
+export interface AttachToBrowserResult {
+  browser: FlowBrowser;
+  page: FlowPage;
+  driver: FlowDriver;
+}
+
+export interface AttachToBrowserOptions {
+  cdpUrl?: string;
+  timeoutMs?: number;
+  connector?: (cdpUrl: string) => Promise<FlowBrowser>;
+}
+
+export interface FlowDriverOptions {
+  actionTimeoutMs?: number;
+  generationTimeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+const UI_ERROR = /(?:quota|not enough|insufficient|failed|failure|error|erreur|unable|impossible)/iu;
+
+export class FlowDriver {
+  private readonly actionTimeoutMs: number;
+  private readonly generationTimeoutMs: number;
+  private readonly pollIntervalMs: number;
+
+  constructor(private readonly page: FlowPage, options: FlowDriverOptions = {}) {
+    this.actionTimeoutMs = positiveTimeout(options.actionTimeoutMs, 15_000, 'action timeout');
+    this.generationTimeoutMs = positiveTimeout(options.generationTimeoutMs, 12 * 60_000, 'generation timeout');
+    this.pollIntervalMs = positiveTimeout(options.pollIntervalMs, 1_000, 'poll interval');
+  }
+
+  async verifyReady(): Promise<void> {
+    await this.assertAuthenticated();
+    await this.visible(FLOW_SELECTORS.appRoot, 'Flow application');
+    await this.visible(FLOW_SELECTORS.promptInput, 'Flow prompt input');
+    await this.visible(FLOW_SELECTORS.modelMenu, 'Flow model selector');
+    await this.visible(FLOW_SELECTORS.aspectMenu, 'Flow aspect selector');
+    await this.visible(FLOW_SELECTORS.ingredientsInput, 'Flow ingredients input');
+    await this.visible(FLOW_SELECTORS.submitButton, 'Flow generate button');
+    await this.visible(FLOW_SELECTORS.creditBalance, 'Flow credit balance');
+    await this.throwIfUiError();
+  }
+
+  async assertAuthenticated(): Promise<void> {
+    const currentUrl = this.page.url();
+    const loginVisible = await this.page.locator(FLOW_SELECTORS.signIn).first().isVisible({ timeout: 500 }).catch(() => false);
+    if (isGoogleLoginUrl(currentUrl) || loginVisible) {
+      throw new Error('Google Flow is not authenticated: connecte-toi d\'abord dans le navigateur, puis relance le driver');
+    }
+  }
+
+  async setModel(model: FlowModel): Promise<void> {
+    await this.throwIfUiError();
+    await this.safeClick(FLOW_SELECTORS.modelMenu, 'Flow model selector');
+    await this.safeClick(FLOW_SELECTORS.modelOption[model], `Flow model ${model}`);
+    await this.throwIfUiError();
+  }
+
+  async setAspect(aspect: FlowAspect): Promise<void> {
+    await this.throwIfUiError();
+    await this.safeClick(FLOW_SELECTORS.aspectMenu, 'Flow aspect selector');
+    await this.safeClick(FLOW_SELECTORS.aspectOption[aspect], `Flow aspect ${aspect}`);
+    await this.throwIfUiError();
+  }
+
+  async setIngredients(imagePaths: string[]): Promise<void> {
+    if (imagePaths.length > 3) throw new Error('Google Flow accepts at most 3 ingredient images');
+    if (!imagePaths.length) throw new Error('Google Flow generation requires at least one ingredient image');
+    if (new Set(imagePaths).size !== imagePaths.length || imagePaths.some((filename) => !path.isAbsolute(filename))) {
+      throw new Error('Flow ingredient paths must be unique absolute paths');
+    }
+    await this.throwIfUiError();
+    const removeButtons = this.page.locator(FLOW_SELECTORS.ingredientRemoveButton);
+    let existing = await removeButtons.count();
+    while (existing > 0) {
+      if (existing > 3) throw new Error('Flow displayed more than 3 existing ingredients; refusing ambiguous edits');
+      const remove = await this.clickable(FLOW_SELECTORS.ingredientRemoveButton, 'Flow ingredient remove button');
+      await remove.click({ timeout: this.actionTimeoutMs });
+      await this.waitUntil(async () => (await removeButtons.count()) < existing, this.actionTimeoutMs,
+        'Flow did not remove the previous ingredient');
+      existing = await removeButtons.count();
+    }
+    const input = await this.visible(FLOW_SELECTORS.ingredientsInput, 'Flow ingredients input');
+    await input.setInputFiles(imagePaths, { timeout: this.actionTimeoutMs });
+    const previews = this.page.locator(FLOW_SELECTORS.ingredientsPreview);
+    await this.waitUntil(async () => (await previews.count()) >= imagePaths.length, this.actionTimeoutMs,
+      `Flow did not display ${imagePaths.length} ingredient preview(s)`);
+    await this.throwIfUiError();
+  }
+
+  async submitPrompt(text: string): Promise<void> {
+    const prompt = text.trim();
+    if (!prompt) throw new Error('Flow prompt must not be empty');
+    await this.throwIfUiError();
+    const result = this.page.locator(FLOW_SELECTORS.resultReady);
+    const previousCount = await result.count();
+    const previousSource = previousCount > 0 ? await result.first().getAttribute('src').catch(() => null) : null;
+    const input = await this.visible(FLOW_SELECTORS.promptInput, 'Flow prompt input');
+    await input.fill(prompt, { timeout: this.actionTimeoutMs });
+    await this.safeClick(FLOW_SELECTORS.submitButton, 'Flow generate button');
+
+    let sawProgress = false;
+    await this.waitUntil(async () => {
+      await this.throwIfUiError();
+      const progress = this.page.locator(FLOW_SELECTORS.generationProgress).first();
+      sawProgress ||= await progress.isVisible({ timeout: 250 }).catch(() => false);
+      const currentCount = await result.count();
+      if (currentCount === 0) return false;
+      const currentSource = await result.first().getAttribute('src').catch(() => null);
+      const progressVisible = await progress.isVisible({ timeout: 250 }).catch(() => false);
+      const resultChanged = previousCount === 0 || currentCount > previousCount || currentSource !== previousSource;
+      return !progressVisible && (sawProgress || resultChanged);
+    }, this.generationTimeoutMs, `Google Flow generation timed out after ${this.generationTimeoutMs} ms`);
+    await this.throwIfUiError();
+  }
+
+  async downloadResult(destPath: string): Promise<void> {
+    if (!path.isAbsolute(destPath) || path.extname(destPath).toLowerCase() !== '.mp4') {
+      throw new Error('Flow download destination must be an absolute .mp4 path');
+    }
+    await this.throwIfUiError();
+    await this.visible(FLOW_SELECTORS.resultReady, 'completed Flow result');
+    const button = await this.clickable(FLOW_SELECTORS.downloadButton, 'Flow download button');
+    await mkdir(path.dirname(destPath), { recursive: true, mode: 0o700 });
+    const [download] = await Promise.all([
+      this.page.waitForEvent('download', { timeout: this.actionTimeoutMs }),
+      button.click({ timeout: this.actionTimeoutMs }),
+    ]);
+    const failure = await download.failure();
+    if (failure) throw new Error(`Google Flow download failed: ${failure}`);
+    await download.saveAs(destPath);
+  }
+
+  async readCreditBalance(): Promise<number> {
+    await this.assertAuthenticated();
+    await this.throwIfUiError();
+    const balance = await this.visible(FLOW_SELECTORS.creditBalance, 'Flow credit balance');
+    const text = (await balance.textContent({ timeout: this.actionTimeoutMs }))?.trim() ?? '';
+    const match = /(\d[\d\s.,\u202f]*)\s*(?:AI\s+)?(?:credits?|crédits?)/iu.exec(text);
+    if (!match?.[1]) throw new Error(`Could not parse Google Flow credit balance from ${JSON.stringify(text)}`);
+    const digits = match[1].replace(/[^\d]/gu, '');
+    const value = Number.parseInt(digits, 10);
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error('Google Flow displayed an invalid credit balance');
+    return value;
+  }
+
+  private async safeClick(selector: string, label: string): Promise<void> {
+    const locator = await this.clickable(selector, label);
+    await locator.click({ timeout: this.actionTimeoutMs });
+  }
+
+  private async visible(selector: string, label: string): Promise<FlowLocator> {
+    const locator = this.page.locator(selector).first();
+    try {
+      await locator.waitFor({ state: 'visible', timeout: this.actionTimeoutMs });
+      if (!await locator.isVisible({ timeout: 500 })) throw new Error('not visible');
+      return locator;
+    } catch (error) {
+      await this.assertAuthenticated();
+      throw new Error(`${label} is unavailable; update FLOW_SELECTORS if the Google UI changed: ${errorMessage(error)}`);
+    }
+  }
+
+  private async clickable(selector: string, label: string): Promise<FlowLocator> {
+    const locator = await this.visible(selector, label);
+    if (!await locator.isEnabled({ timeout: 500 })) throw new Error(`${label} is disabled; refusing a blind click`);
+    return locator;
+  }
+
+  private async throwIfUiError(): Promise<void> {
+    const locator = this.page.locator(FLOW_SELECTORS.errorBanner).first();
+    if (!await locator.isVisible({ timeout: 250 }).catch(() => false)) return;
+    const text = (await locator.textContent({ timeout: 500 }).catch(() => null))?.trim() ?? '';
+    if (UI_ERROR.test(text)) throw new Error(`Google Flow UI error: ${text || 'unknown generation failure'}`);
+  }
+
+  private async waitUntil(
+    predicate: () => Promise<boolean>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await this.page.waitForTimeout(Math.min(this.pollIntervalMs, Math.max(1, deadline - Date.now())));
+    }
+    throw new Error(timeoutMessage);
+  }
+}
+
+async function defaultConnectOverCdp(cdpUrl: string): Promise<FlowBrowser> {
+  const { chromium } = await import('playwright');
+  return chromium.connectOverCDP(cdpUrl) as unknown as FlowBrowser;
+}
+
+export async function attachToBrowser(options: AttachToBrowserOptions = {}): Promise<AttachToBrowserResult> {
+  const cdpUrl = assertLoopbackCdpUrl(options.cdpUrl ?? DEFAULT_FLOW_CDP_URL);
+  const timeoutMs = positiveTimeout(options.timeoutMs, 30_000, 'CDP timeout');
+  let attached: FlowBrowser;
+  try {
+    attached = await (options.connector ?? defaultConnectOverCdp)(cdpUrl);
+  } catch (error) {
+    throw new Error(`Could not attach to operator Chrome at ${cdpUrl}: ${errorMessage(error)}`);
+  }
+  const context = attached.contexts()[0];
+  if (!context) {
+    throw new Error('The attached Chrome has no operator profile context; launch Chrome with the connected profile first');
+  }
+  const page = context.pages().find((candidate) => isFlowUrl(candidate.url())) ?? await openFlowTab(context, timeoutMs);
+  const driver = new FlowDriver(page, { actionTimeoutMs: timeoutMs });
+  await driver.assertAuthenticated();
+  await driver.verifyReady();
+  return {
+    browser: attached,
+    page,
+    driver,
+  };
+}
+
+export function assertLoopbackCdpUrl(rawUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid CDP URL: ${rawUrl}`);
+  }
+  if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || !isLoopbackHost(parsed.hostname)) {
+    throw new Error('Google Flow CDP attachment is restricted to an operator-controlled loopback browser');
+  }
+  if (parsed.username || parsed.password) throw new Error('CDP URL must not contain credentials');
+  return parsed.toString().replace(/\/$/u, '');
+}
+
+async function openFlowTab(context: FlowBrowserContext, timeoutMs: number): Promise<FlowPage> {
+  const page = await context.newPage();
+  await page.goto(GOOGLE_FLOW_URL, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+  return page;
+}
+
+function isFlowUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return url.hostname === 'labs.google' && /(?:^|\/)flow(?:\/|$)/u.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function isGoogleLoginUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname;
+    return hostname === 'accounts.google.com' || hostname.endsWith('.accounts.google.com');
+  } catch {
+    return false;
+  }
+}
+
+function positiveTimeout(value: number | undefined, fallback: number, label: string): number {
+  const timeout = value ?? fallback;
+  if (!Number.isFinite(timeout) || timeout <= 0) throw new Error(`${label} must be positive`);
+  return timeout;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export type FlowRunModel = 'fast' | 'quality';
+
+export class FlowCreditBudgetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FlowCreditBudgetError';
+  }
+}
+
+function creditCostPerClip(model: FlowRunModel): 10 | 100 {
+  if (model === 'fast') return 10;
+  if (model === 'quality') return 100;
+  throw new Error('Flow model must be fast or quality');
+}
+
+function assertNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} must be a non-negative integer`);
+}
+
+export function estimateCreditCost(jobs: readonly unknown[], model: FlowRunModel): number {
+  return jobs.length * creditCostPerClip(model);
+}
+
+export function assertSufficientCreditBalance(balance: number, estimatedCost: number): void {
+  assertNonNegativeInteger(balance, 'Flow credit balance');
+  assertNonNegativeInteger(estimatedCost, 'estimated Flow credit cost');
+  if (balance < estimatedCost) {
+    throw new FlowCreditBudgetError(
+      `Insufficient Google Flow credits: balance ${balance}, full-run estimate ${estimatedCost}; no generation submitted`,
+    );
+  }
+}
+
+export function assertCreditBudget(spent: number, nextCost: number, maxCredits: number): void {
+  assertNonNegativeInteger(spent, 'spent Flow credits');
+  if (!Number.isSafeInteger(nextCost) || nextCost <= 0) throw new Error('next Flow credit cost must be positive');
+  if (!Number.isSafeInteger(maxCredits) || maxCredits <= 0) throw new Error('--max-credits must be a positive integer');
+  if (spent + nextCost > maxCredits) {
+    throw new FlowCreditBudgetError(
+      `Flow max-credit guard stopped the run at ${spent}/${maxCredits}; next clip costs ${nextCost}`,
+    );
+  }
+}

--- a/src/tools/video/google-flow-handoff.ts
+++ b/src/tools/video/google-flow-handoff.ts
@@ -1,0 +1,206 @@
+/** Browser-assisted Google Flow work packets. No unofficial API or hidden billing. */
+
+import { createHash } from 'crypto';
+
+import {
+  routeHybridVideoBatch,
+  type HybridVideoCapacity,
+  type HybridVideoEngine,
+  type HybridVideoUseCase,
+} from './hybrid-video-router.js';
+
+export type GoogleFlowModel = 'lite' | 'fast' | 'quality';
+
+export interface GoogleFlowSourceShot {
+  id: string;
+  characterName: string;
+  declaredAdultAge: number;
+  sourcePath: string;
+  sourceSha256: string;
+  motionPrompt: string;
+  role: 'hero' | 'b-roll' | 'transition';
+  consumerShortIds?: string[];
+  consumers?: Array<{ shortId: string; shotIndex: number }>;
+}
+
+export interface GoogleFlowHandoffOptions {
+  sourcePlanSha256: string;
+  batchId: string;
+  model: GoogleFlowModel;
+  locale: string;
+  durationSeconds: 4 | 6 | 8;
+  aspectRatio: '9:16' | '16:9';
+  upscale4k: boolean;
+  capacity: HybridVideoCapacity;
+}
+
+export interface GoogleFlowHandoffJob {
+  id: string;
+  engine: HybridVideoEngine;
+  executionMode: 'browser-assisted';
+  estimatedCredits: number;
+  source: {
+    path: string;
+    sha256: string;
+  };
+  consumerShortIds: string[];
+  consumers: Array<{ shortId: string; shotIndex: number }>;
+  prompt: string;
+  role: 'hero' | 'b-roll' | 'transition';
+  settings: {
+    durationSeconds: 4 | 6 | 8;
+    aspectRatio: '9:16' | '16:9';
+    upscale4k: boolean;
+    audio: 'ambient-only';
+    lipSync: false;
+  };
+  status: 'awaiting-flow-generation';
+}
+
+export interface GoogleFlowHandoff {
+  schemaVersion: 2;
+  sourcePlanSha256: string;
+  handoffSha256: string;
+  batchId: string;
+  provider: 'google-flow-web';
+  billingMode: 'google-ai-ultra-flow-credits';
+  apiBillingAllowed: false;
+  model: GoogleFlowModel;
+  locale: string;
+  estimatedCredits: number;
+  remainingCreditsBefore: number;
+  remainingCreditsAfterEstimate: number;
+  humanFlowSessionRequired: true;
+  autoPublish: false;
+  jobs: GoogleFlowHandoffJob[];
+}
+
+type UnsignedGoogleFlowHandoff = Omit<GoogleFlowHandoff, 'handoffSha256'>;
+
+/** Stable JSON encoding used by local handoff and receipt digests. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().filter((key) => record[key] !== undefined).map((key) =>
+    `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
+}
+
+export function canonicalSha256(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+export function verifyGoogleFlowHandoffDigest(handoff: GoogleFlowHandoff): boolean {
+  const { handoffSha256, ...unsigned } = handoff;
+  return /^[a-f0-9]{64}$/u.test(handoffSha256) && canonicalSha256(unsigned) === handoffSha256;
+}
+
+function routeSettings(model: GoogleFlowModel): { useCase: HybridVideoUseCase; premium: boolean } {
+  if (model === 'quality') return { useCase: 'hero-shot', premium: true };
+  if (model === 'lite') return { useCase: 'bulk-variation', premium: false };
+  return { useCase: 'long-form-b-roll', premium: false };
+}
+
+export function buildGoogleFlowPrompt(shot: GoogleFlowSourceShot, aspectRatio: '9:16' | '16:9'): string {
+  if (!shot.characterName.trim() || shot.declaredAdultAge < 25 || !shot.motionPrompt.trim()) {
+    throw new Error(`Flow shot ${shot.id} lacks an approved adult identity or motion prompt`);
+  }
+  return [
+    `Fictional adult character ${shot.characterName}, clearly age ${shot.declaredAdultAge}.`,
+    'Use the supplied image as the identity reference; preserve face, hair, body proportions and wardrobe.',
+    shot.motionPrompt.trim(),
+    aspectRatio === '9:16' ? 'Vertical cinematic composition for YouTube Shorts.' : 'Cinematic widescreen composition.',
+    'Natural anatomy, coherent hands, stable background, physically plausible motion, no text, no logo.',
+    'Ambient sound only. No speech, no singing and no visible lip synchronization.',
+    'End on a visually clean frame suitable for editing into a larger original story.',
+  ].join(' ');
+}
+
+export function createGoogleFlowHandoff(
+  shots: readonly GoogleFlowSourceShot[],
+  options: GoogleFlowHandoffOptions,
+): GoogleFlowHandoff {
+  if (!/^[a-f0-9]{64}$/u.test(options.sourcePlanSha256)) {
+    throw new Error('Flow handoff requires the canonical SHA-256 of its V3 source plan');
+  }
+  if (new Set(shots.map((shot) => shot.id)).size !== shots.length) {
+    throw new Error('Flow handoff job IDs must be unique');
+  }
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u.test(options.batchId) || !shots.length) {
+    throw new Error('Flow handoff requires a safe batch ID and shots');
+  }
+  for (const shot of shots) {
+    if (
+      !/^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u.test(shot.id) ||
+      !/^[a-f0-9]{64}$/u.test(shot.sourceSha256) || !shot.sourcePath.startsWith('/') ||
+      !['hero', 'b-roll', 'transition'].includes(shot.role) ||
+      !(shot.consumers?.length || shot.consumerShortIds?.length) ||
+      (shot.consumerShortIds ?? []).some((shortId) =>
+        !/^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u.test(shortId)) ||
+      (shot.consumers ?? []).some((consumer) =>
+        !/^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u.test(consumer.shortId) ||
+        !Number.isInteger(consumer.shotIndex) || consumer.shotIndex < 1)
+    ) throw new Error(`Flow shot ${shot.id || '<unknown>'} has an unsafe source or consumer mapping`);
+  }
+  if (options.model === 'quality' && options.durationSeconds !== 8) {
+    throw new Error('Veo 3.1 Quality only supports 8-second generations in Google Flow');
+  }
+  const settings = routeSettings(options.model);
+  const routed = routeHybridVideoBatch(
+    shots.map((shot) => ({
+      id: shot.id,
+      useCase: settings.useCase,
+      contentTier: 'safe' as const,
+      quantity: 1,
+      requiresLipSync: false,
+      premium: settings.premium,
+      upscale4k: options.upscale4k,
+    })),
+    options.capacity,
+  );
+  const jobs = shots.map((shot, index): GoogleFlowHandoffJob => {
+    const route = routed.routes[index]!;
+    if (!route.primary.startsWith('google-flow-') || route.executionMode !== 'browser-assisted') {
+      throw new Error(`Flow credit guardrail routed ${shot.id} to ${route.primary}; reduce or split the batch`);
+    }
+    return {
+      id: shot.id,
+      engine: route.primary,
+      executionMode: 'browser-assisted',
+      estimatedCredits: route.estimatedFlowCredits,
+      source: { path: shot.sourcePath, sha256: shot.sourceSha256 },
+      consumerShortIds: [...new Set(shot.consumerShortIds ?? [])],
+      consumers: [...new Map((shot.consumers?.length ? shot.consumers : (shot.consumerShortIds ?? []).map((shortId) => ({
+        shortId,
+        shotIndex: index + 1,
+      }))).map((consumer) => [`${consumer.shortId}:${consumer.shotIndex}`, consumer])).values()],
+      prompt: buildGoogleFlowPrompt(shot, options.aspectRatio),
+      role: shot.role,
+      settings: {
+        durationSeconds: options.durationSeconds,
+        aspectRatio: options.aspectRatio,
+        upscale4k: options.upscale4k,
+        audio: 'ambient-only',
+        lipSync: false,
+      },
+      status: 'awaiting-flow-generation',
+    };
+  });
+  const unsigned: UnsignedGoogleFlowHandoff = {
+    schemaVersion: 2,
+    sourcePlanSha256: options.sourcePlanSha256,
+    batchId: options.batchId,
+    provider: 'google-flow-web',
+    billingMode: 'google-ai-ultra-flow-credits',
+    apiBillingAllowed: false,
+    model: options.model,
+    locale: options.locale,
+    estimatedCredits: routed.estimatedFlowCredits,
+    remainingCreditsBefore: options.capacity.remainingFlowCredits,
+    remainingCreditsAfterEstimate: options.capacity.remainingFlowCredits - routed.estimatedFlowCredits,
+    humanFlowSessionRequired: true,
+    autoPublish: false,
+    jobs,
+  };
+  return { ...unsigned, handoffSha256: canonicalSha256(unsigned) };
+}

--- a/src/tools/video/google-flow-handoff.ts
+++ b/src/tools/video/google-flow-handoff.ts
@@ -1,5 +1,6 @@
 /** Browser-assisted Google Flow work packets. No unofficial API or hidden billing. */
 
+import { isAbsolute } from 'node:path';
 import { createHash } from 'crypto';
 
 import {
@@ -132,7 +133,7 @@ export function createGoogleFlowHandoff(
   for (const shot of shots) {
     if (
       !/^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u.test(shot.id) ||
-      !/^[a-f0-9]{64}$/u.test(shot.sourceSha256) || !shot.sourcePath.startsWith('/') ||
+      !/^[a-f0-9]{64}$/u.test(shot.sourceSha256) || !isAbsolute(shot.sourcePath) ||
       !['hero', 'b-roll', 'transition'].includes(shot.role) ||
       !(shot.consumers?.length || shot.consumerShortIds?.length) ||
       (shot.consumerShortIds ?? []).some((shortId) =>

--- a/src/tools/video/google-flow-plan-export.ts
+++ b/src/tools/video/google-flow-plan-export.ts
@@ -1,0 +1,210 @@
+/** Convert a QA-approved MySoulmate Short plan into a bounded Google Flow handoff. */
+
+import path from 'path';
+
+import { loadApprovedImageSource } from './approved-media-source.js';
+import {
+  createGoogleFlowHandoff,
+  canonicalSha256,
+  type GoogleFlowHandoff,
+  type GoogleFlowModel,
+  type GoogleFlowSourceShot,
+} from './google-flow-handoff.js';
+
+interface PlannedShot {
+  index: number;
+  assetId: string;
+  sourceSha256: string;
+  referenceImagePath: string;
+  contentTier: 'safe';
+  qaStatus: 'approved';
+  motionPrompt: string;
+}
+
+interface PlannedShort {
+  shortId: string;
+  locale?: string;
+  profile: {
+    name: string;
+    declaredAdultAge: number;
+  };
+  render: {
+    shots: PlannedShot[];
+  };
+  publication: {
+    visibility: 'private';
+    autoPublish: false;
+    containsSyntheticMedia: true;
+    reviewStatus: 'pending-human-review';
+  };
+}
+
+interface ShortPlan {
+  schemaVersion: 3;
+  sourceDigests: {
+    imageManifestSha256: string;
+    imageCatalogSha256: string;
+    factoryConfigSha256: string;
+    assetApprovalsSha256: string;
+    productionLedgerSha256: string;
+  };
+  policy: {
+    contentTier: 'safe';
+    qaStatus: 'approved';
+    autoPublish: false;
+    initialVisibility: 'private';
+    syntheticMediaDisclosureRequired: true;
+  };
+  shorts: PlannedShort[];
+}
+
+const REQUIRED_SOURCE_DIGEST_KEYS = [
+  'assetApprovalsSha256',
+  'factoryConfigSha256',
+  'imageCatalogSha256',
+  'imageManifestSha256',
+  'productionLedgerSha256',
+] as const;
+
+function hasExactSourceDigests(value: unknown): value is ShortPlan['sourceDigests'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return keys.length === REQUIRED_SOURCE_DIGEST_KEYS.length &&
+    keys.every((key, index) => key === REQUIRED_SOURCE_DIGEST_KEYS[index]) &&
+    REQUIRED_SOURCE_DIGEST_KEYS.every((key) =>
+      typeof record[key] === 'string' && /^[a-f0-9]{64}$/u.test(record[key]));
+}
+
+export interface GoogleFlowPlanExportOptions {
+  approvedAssetRoot: string;
+  batchId: string;
+  shortId?: string;
+  includeAllShorts?: boolean;
+  model: GoogleFlowModel;
+  durationSeconds: 4 | 6 | 8;
+  aspectRatio: '9:16' | '16:9';
+  upscale4k: boolean;
+  remainingFlowCredits: number;
+  maxFlowCreditsPerBatch: number;
+  darkstarAvailable: boolean;
+  ministarAvailable: boolean;
+}
+
+function assertShortPlan(value: unknown): asserts value is ShortPlan {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Short plan must be an object');
+  const plan = value as Partial<ShortPlan>;
+  if (
+    plan.schemaVersion !== 3 ||
+    !hasExactSourceDigests(plan.sourceDigests) ||
+    plan.policy?.contentTier !== 'safe' ||
+    plan.policy.qaStatus !== 'approved' ||
+    plan.policy.autoPublish !== false ||
+    plan.policy.initialVisibility !== 'private' ||
+    plan.policy.syntheticMediaDisclosureRequired !== true ||
+    !Array.isArray(plan.shorts) ||
+    !plan.shorts.length
+  ) {
+    throw new Error('Short plan is not safe, QA-approved, private and disclosed');
+  }
+}
+
+function selectShorts(plan: ShortPlan, options: GoogleFlowPlanExportOptions): PlannedShort[] {
+  if (options.shortId && options.includeAllShorts) {
+    throw new Error('Select either one Short or all Shorts, not both');
+  }
+  if (options.shortId) {
+    const selected = plan.shorts.find((short) => short.shortId === options.shortId);
+    if (!selected) throw new Error(`Unknown Short ID: ${options.shortId}`);
+    return [selected];
+  }
+  return options.includeAllShorts ? plan.shorts : [plan.shorts[0]!];
+}
+
+function assertPlannedShort(short: PlannedShort): void {
+  if (
+    !short.shortId?.trim() ||
+    !short.profile?.name?.trim() ||
+    !Number.isInteger(short.profile.declaredAdultAge) ||
+    short.profile.declaredAdultAge < 25 ||
+    short.publication?.visibility !== 'private' ||
+    short.publication.autoPublish !== false ||
+    short.publication.containsSyntheticMedia !== true ||
+    short.publication.reviewStatus !== 'pending-human-review' ||
+    !Array.isArray(short.render?.shots) ||
+    !short.render.shots.length
+  ) {
+    throw new Error(`Short ${short.shortId || '<unknown>'} is not approved for a Flow handoff`);
+  }
+}
+
+/**
+ * Validate every source file before creating a handoff. Identical visual shots
+ * shared by localized masters are generated once and list every consumer.
+ */
+export async function exportGoogleFlowHandoffFromPlan(
+  value: unknown,
+  options: GoogleFlowPlanExportOptions,
+): Promise<GoogleFlowHandoff> {
+  assertShortPlan(value);
+  if (!path.isAbsolute(options.approvedAssetRoot)) throw new Error('Approved asset root must be absolute');
+  const selected = selectShorts(value, options);
+  const uniqueShots = new Map<string, GoogleFlowSourceShot>();
+
+  for (const short of selected) {
+    assertPlannedShort(short);
+    for (const shot of short.render.shots) {
+      if (
+        shot.contentTier !== 'safe' ||
+        shot.qaStatus !== 'approved' ||
+        !path.isAbsolute(shot.referenceImagePath) ||
+        !/^[a-f0-9]{64}$/u.test(shot.sourceSha256) ||
+        !shot.motionPrompt?.trim()
+      ) {
+        throw new Error(`Short ${short.shortId} contains an incomplete or unsafe source shot`);
+      }
+      const source = await loadApprovedImageSource(
+        shot.referenceImagePath,
+        options.approvedAssetRoot,
+        shot.sourceSha256,
+      );
+      const key = `${source.sha256}\u0000${shot.motionPrompt.trim()}`;
+      const existing = uniqueShots.get(key);
+      if (existing) {
+        existing.consumerShortIds = [...new Set([...(existing.consumerShortIds ?? []), short.shortId])];
+        existing.consumers = [...new Map([...(existing.consumers ?? []), { shortId: short.shortId, shotIndex: shot.index ?? short.render.shots.indexOf(shot) + 1 }]
+          .map((consumer) => [`${consumer.shortId}:${consumer.shotIndex}`, consumer])).values()];
+        continue;
+      }
+      uniqueShots.set(key, {
+        id: `${short.shortId}-flow-${String(uniqueShots.size + 1).padStart(2, '0')}`,
+        characterName: short.profile.name,
+        declaredAdultAge: short.profile.declaredAdultAge,
+        sourcePath: source.realPath,
+        sourceSha256: source.sha256,
+        motionPrompt: shot.motionPrompt,
+        role: uniqueShots.size === 0 ? 'hero' : uniqueShots.size % 3 === 2 ? 'transition' : 'b-roll',
+        consumerShortIds: [short.shortId],
+        consumers: [{ shortId: short.shortId, shotIndex: shot.index ?? short.render.shots.indexOf(shot) + 1 }],
+      });
+    }
+  }
+
+  const locales = [...new Set(selected.map((short) => short.locale).filter((locale): locale is string => Boolean(locale)))];
+  return createGoogleFlowHandoff([...uniqueShots.values()], {
+    sourcePlanSha256: canonicalSha256(value),
+    batchId: options.batchId,
+    model: options.model,
+    locale: locales.length === 1 ? locales[0]! : locales.length ? 'multilingual-shared-visuals' : 'und',
+    durationSeconds: options.durationSeconds,
+    aspectRatio: options.aspectRatio,
+    upscale4k: options.upscale4k,
+    capacity: {
+      darkstar: options.darkstarAvailable,
+      ministar: options.ministarAvailable,
+      googleFlow: true,
+      remainingFlowCredits: options.remainingFlowCredits,
+      maxFlowCreditsPerBatch: options.maxFlowCreditsPerBatch,
+    },
+  });
+}

--- a/src/tools/video/google-flow-result-import.ts
+++ b/src/tools/video/google-flow-result-import.ts
@@ -1,0 +1,436 @@
+/** Verify operator-provided Google Flow outputs and create auditable local receipts. */
+
+import { execFile as realExecFile } from 'child_process';
+import { createHash } from 'crypto';
+import { constants as fsConstants } from 'fs';
+import {
+  link,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  realpath,
+  stat,
+  unlink,
+  writeFile,
+} from 'fs/promises';
+import path from 'path';
+import { promisify } from 'util';
+
+import {
+  canonicalJson,
+  canonicalSha256,
+  verifyGoogleFlowHandoffDigest,
+  type GoogleFlowHandoff,
+} from './google-flow-handoff.js';
+
+const execFile = promisify(realExecFile);
+const SAFE_ID = /^[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const MAX_VIDEO_BYTES = 1024 * 1024 * 1024;
+
+export interface GoogleFlowResultProbe {
+  durationSeconds: number;
+  width: number;
+  height: number;
+  hasVideo: boolean;
+  hasAudio: boolean;
+  videoCodec?: string;
+  audioCodec?: string;
+  audioChannels?: number;
+  audioSampleRate?: number;
+}
+
+interface GoogleFlowImportedJob {
+  id: string;
+  role: 'hero' | 'b-roll' | 'transition';
+  sourceFile: string;
+  sourceSha256: string;
+  sourceHadAudio: boolean;
+  outputFile: string;
+  sha256: string;
+  bytes: number;
+  probe: GoogleFlowResultProbe;
+  audioPreserved?: true;
+  qaStatus: 'pending-human-review';
+}
+
+interface UnsignedGoogleFlowImportReceipt {
+  schemaVersion: 2;
+  batchId: string;
+  provider: 'google-flow-web';
+  sourcePlanSha256: string;
+  handoffSha256: string;
+  handoffFileSha256: string;
+  importedAt: string;
+  audioPolicy: 'removed-on-import' | 'preserved-on-import';
+  audioPreserved?: true;
+  autoPublish: false;
+  humanReviewRequired: true;
+  jobs: GoogleFlowImportedJob[];
+}
+
+export interface GoogleFlowImportReceipt extends UnsignedGoogleFlowImportReceipt {
+  receiptSha256: string;
+}
+
+export interface GoogleFlowReviewChecks {
+  identity: boolean;
+  anatomy: boolean;
+  motion: boolean;
+  cleanEnd: boolean;
+  noSpeech: boolean;
+  noTextOrLogo: boolean;
+  safeContent: boolean;
+}
+
+export interface GoogleFlowReviewReceipt {
+  schemaVersion: 1;
+  batchId: string;
+  status: 'approved-for-editing';
+  importReceiptSha256: string;
+  jobs: Array<{ id: string; sha256: string; qaStatus: 'approved' }>;
+  checks: GoogleFlowReviewChecks;
+  reviewer: string;
+  reason: string;
+  reviewedAt: string;
+  autoPublish: false;
+}
+
+export async function importGoogleFlowResults(input: {
+  handoff: GoogleFlowHandoff;
+  handoffBytes: Uint8Array;
+  resultsRoot: string;
+  outputRoot: string;
+  now?: () => Date;
+  minWidth?: number;
+  minHeight?: number;
+  preserveAudio?: boolean;
+  probe?: (filename: string) => Promise<GoogleFlowResultProbe>;
+  normalize?: (
+    source: string,
+    destination: string,
+    options: { preserveAudio: boolean },
+  ) => Promise<void>;
+}): Promise<GoogleFlowImportReceipt> {
+  assertHandoff(input.handoff);
+  assertHandoffBytes(input.handoff, input.handoffBytes);
+  assertImportOptions(input.minWidth, input.minHeight);
+  const resultsRoot = await confinedRoot(input.resultsRoot, false);
+  const outputRoot = await confinedRoot(input.outputRoot, true);
+  await assertExactResultSet(resultsRoot, input.handoff.jobs.map((job) => `${job.id}.mp4`));
+  const batchDirectory = await createConfinedBatchDirectory(outputRoot, input.handoff.batchId);
+  const probe = input.probe ?? probeFlowResult;
+  const normalize = input.normalize ?? normalizeFlowResult;
+  const preserveAudio = input.preserveAudio ?? false;
+
+  const jobs: GoogleFlowImportedJob[] = [];
+  for (const job of input.handoff.jobs) {
+    const source = path.join(resultsRoot, `${job.id}.mp4`);
+    const sourceBytes = await readRegularNoFollow(source, `Flow result ${job.id}`);
+    if (!hasMp4Signature(sourceBytes)) throw new Error(`Flow result ${job.id} is not an MP4 file`);
+
+    const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const capturedSource = path.join(batchDirectory, `.${job.id}-${nonce}-source.mp4`);
+    const normalizedTemporary = path.join(
+      batchDirectory,
+      `.${job.id}-${nonce}-${preserveAudio ? 'audio' : 'silent'}.mp4`,
+    );
+    await writeFile(capturedSource, sourceBytes, { flag: 'wx', mode: 0o600 });
+    try {
+      // Probe the immutable captured bytes, never the operator-controlled path
+      // again, so a concurrent replacement cannot change what gets imported.
+      const sourceProbe = await probe(capturedSource);
+      assertExpectedProbe(job.id, sourceProbe, job.settings.aspectRatio, job.settings.durationSeconds, {
+        minWidth: input.minWidth,
+        minHeight: input.minHeight,
+        requireAudio: preserveAudio,
+      });
+      await normalize(capturedSource, normalizedTemporary, { preserveAudio });
+      const normalizedBytes = await readRegularNoFollow(normalizedTemporary, `Normalized Flow result ${job.id}`);
+      if (!hasMp4Signature(normalizedBytes)) throw new Error(`Normalized Flow result ${job.id} is not an MP4 file`);
+      const normalizedProbe = await probe(normalizedTemporary);
+      assertExpectedProbe(job.id, normalizedProbe, job.settings.aspectRatio, job.settings.durationSeconds, {
+        minWidth: input.minWidth,
+        minHeight: input.minHeight,
+        requireAudio: preserveAudio,
+        requireSilent: !preserveAudio,
+      });
+      const sha256 = digest(normalizedBytes);
+      const outputFile = `${job.id}-${sha256.slice(0, 16)}.mp4`;
+      const destination = path.join(batchDirectory, outputFile);
+      await installImmutableFile(normalizedTemporary, destination, sha256);
+      const importedJob: GoogleFlowImportedJob = {
+        id: job.id,
+        role: job.role,
+        sourceFile: path.basename(source),
+        sourceSha256: digest(sourceBytes),
+        sourceHadAudio: sourceProbe.hasAudio,
+        outputFile: path.relative(outputRoot, destination).split(path.sep).join('/'),
+        sha256,
+        bytes: normalizedBytes.length,
+        probe: normalizedProbe,
+        qaStatus: 'pending-human-review',
+      };
+      if (preserveAudio) importedJob.audioPreserved = true;
+      jobs.push(importedJob);
+    } finally {
+      await Promise.all([
+        unlink(capturedSource).catch(() => undefined),
+        unlink(normalizedTemporary).catch(() => undefined),
+      ]);
+    }
+  }
+
+  const unsigned: UnsignedGoogleFlowImportReceipt = {
+    schemaVersion: 2,
+    batchId: input.handoff.batchId,
+    provider: 'google-flow-web',
+    sourcePlanSha256: input.handoff.sourcePlanSha256,
+    handoffSha256: input.handoff.handoffSha256,
+    handoffFileSha256: digest(input.handoffBytes),
+    importedAt: (input.now ?? (() => new Date()))().toISOString(),
+    audioPolicy: preserveAudio ? 'preserved-on-import' : 'removed-on-import',
+    autoPublish: false,
+    humanReviewRequired: true,
+    jobs,
+  };
+  if (preserveAudio) unsigned.audioPreserved = true;
+  const receipt: GoogleFlowImportReceipt = { ...unsigned, receiptSha256: canonicalSha256(unsigned) };
+  await writeImmutableJson(path.join(batchDirectory, 'receipt.json'), receipt);
+  return receipt;
+}
+
+export function reviewGoogleFlowImport(input: {
+  receipt: GoogleFlowImportReceipt;
+  expectedReceiptSha256: string;
+  reviewer: string;
+  reason: string;
+  checks: GoogleFlowReviewChecks;
+  now?: () => Date;
+}): GoogleFlowReviewReceipt {
+  const { receiptSha256, ...unsigned } = input.receipt;
+  if (
+    !SHA256.test(input.expectedReceiptSha256) ||
+    receiptSha256 !== input.expectedReceiptSha256 ||
+    canonicalSha256(unsigned) !== receiptSha256 ||
+    !input.receipt.jobs.length ||
+    input.receipt.jobs.some((job) => job.qaStatus !== 'pending-human-review' || !SHA256.test(job.sha256))
+  ) throw new Error('Flow review must target the current immutable import receipt SHA-256');
+  if (Object.values(input.checks).some((value) => value !== true)) {
+    throw new Error('Every Flow human-review check must pass');
+  }
+  if (input.reviewer.trim().length < 2 || input.reason.trim().length < 3) {
+    throw new Error('Reviewer and reason are required');
+  }
+  return {
+    schemaVersion: 1,
+    batchId: input.receipt.batchId,
+    status: 'approved-for-editing',
+    importReceiptSha256: receiptSha256,
+    jobs: input.receipt.jobs.map((job) => ({ id: job.id, sha256: job.sha256, qaStatus: 'approved' })),
+    checks: input.checks,
+    reviewer: input.reviewer.trim(),
+    reason: input.reason.trim(),
+    reviewedAt: (input.now ?? (() => new Date()))().toISOString(),
+    autoPublish: false,
+  };
+}
+
+function assertHandoff(value: GoogleFlowHandoff): void {
+  const uniqueJobIds = Array.isArray(value?.jobs) ? new Set(value.jobs.map((job) => job.id)) : new Set<string>();
+  if (
+    value?.schemaVersion !== 2 || value.provider !== 'google-flow-web' || value.apiBillingAllowed !== false ||
+    value.autoPublish !== false || !SAFE_ID.test(value.batchId) || !SHA256.test(value.sourcePlanSha256) ||
+    !verifyGoogleFlowHandoffDigest(value) || !Array.isArray(value.jobs) || !value.jobs.length || value.jobs.length > 100 ||
+    uniqueJobIds.size !== value.jobs.length || value.estimatedCredits !== value.jobs.reduce((total, job) => total + job.estimatedCredits, 0) ||
+    value.jobs.some((job) =>
+      !SAFE_ID.test(job.id) || !SHA256.test(job.source.sha256) ||
+      !['hero', 'b-roll', 'transition'].includes(job.role) || job.status !== 'awaiting-flow-generation' ||
+      job.settings.audio !== 'ambient-only' || job.settings.lipSync !== false ||
+      !Array.isArray(job.consumerShortIds) || !job.consumerShortIds.length ||
+      job.consumerShortIds.some((shortId) => !SAFE_ID.test(shortId)) ||
+      !Array.isArray(job.consumers) || !job.consumers.length || job.consumers.some((consumer) =>
+        !SAFE_ID.test(consumer.shortId) || !job.consumerShortIds.includes(consumer.shortId) ||
+        !Number.isInteger(consumer.shotIndex) || consumer.shotIndex < 1))
+  ) throw new Error('Flow handoff is invalid, modified or unsafe');
+}
+
+function assertHandoffBytes(handoff: GoogleFlowHandoff, bytes: Uint8Array): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(bytes).toString('utf8')) as unknown;
+  } catch {
+    throw new Error('Flow handoff bytes are not valid JSON');
+  }
+  if (canonicalJson(parsed) !== canonicalJson(handoff)) {
+    throw new Error('Flow handoff bytes do not match the supplied handoff');
+  }
+}
+
+async function assertExactResultSet(root: string, expectedNames: string[]): Promise<void> {
+  const actual = (await readdir(root, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() || entry.isSymbolicLink())
+    .map((entry) => entry.name)
+    .filter((name) => name.toLowerCase().endsWith('.mp4'))
+    .sort();
+  const expected = [...expectedNames].sort();
+  if (actual.length !== expected.length || actual.some((name, index) => name !== expected[index])) {
+    throw new Error('Flow results directory must contain exactly one MP4 for every handoff job');
+  }
+}
+
+async function createConfinedBatchDirectory(outputRoot: string, batchId: string): Promise<string> {
+  const batchDirectory = path.join(outputRoot, batchId);
+  try {
+    await mkdir(batchDirectory, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+  const existing = await lstat(batchDirectory);
+  if (existing.isSymbolicLink() || !existing.isDirectory()) throw new Error('Flow import batch destination is unsafe');
+  const canonical = await realpath(batchDirectory);
+  if (!isWithin(canonical, outputRoot)) throw new Error('Flow import destination escapes its output root');
+  return canonical;
+}
+
+async function installImmutableFile(temporary: string, destination: string, expectedSha256: string): Promise<void> {
+  try {
+    await link(temporary, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    const existing = await readRegularNoFollow(destination, 'Existing Flow import');
+    if (digest(existing) !== expectedSha256) throw new Error('Existing Flow import has different bytes');
+  }
+}
+
+async function writeImmutableJson(filename: string, value: unknown): Promise<void> {
+  const temporary = `${filename}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+  try {
+    await link(temporary, filename);
+  } finally {
+    await unlink(temporary).catch(() => undefined);
+  }
+}
+
+async function confinedRoot(value: string, create: boolean): Promise<string> {
+  if (!path.isAbsolute(value) || value.includes('\0')) throw new Error('Flow import root must be absolute');
+  if (create) await mkdir(value, { recursive: true, mode: 0o700 });
+  const lexical = await lstat(value);
+  if (lexical.isSymbolicLink() || !lexical.isDirectory()) throw new Error('Flow import root must be a regular directory');
+  const canonical = await realpath(value);
+  if (!(await stat(canonical)).isDirectory()) throw new Error('Flow import root is invalid');
+  return canonical;
+}
+
+function isWithin(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+async function readRegularNoFollow(filename: string, label: string): Promise<Buffer> {
+  const handle = await open(filename, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile() || info.size <= 0 || info.size > MAX_VIDEO_BYTES) {
+      throw new Error(`${label} must be a regular file smaller than 1 GiB`);
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+function hasMp4Signature(bytes: Uint8Array): boolean {
+  return bytes.length >= 12 && String.fromCharCode(...bytes.slice(4, 8)) === 'ftyp';
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function assertExpectedProbe(
+  id: string,
+  probe: GoogleFlowResultProbe,
+  aspectRatio: '9:16' | '16:9',
+  durationSeconds: number,
+  requirements: {
+    minWidth?: number;
+    minHeight?: number;
+    requireAudio?: boolean;
+    requireSilent?: boolean;
+  },
+): void {
+  const targetRatio = aspectRatio === '9:16' ? 9 / 16 : 16 / 9;
+  const actualRatio = probe.width / probe.height;
+  if (
+    !probe.hasVideo || !Number.isFinite(probe.durationSeconds) ||
+    !Number.isInteger(probe.width) || !Number.isInteger(probe.height) ||
+    probe.width < (requirements.minWidth ?? 480) || probe.height < (requirements.minHeight ?? 480) ||
+    Math.abs(actualRatio - targetRatio) > 0.01 ||
+    Math.abs(probe.durationSeconds - durationSeconds) > 0.75 ||
+    (requirements.requireSilent && probe.hasAudio) ||
+    (requirements.requireAudio && (
+      !probe.hasAudio || !probe.audioCodec || !Number.isInteger(probe.audioChannels) ||
+      probe.audioChannels! <= 0 || !Number.isInteger(probe.audioSampleRate) || probe.audioSampleRate! <= 0
+    ))
+  ) throw new Error(`Flow result ${id} failed video, duration, aspect-ratio, resolution or audio validation`);
+}
+
+function assertImportOptions(minWidth: number | undefined, minHeight: number | undefined): void {
+  if (
+    (minWidth === undefined) !== (minHeight === undefined) ||
+    (minWidth !== undefined && (!Number.isInteger(minWidth) || minWidth < 1)) ||
+    (minHeight !== undefined && (!Number.isInteger(minHeight) || minHeight < 1))
+  ) throw new Error('Flow import minimum resolution requires positive integer minWidth and minHeight');
+}
+
+export function buildNormalizeFlowResultArgs(
+  source: string,
+  destination: string,
+  preserveAudio = false,
+): string[] {
+  if (!preserveAudio) {
+    return [
+      '-v', 'error', '-n', '-i', source, '-map', '0:v:0', '-an', '-c:v', 'copy',
+      '-movflags', '+faststart', destination,
+    ];
+  }
+  return [
+    '-v', 'error', '-n', '-i', source, '-map', '0:v:0', '-map', '0:a:0', '-c:v', 'copy',
+    '-c:a', 'aac', '-b:a', '192k', '-ar', '48000', '-movflags', '+faststart', destination,
+  ];
+}
+
+async function normalizeFlowResult(
+  source: string,
+  destination: string,
+  options: { preserveAudio: boolean },
+): Promise<void> {
+  await execFile('ffmpeg', buildNormalizeFlowResultArgs(source, destination, options.preserveAudio), {
+    timeout: 5 * 60_000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+async function probeFlowResult(filename: string): Promise<GoogleFlowResultProbe> {
+  const { stdout } = await execFile('ffprobe', [
+    '-v', 'error', '-show_entries',
+    'format=duration:stream=codec_type,codec_name,width,height,channels,sample_rate', '-of', 'json', filename,
+  ], { timeout: 30_000, maxBuffer: 1024 * 1024 });
+  const parsed = JSON.parse(stdout) as { format?: { duration?: string }; streams?: Array<Record<string, unknown>> };
+  const video = parsed.streams?.find((stream) => stream.codec_type === 'video');
+  const audio = parsed.streams?.find((stream) => stream.codec_type === 'audio');
+  return {
+    durationSeconds: Number(parsed.format?.duration),
+    width: Number(video?.width),
+    height: Number(video?.height),
+    hasVideo: Boolean(video),
+    hasAudio: Boolean(audio),
+    videoCodec: typeof video?.codec_name === 'string' ? video.codec_name : undefined,
+    audioCodec: typeof audio?.codec_name === 'string' ? audio.codec_name : undefined,
+    audioChannels: audio ? Number(audio.channels) : undefined,
+    audioSampleRate: audio ? Number(audio.sample_rate) : undefined,
+  };
+}

--- a/src/tools/video/hybrid-video-router.ts
+++ b/src/tools/video/hybrid-video-router.ts
@@ -1,0 +1,166 @@
+/** Routing policy for the MySoulmate hybrid image/video production fleet. */
+
+/** Ordered from advertiser-safe public material to fully private. */
+export const CONTENT_TIERS = ['safe', 'sensual', 'explicit'] as const;
+export type ContentTier = (typeof CONTENT_TIERS)[number];
+export type HybridVideoUseCase =
+  | 'avatar-lipsync'
+  | 'bulk-variation'
+  | 'hero-shot'
+  | 'long-form-b-roll'
+  | 'transition';
+export type HybridVideoEngine =
+  | 'darkstar-longcat'
+  | 'darkstar-comfyui'
+  | 'ministar-comfyui'
+  | 'google-flow-veo31-lite'
+  | 'google-flow-veo31-fast'
+  | 'google-flow-veo31-quality';
+
+export interface HybridVideoCapacity {
+  darkstar: boolean;
+  ministar: boolean;
+  googleFlow: boolean;
+  remainingFlowCredits: number;
+  maxFlowCreditsPerBatch: number;
+}
+
+export interface HybridVideoRequest {
+  id: string;
+  useCase: HybridVideoUseCase;
+  contentTier: ContentTier;
+  quantity: number;
+  requiresLipSync: boolean;
+  premium: boolean;
+  upscale4k?: boolean;
+}
+
+export interface HybridVideoRoute {
+  requestId: string;
+  primary: HybridVideoEngine;
+  fallbacks: HybridVideoEngine[];
+  executionMode: 'automatic-local' | 'browser-assisted';
+  estimatedFlowCredits: number;
+  reason: string;
+}
+
+const FLOW_CREDITS = {
+  'google-flow-veo31-lite': 5,
+  'google-flow-veo31-fast': 10,
+  'google-flow-veo31-quality': 100,
+} as const;
+
+function localFallbacks(capacity: HybridVideoCapacity): HybridVideoEngine[] {
+  return [
+    ...(capacity.darkstar ? (['darkstar-comfyui'] as const) : []),
+    ...(capacity.ministar ? (['ministar-comfyui'] as const) : []),
+  ];
+}
+
+function flowCost(engine: keyof typeof FLOW_CREDITS, request: HybridVideoRequest): number {
+  return request.quantity * FLOW_CREDITS[engine] + (request.upscale4k ? request.quantity * 50 : 0);
+}
+
+function canSpendFlow(capacity: HybridVideoCapacity, cost: number): boolean {
+  return capacity.googleFlow &&
+    cost <= capacity.remainingFlowCredits &&
+    cost <= capacity.maxFlowCreditsPerBatch;
+}
+
+export function routeHybridVideo(
+  request: HybridVideoRequest,
+  capacity: HybridVideoCapacity,
+): HybridVideoRoute {
+  if (!request.id.trim() || !Number.isInteger(request.quantity) || request.quantity < 1) {
+    throw new Error('Hybrid video request requires an ID and a positive integer quantity');
+  }
+  const fallbacks = localFallbacks(capacity);
+
+  // Adult media is kept on infrastructure controlled by the project. Flow is
+  // reserved for advertiser-safe YouTube and public companion assets.
+  if (request.contentTier !== 'safe') {
+    const primary = capacity.darkstar ? 'darkstar-comfyui' : 'ministar-comfyui';
+    if (!capacity.darkstar && !capacity.ministar) throw new Error('No local engine is available for private media');
+    return {
+      requestId: request.id,
+      primary,
+      fallbacks: fallbacks.filter((engine) => engine !== primary),
+      executionMode: 'automatic-local',
+      estimatedFlowCredits: 0,
+      reason: 'Private content remains on controlled local infrastructure',
+    };
+  }
+
+  if (request.requiresLipSync || request.useCase === 'avatar-lipsync') {
+    if (!capacity.darkstar) {
+      if (!capacity.ministar) throw new Error('No avatar-capable local engine is available');
+      return {
+        requestId: request.id,
+        primary: 'ministar-comfyui',
+        fallbacks: [],
+        executionMode: 'automatic-local',
+        estimatedFlowCredits: 0,
+        reason: 'Lip synchronization uses the local fallback while Darkstar is unavailable',
+      };
+    }
+    return {
+      requestId: request.id,
+      primary: 'darkstar-longcat',
+      fallbacks,
+      executionMode: 'automatic-local',
+      estimatedFlowCredits: 0,
+      reason: 'LongCat preserves localized lip synchronization and companion identity',
+    };
+  }
+
+  const preferredFlow: keyof typeof FLOW_CREDITS = request.premium || request.useCase === 'hero-shot'
+    ? 'google-flow-veo31-quality'
+    : request.useCase === 'bulk-variation'
+      ? 'google-flow-veo31-lite'
+      : 'google-flow-veo31-fast';
+  const estimatedFlowCredits = flowCost(preferredFlow, request);
+  if (canSpendFlow(capacity, estimatedFlowCredits)) {
+    return {
+      requestId: request.id,
+      primary: preferredFlow,
+      fallbacks,
+      executionMode: 'browser-assisted',
+      estimatedFlowCredits,
+      reason: request.premium
+        ? 'Veo Quality is reserved for an approved premium shot'
+        : 'Google Flow credits accelerate safe visual exploration without API billing',
+    };
+  }
+
+  if (!fallbacks.length) throw new Error('No engine is available within the configured credit guardrail');
+  return {
+    requestId: request.id,
+    primary: fallbacks[0]!,
+    fallbacks: fallbacks.slice(1),
+    executionMode: 'automatic-local',
+    estimatedFlowCredits: 0,
+    reason: 'The Flow credit ceiling or availability guardrail selected a local engine',
+  };
+}
+
+export function routeHybridVideoBatch(
+  requests: readonly HybridVideoRequest[],
+  capacity: HybridVideoCapacity,
+): { routes: HybridVideoRoute[]; estimatedFlowCredits: number } {
+  let remainingFlowCredits = capacity.remainingFlowCredits;
+  let remainingBatchCredits = capacity.maxFlowCreditsPerBatch;
+  const routes = requests.map((request) => {
+    const route = routeHybridVideo(request, {
+      ...capacity,
+      remainingFlowCredits,
+      maxFlowCreditsPerBatch: remainingBatchCredits,
+    });
+    remainingFlowCredits -= route.estimatedFlowCredits;
+    remainingBatchCredits -= route.estimatedFlowCredits;
+    return route;
+  });
+  return {
+    routes,
+    estimatedFlowCredits: routes.reduce((total, route) => total + route.estimatedFlowCredits, 0),
+  };
+}

--- a/src/tools/video/localized-media.ts
+++ b/src/tools/video/localized-media.ts
@@ -1,0 +1,175 @@
+/**
+ * Pure helpers shared by localized video renderers.
+ *
+ * The helpers deliberately fail closed: a locale, narration slot, caption cue
+ * or cache identity must be valid before any GPU or publication work starts.
+ */
+
+import { createHash } from 'crypto';
+
+export interface AudioFitPolicy {
+  slotDurationMs: number;
+  leadInMs: number;
+  tailOutMs: number;
+  maxSpeedup: number;
+  toleranceMs?: number;
+}
+
+export type AudioFitResult =
+  | { status: 'fits'; playbackRate: 1; availableSpeechMs: number }
+  | { status: 'speedup'; playbackRate: number; availableSpeechMs: number }
+  | {
+      status: 'overflow';
+      requiredRate: number;
+      availableSpeechMs: number;
+      overflowMs: number;
+    };
+
+export interface WebVttCue {
+  id?: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+}
+
+export interface RenderCacheIdentity {
+  rendererVersion: string;
+  sourceSha256: string;
+  motionPrompt: string;
+  locale: string;
+  voiceProfileId: string;
+  voiceProfileRevision: string;
+  voiceLine: string;
+  clipDurationMs: number;
+  visualSpeechMode: 'neutral-voiceover' | 'localized-lipsync';
+}
+
+export function canonicalizeLocale(input: string, supportedLocales?: readonly string[]): string {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.includes('_') || /-(?:u|t|x)-/iu.test(trimmed)) {
+    throw new Error(`Invalid or unsupported locale tag: ${input}`);
+  }
+  let canonical: string | undefined;
+  try {
+    [canonical] = Intl.getCanonicalLocales(trimmed);
+  } catch {
+    throw new Error(`Invalid or unsupported locale tag: ${input}`);
+  }
+  if (!canonical || canonical.toLowerCase() === 'und' || !new Intl.Locale(canonical).language) {
+    throw new Error(`Invalid or unsupported locale tag: ${input}`);
+  }
+  if (supportedLocales) {
+    const supported = supportedLocales.map((locale) => canonicalizeLocale(locale));
+    if (!supported.includes(canonical)) {
+      throw new Error(`Locale ${canonical} is not enabled for this render`);
+    }
+  }
+  return canonical;
+}
+
+export function localePathSlug(locale: string): string {
+  return canonicalizeLocale(locale).toLowerCase();
+}
+
+export function assessAudioFit(narrationDurationMs: number, policy: AudioFitPolicy): AudioFitResult {
+  const values = [
+    narrationDurationMs,
+    policy.slotDurationMs,
+    policy.leadInMs,
+    policy.tailOutMs,
+    policy.maxSpeedup,
+  ];
+  if (values.some((value) => !Number.isFinite(value)) || narrationDurationMs <= 0) {
+    throw new Error('Audio fit values must be finite and narration duration must be positive');
+  }
+  if (
+    policy.slotDurationMs <= 0 ||
+    policy.leadInMs < 0 ||
+    policy.tailOutMs < 0 ||
+    policy.maxSpeedup < 1
+  ) {
+    throw new Error('Invalid audio fit policy');
+  }
+  const availableSpeechMs = policy.slotDurationMs - policy.leadInMs - policy.tailOutMs;
+  if (availableSpeechMs <= 0) throw new Error('Audio fit policy leaves no room for speech');
+  const toleranceMs = Math.max(0, policy.toleranceMs ?? 20);
+  if (narrationDurationMs <= availableSpeechMs + toleranceMs) {
+    return { status: 'fits', playbackRate: 1, availableSpeechMs };
+  }
+  const requiredRate = narrationDurationMs / availableSpeechMs;
+  if (requiredRate <= policy.maxSpeedup) {
+    return {
+      status: 'speedup',
+      playbackRate: Math.ceil(requiredRate * 10_000) / 10_000,
+      availableSpeechMs,
+    };
+  }
+  return {
+    status: 'overflow',
+    requiredRate: Math.ceil(requiredRate * 10_000) / 10_000,
+    availableSpeechMs,
+    overflowMs: Math.ceil(narrationDurationMs - availableSpeechMs * policy.maxSpeedup),
+  };
+}
+
+export function formatWebVttTimestamp(milliseconds: number): string {
+  if (!Number.isInteger(milliseconds) || milliseconds < 0) {
+    throw new Error('WebVTT timestamps must be non-negative integer milliseconds');
+  }
+  const hours = Math.floor(milliseconds / 3_600_000);
+  const minutes = Math.floor((milliseconds % 3_600_000) / 60_000);
+  const seconds = Math.floor((milliseconds % 60_000) / 1_000);
+  const millis = milliseconds % 1_000;
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+}
+
+function escapeWebVttText(text: string): string {
+  if (text.includes('\0')) throw new Error('WebVTT cue text cannot contain NUL bytes');
+  return text
+    .replace(/\r\n?/gu, '\n')
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;');
+}
+
+export function buildWebVtt(cues: readonly WebVttCue[], mediaDurationMs: number): string {
+  if (!Number.isInteger(mediaDurationMs) || mediaDurationMs <= 0) {
+    throw new Error('WebVTT media duration must be positive integer milliseconds');
+  }
+  let previousEndMs = 0;
+  const blocks = cues.map((cue, index) => {
+    if (
+      !Number.isInteger(cue.startMs) ||
+      !Number.isInteger(cue.endMs) ||
+      cue.startMs < 0 ||
+      cue.endMs <= cue.startMs ||
+      cue.endMs > mediaDurationMs
+    ) {
+      throw new Error(`Invalid WebVTT cue ${index + 1}`);
+    }
+    if (index > 0 && cue.startMs < previousEndMs) {
+      throw new Error(`WebVTT cue ${index + 1} overlaps the previous cue`);
+    }
+    previousEndMs = cue.endMs;
+    const id = cue.id ? `${escapeWebVttText(cue.id)}\n` : '';
+    return `${id}${formatWebVttTimestamp(cue.startMs)} --> ${formatWebVttTimestamp(cue.endMs)}\n${escapeWebVttText(cue.text)}`;
+  });
+  return `WEBVTT\n\n${blocks.join('\n\n')}${blocks.length ? '\n' : ''}`;
+}
+
+export function renderCacheKey(identity: RenderCacheIdentity): string {
+  const locale = canonicalizeLocale(identity.locale);
+  if (!/^[a-f0-9]{64}$/u.test(identity.sourceSha256)) {
+    throw new Error('Render cache identity requires a SHA-256 source digest');
+  }
+  if (
+    !identity.rendererVersion.trim() ||
+    !identity.voiceProfileId.trim() ||
+    !identity.voiceProfileRevision.trim()
+  ) {
+    throw new Error('Render cache identity is incomplete');
+  }
+  return createHash('sha256')
+    .update(JSON.stringify({ ...identity, locale }))
+    .digest('hex');
+}

--- a/src/tools/video/long-form-plan.ts
+++ b/src/tools/video/long-form-plan.ts
@@ -1,0 +1,121 @@
+/** Quality and monetization-readiness gate for original long-form episodes. */
+
+import { canonicalizeLocale } from './localized-media.js';
+
+export interface LongFormScene {
+  id: string;
+  durationSeconds: number;
+  narration: string;
+  visualPrompt: string;
+}
+
+export interface LongFormChapter {
+  id: string;
+  title: string;
+  scenes: LongFormScene[];
+}
+
+export interface LongFormEpisodePlan {
+  schemaVersion: 1;
+  episodeId: string;
+  locale: string;
+  title: string;
+  description: string;
+  chapters: LongFormChapter[];
+  publication: {
+    visibility: 'private';
+    autoPublish: false;
+    madeForKids: false;
+    containsSyntheticMedia: true;
+    humanReviewRequired: true;
+  };
+}
+
+export interface LongFormPlanAssessment {
+  ready: boolean;
+  durationSeconds: number;
+  narrationWords: number;
+  uniqueVisualRatio: number;
+  midRollEligible: boolean;
+  suggestedAdBreakSeconds: number[];
+  failures: string[];
+}
+
+function normalizedPrompt(prompt: string): string {
+  return prompt.toLowerCase().replace(/\s+/gu, ' ').trim();
+}
+
+export function assessLongFormPlan(plan: LongFormEpisodePlan): LongFormPlanAssessment {
+  const failures: string[] = [];
+  if (plan.schemaVersion !== 1) failures.push('unsupported-schema');
+  try {
+    canonicalizeLocale(plan.locale);
+  } catch {
+    failures.push('invalid-locale');
+  }
+  if (!plan.episodeId.trim() || !plan.title.trim() || !plan.description.trim()) {
+    failures.push('missing-editorial-metadata');
+  }
+  if (plan.chapters.length < 5) failures.push('insufficient-chapters');
+
+  const chapterIds = new Set<string>();
+  const sceneIds = new Set<string>();
+  const prompts = new Set<string>();
+  let durationSeconds = 0;
+  let narrationWords = 0;
+  const chapterEndSeconds: number[] = [];
+
+  for (const chapter of plan.chapters) {
+    if (!chapter.id.trim() || chapterIds.has(chapter.id) || !chapter.title.trim() || !chapter.scenes.length) {
+      failures.push('invalid-chapter');
+    }
+    chapterIds.add(chapter.id);
+    for (const scene of chapter.scenes) {
+      if (!scene.id.trim() || sceneIds.has(scene.id)) failures.push('duplicate-or-empty-scene-id');
+      sceneIds.add(scene.id);
+      if (!Number.isFinite(scene.durationSeconds) || scene.durationSeconds < 4 || scene.durationSeconds > 30) {
+        failures.push('invalid-scene-duration');
+      }
+      if (!scene.narration.trim() || !scene.visualPrompt.trim()) failures.push('incomplete-scene');
+      durationSeconds += scene.durationSeconds;
+      narrationWords += scene.narration.trim().split(/\s+/u).filter(Boolean).length;
+      prompts.add(normalizedPrompt(scene.visualPrompt));
+    }
+    chapterEndSeconds.push(durationSeconds);
+  }
+
+  if (durationSeconds < 480) failures.push('shorter-than-eight-minutes');
+  if (durationSeconds > 1_200) failures.push('longer-than-twenty-minutes');
+  if (sceneIds.size < 24) failures.push('insufficient-visual-scenes');
+  if (narrationWords < 600) failures.push('insufficient-original-narration');
+  const uniqueVisualRatio = sceneIds.size ? prompts.size / sceneIds.size : 0;
+  if (uniqueVisualRatio < 0.8) failures.push('repetitive-visual-plan');
+  if (
+    plan.publication.visibility !== 'private' ||
+    plan.publication.autoPublish !== false ||
+    plan.publication.madeForKids !== false ||
+    plan.publication.containsSyntheticMedia !== true ||
+    plan.publication.humanReviewRequired !== true
+  ) {
+    failures.push('unsafe-publication-gate');
+  }
+
+  const suggestedAdBreakSeconds: number[] = [];
+  let previousBreak = 0;
+  for (const boundary of chapterEndSeconds.slice(0, -1)) {
+    if (boundary >= 150 && boundary - previousBreak >= 150 && durationSeconds - boundary >= 90) {
+      suggestedAdBreakSeconds.push(Math.round(boundary));
+      previousBreak = boundary;
+    }
+  }
+
+  return {
+    ready: failures.length === 0,
+    durationSeconds: Math.round(durationSeconds * 100) / 100,
+    narrationWords,
+    uniqueVisualRatio: Math.round(uniqueVisualRatio * 1_000) / 1_000,
+    midRollEligible: durationSeconds >= 480,
+    suggestedAdBreakSeconds,
+    failures: [...new Set(failures)],
+  };
+}

--- a/src/tools/video/long-form-production.ts
+++ b/src/tools/video/long-form-production.ts
@@ -1,0 +1,201 @@
+/** Compile and assemble human-reviewed long-form episode plans without publishing them. */
+
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { assembleFilm, type AssembleFilmResult } from './film-assemble.js';
+import { assessLongFormPlan, type LongFormEpisodePlan } from './long-form-plan.js';
+
+export interface LongFormRenderPacket {
+  schemaVersion: 1;
+  episodeId: string;
+  planSha256: string;
+  locale: string;
+  target: { width: 1920; height: 1080; fps: 30; audio: 'required' };
+  publication: { visibility: 'private'; autoPublish: false; humanReviewRequired: true };
+  scenes: Array<{
+    order: number;
+    chapterId: string;
+    sceneId: string;
+    role: 'chapter-hero' | 'b-roll';
+    durationSeconds: number;
+    narration: string;
+    visualPrompt: string;
+    expectedFilename: string;
+    status: 'awaiting-media-generation';
+  }>;
+}
+
+export function compileLongFormRenderPacket(plan: LongFormEpisodePlan): LongFormRenderPacket {
+  const assessment = assessLongFormPlan(plan);
+  if (!assessment.ready) throw new Error(`Long-form plan is not production-ready: ${assessment.failures.join(', ')}`);
+  const planSha256 = createHash('sha256').update(JSON.stringify(plan)).digest('hex');
+  let order = 0;
+  return {
+    schemaVersion: 1,
+    episodeId: plan.episodeId,
+    planSha256,
+    locale: plan.locale,
+    target: { width: 1920, height: 1080, fps: 30, audio: 'required' },
+    publication: { visibility: 'private', autoPublish: false, humanReviewRequired: true },
+    scenes: plan.chapters.flatMap((chapter) => chapter.scenes.map((scene, index) => ({
+      order: ++order,
+      chapterId: chapter.id,
+      sceneId: scene.id,
+      role: index === 0 ? 'chapter-hero' as const : 'b-roll' as const,
+      durationSeconds: scene.durationSeconds,
+      narration: scene.narration,
+      visualPrompt: scene.visualPrompt,
+      expectedFilename: `${scene.id}.mp4`,
+      status: 'awaiting-media-generation' as const,
+    }))),
+  };
+}
+
+export async function assembleLongFormMaster(input: {
+  plan: LongFormEpisodePlan;
+  clipsRoot: string;
+  projectRoot: string;
+  assembler?: typeof assembleFilm;
+}): Promise<{ outputPath: string; metadataPath: string; result: AssembleFilmResult }> {
+  const packet = compileLongFormRenderPacket(input.plan);
+  const clipsRoot = await regularDirectory(input.clipsRoot, 'Long-form clips root');
+  const projectRoot = await regularDirectory(input.projectRoot, 'Long-form project root');
+  const clips: string[] = [];
+  for (const scene of packet.scenes) {
+    const candidate = path.join(clipsRoot, scene.expectedFilename);
+    const info = await fs.lstat(candidate);
+    if (info.isSymbolicLink() || !info.isFile() || info.size <= 1024) {
+      throw new Error(`Long-form scene ${scene.sceneId} must be a regular non-empty MP4`);
+    }
+    const canonical = await fs.realpath(candidate);
+    if (!within(canonical, clipsRoot)) throw new Error(`Long-form scene ${scene.sceneId} escapes the clips root`);
+    clips.push(canonical);
+  }
+  const outputRelative = `long-form/${input.plan.episodeId}/${packet.planSha256}.mp4`;
+  const result = await (input.assembler ?? assembleFilm)({
+    clips,
+    transitions: clips.slice(1).map(() => ({ type: 'cut', duration: 0 })),
+    resolution: '1080p',
+    aspectRatio: '16:9',
+    fps: 30,
+    rootDir: projectRoot,
+    name: input.plan.episodeId,
+    output: outputRelative,
+  });
+  if (!result.success || !result.outputPath || result.clipCount !== clips.length || result.transitionCount !== clips.length - 1 ||
+      result.targetWidth !== 1920 || result.targetHeight !== 1080 || result.fps !== 30 || !result.hasAudio ||
+      (result.probedDuration ?? result.estimatedDuration) < 480 || (result.probedDuration ?? result.estimatedDuration) > 1200 ||
+      Math.abs((result.probedDuration ?? result.estimatedDuration) - assessLongFormPlan(input.plan).durationSeconds) > 1) {
+    throw new Error(result.error ?? 'Long-form master failed its clip, audio, duration or output-profile contract');
+  }
+  const outputPath = await regularFile(result.outputPath, 'Long-form master');
+  const expectedOutput = path.join(
+    projectRoot, '.codebuddy', 'media-generation', 'films', 'long-form', input.plan.episodeId, `${packet.planSha256}.mp4`,
+  );
+  if (outputPath !== expectedOutput) throw new Error('Long-form assembler returned an unexpected output path');
+  const outputSha256 = createHash('sha256').update(await fs.readFile(outputPath)).digest('hex');
+  const captionPath = `${outputPath}.${input.plan.locale}.vtt`;
+  await fs.writeFile(captionPath, buildLongFormWebVtt(input.plan), { flag: 'wx', mode: 0o600 });
+  const captionSha256 = createHash('sha256').update(await fs.readFile(captionPath)).digest('hex');
+  const metadataPath = `${outputPath}.youtube.json`;
+  await fs.writeFile(metadataPath, `${JSON.stringify({
+    schemaVersion: 1,
+    episodeId: input.plan.episodeId,
+    planSha256: packet.planSha256,
+    videoSha256: outputSha256,
+    caption: { file: path.basename(captionPath), sha256: captionSha256, locale: input.plan.locale, format: 'webvtt' },
+    title: input.plan.title,
+    description: input.plan.description,
+    locale: input.plan.locale,
+    chapters: input.plan.chapters.map((chapter) => ({ id: chapter.id, title: chapter.title })),
+    suggestedAdBreakSeconds: assessLongFormPlan(input.plan).suggestedAdBreakSeconds,
+    visibility: 'private',
+    madeForKids: false,
+    containsSyntheticMedia: true,
+    humanReviewRequired: true,
+    reviewStatus: 'pending-human-review',
+    technical: { width: 1920, height: 1080, fps: 30, hasAudio: true, durationSeconds: result.probedDuration ?? result.estimatedDuration },
+    autoPublish: false,
+  }, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+  return { outputPath, metadataPath, result };
+}
+
+export async function reviewLongFormMaster(input: {
+  videoPath: string;
+  reviewer: string;
+  reason: string;
+  checks: Record<'voice' | 'identity' | 'anatomy' | 'captions' | 'disclosure' | 'chapters' | 'editorial', boolean>;
+  now?: () => Date;
+}): Promise<Record<string, unknown>> {
+  const videoPath = await regularFile(input.videoPath, 'Long-form master');
+  const metadataPath = await regularFile(`${videoPath}.youtube.json`, 'Long-form metadata');
+  const metadata = JSON.parse(await fs.readFile(metadataPath, 'utf8')) as Record<string, unknown>;
+  const videoSha256 = createHash('sha256').update(await fs.readFile(videoPath)).digest('hex');
+  const caption = metadata.caption as Record<string, unknown> | undefined;
+  if (
+    metadata.schemaVersion !== 1 || metadata.videoSha256 !== videoSha256 || metadata.visibility !== 'private' ||
+    metadata.autoPublish !== false || metadata.humanReviewRequired !== true || metadata.reviewStatus !== 'pending-human-review' ||
+    !caption || typeof caption.file !== 'string' || path.basename(caption.file) !== caption.file
+  ) throw new Error('Long-form metadata is incomplete, stale or unsafe');
+  const captionPath = await regularFile(path.join(path.dirname(videoPath), caption.file), 'Long-form captions');
+  const captionSha256 = createHash('sha256').update(await fs.readFile(captionPath)).digest('hex');
+  if (caption.sha256 !== captionSha256) throw new Error('Long-form caption digest is stale');
+  if (Object.values(input.checks).some((value) => value !== true)) throw new Error('Every long-form human-review check must pass');
+  if (input.reviewer.trim().length < 2 || input.reason.trim().length < 3) throw new Error('Reviewer and reason are required');
+  return {
+    schemaVersion: 1,
+    status: 'ready-for-private-upload',
+    episodeId: metadata.episodeId,
+    videoSha256,
+    metadataSha256: createHash('sha256').update(await fs.readFile(metadataPath)).digest('hex'),
+    captionSha256,
+    reviewer: input.reviewer.trim(),
+    reason: input.reason.trim(),
+    checks: input.checks,
+    reviewedAt: (input.now ?? (() => new Date()))().toISOString(),
+    visibility: 'private',
+    autoPublish: false,
+  };
+}
+
+function buildLongFormWebVtt(plan: LongFormEpisodePlan): string {
+  let cursor = 0;
+  const cues: string[] = ['WEBVTT', ''];
+  for (const chapter of plan.chapters) {
+    for (const scene of chapter.scenes) {
+      const start = cursor;
+      cursor += scene.durationSeconds;
+      cues.push(scene.id, `${vttTime(start)} --> ${vttTime(cursor)}`, scene.narration.replace(/-->/gu, '→').trim(), '');
+    }
+  }
+  return `${cues.join('\n')}\n`;
+}
+
+function vttTime(seconds: number): string {
+  const milliseconds = Math.round(seconds * 1_000);
+  const hours = Math.floor(milliseconds / 3_600_000);
+  const minutes = Math.floor(milliseconds % 3_600_000 / 60_000);
+  const secs = Math.floor(milliseconds % 60_000 / 1_000);
+  const millis = milliseconds % 1_000;
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+}
+
+async function regularDirectory(value: string, label: string): Promise<string> {
+  if (!path.isAbsolute(value) || value.includes('\0')) throw new Error(`${label} must be absolute`);
+  const info = await fs.lstat(value);
+  if (info.isSymbolicLink() || !info.isDirectory()) throw new Error(`${label} must be a regular directory`);
+  return fs.realpath(value);
+}
+
+async function regularFile(value: string, label: string): Promise<string> {
+  const info = await fs.lstat(value);
+  if (info.isSymbolicLink() || !info.isFile()) throw new Error(`${label} must be a regular file`);
+  return fs.realpath(value);
+}
+
+function within(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/src/tools/video/native-fashion-defects.ts
+++ b/src/tools/video/native-fashion-defects.ts
@@ -1,0 +1,121 @@
+/** Blocking-gate defect classification and append-only retry receipts. */
+
+import { constants as fsConstants } from 'fs';
+import { open } from 'fs/promises';
+
+const SHA256 = /^[a-f0-9]{64}$/u;
+
+export type NativeFashionGate =
+  | 'identity'
+  | 'anatomy'
+  | 'temporal-stability'
+  | 'outfit'
+  | 'decor-framing'
+  | 'master-properties';
+
+export interface GateResult {
+  gate: NativeFashionGate;
+  pass: boolean;
+  evidence: string;
+}
+
+export interface ClassifiedNativeFashionDefect {
+  gate: NativeFashionGate;
+  causalAdjustment: string;
+}
+
+const GATE_ORDER: readonly NativeFashionGate[] = [
+  'identity',
+  'anatomy',
+  'temporal-stability',
+  'outfit',
+  'decor-framing',
+  'master-properties',
+];
+
+/** Every retry changes the parameter family most directly linked to its failed gate. */
+export const NATIVE_FASHION_CAUSAL_ADJUSTMENTS: Readonly<Record<NativeFashionGate, string>> = {
+  identity: 'strengthen identity LoRA and face conditioning',
+  anatomy: 'adjust skeleton and pose control, then change the seed',
+  'temporal-stability': 'change the seed and temporal engine parameters',
+  outfit: 'strengthen outfit conditioning and revise the outfit prompt',
+  'decor-framing': 'revise the decor and framing prompt, then change the seed',
+  'master-properties': 'correct native generation and encoding parameters',
+};
+
+export function classifyDefects(results: readonly GateResult[]): ClassifiedNativeFashionDefect[] {
+  const failed = new Set(results.filter((result) => !result.pass).map((result) => result.gate));
+  return GATE_ORDER
+    .filter((gate) => failed.has(gate))
+    .map((gate) => ({ gate, causalAdjustment: NATIVE_FASHION_CAUSAL_ADJUSTMENTS[gate] }));
+}
+
+export interface RetryReceipt {
+  attempt: number;
+  batchId: string;
+  sceneId: string;
+  candidateSha256: string;
+  seed: number;
+  adjustedParameters: string[];
+  failedGates: NativeFashionGate[];
+  verdict: 'rejected' | 'promoted-to-human-review' | 'batch-exhausted';
+  at: string;
+}
+
+function assertRetryReceipt(receipt: RetryReceipt): void {
+  if (!Number.isInteger(receipt.attempt) || receipt.attempt < 1) {
+    throw new Error('Retry receipt attempt must be a positive integer');
+  }
+  if (!receipt.batchId.trim() || !receipt.sceneId.trim()) {
+    throw new Error('Retry receipt batchId and sceneId are required');
+  }
+  if (!SHA256.test(receipt.candidateSha256)) {
+    throw new Error('Retry receipt candidateSha256 must be a lowercase SHA-256');
+  }
+  if (!Number.isSafeInteger(receipt.seed)) throw new Error('Retry receipt seed must be a safe integer');
+  if (!receipt.adjustedParameters.every((parameter) => parameter.trim().length > 0)) {
+    throw new Error('Retry receipt adjustedParameters must contain non-empty descriptions');
+  }
+  if (receipt.attempt > 1 && receipt.adjustedParameters.length === 0) {
+    throw new Error('A retry must adjust causal parameters; an identical retry is not allowed');
+  }
+  if (!receipt.failedGates.every((gate) => GATE_ORDER.includes(gate))) {
+    throw new Error('Retry receipt contains an unknown failed gate');
+  }
+  if (receipt.verdict === 'promoted-to-human-review' && receipt.failedGates.length > 0) {
+    throw new Error('A candidate with a failed blocking gate cannot be promoted to human review');
+  }
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u.test(receipt.at) || !Number.isFinite(Date.parse(receipt.at))) {
+    throw new Error('Retry receipt at must be an ISO UTC timestamp');
+  }
+}
+
+export async function appendRetryReceipt(journalPath: string, receipt: RetryReceipt): Promise<void> {
+  assertRetryReceipt(receipt);
+  const handle = await open(
+    journalPath,
+    fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) throw new Error('Retry journal must be a regular non-symlink file');
+    await handle.writeFile(`${JSON.stringify(receipt)}\n`, 'utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+export function assertBatchBounded(receipts: readonly RetryReceipt[], maxAttempts: number): void {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error('maxAttempts must be a positive integer');
+  }
+  for (const receipt of receipts) {
+    assertRetryReceipt(receipt);
+    if (receipt.attempt >= maxAttempts && receipt.verdict !== 'batch-exhausted') {
+      throw new Error(
+        `Attempt ${receipt.attempt} reached batch bound ${maxAttempts}; verdict must be batch-exhausted`,
+      );
+    }
+  }
+}

--- a/src/tools/video/visual-gate-report.ts
+++ b/src/tools/video/visual-gate-report.ts
@@ -1,0 +1,524 @@
+/** Strict schema-V1 parser and fail-closed evaluator for measured visual gates. */
+
+import { createHash } from 'crypto';
+import { constants as fsConstants } from 'fs';
+import { open } from 'fs/promises';
+import path from 'path';
+
+import type { GateResult } from './native-fashion-defects.js';
+
+const SHA256 = /^[a-f0-9]{64}$/u;
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u;
+
+export type VisualGateReportProfile = 'native-fashion-v1' | 'legacy-localized-v1';
+
+export interface VisualGateFrameReference {
+  frameIndex: number;
+  timestampSeconds: number;
+}
+
+export interface VisualGateIdentityFrame extends VisualGateFrameReference {
+  similarity: number;
+}
+
+export interface VisualGateIdentityMetrics {
+  evaluatedFrameCount: number;
+  detectedFaceCount: number;
+  minSimilarity: number;
+  meanSimilarity: number;
+  stdDevSimilarity: number;
+  lowSimilarityFrames: VisualGateIdentityFrame[];
+  noFace: VisualGateFrameReference[];
+}
+
+export interface VisualGateAnatomyFrame extends VisualGateFrameReference {
+  lowVisibilityLandmarkCount: number;
+  detectedHandFingerCounts: number[];
+  implausibleFingerCounts: number[];
+  teleportation: boolean;
+}
+
+export interface VisualGateTeleportationFrame extends VisualGateFrameReference {
+  landmarkIndices: number[];
+  maxNormalizedDelta: number;
+}
+
+export interface VisualGateAnatomyMetrics {
+  evaluatedFrameCount: number;
+  suspectFrameCount: number;
+  suspiciousFrames: VisualGateAnatomyFrame[];
+  teleportationFrames: VisualGateTeleportationFrame[];
+}
+
+export interface VisualGateTemporalStabilityMetrics {
+  framePairCount: number;
+  globalFlickerMean: number;
+  thirdsFlickerMean: {
+    top: number;
+    middle: number;
+    bottom: number;
+  };
+  exposureJitterVariance: number;
+  localWarpGradientMean: number;
+}
+
+export interface VisualGateSharpnessFrame extends VisualGateFrameReference {
+  laplacianVariance: number;
+}
+
+export interface VisualGateSharpnessMetrics {
+  evaluatedFrameCount: number;
+  minLaplacianVariance: number;
+  meanLaplacianVariance: number;
+  lowSharpnessFrames: VisualGateSharpnessFrame[];
+}
+
+export interface VisualGateMasterProperties {
+  width: number;
+  height: number;
+  fps: number;
+  durationSeconds: number;
+  videoBitrateKbps: number;
+  videoCodec: string;
+  audioCodec: string;
+  hasAudio: boolean;
+  nearBlackFrameRatio: number;
+}
+
+export interface VisualGateLoopMetrics {
+  normalizedAbsoluteDifference: number;
+  histogramCorrelation: number;
+}
+
+export interface VisualGateReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  clipSha256: string | null;
+  profile: VisualGateReportProfile;
+  sampleFps: number;
+  metrics: {
+    identity: VisualGateIdentityMetrics;
+    anatomy: VisualGateAnatomyMetrics;
+    temporalStability: VisualGateTemporalStabilityMetrics;
+    sharpness: VisualGateSharpnessMetrics;
+    masterProperties: VisualGateMasterProperties;
+    loop: VisualGateLoopMetrics | null;
+  };
+}
+
+export interface HumanConfirmedVisualGates {
+  outfit?: true;
+  decorFraming?: true;
+}
+
+export const VISUAL_GATE_THRESHOLDS = {
+  'native-fashion-v1': {
+    // calibration pending — see docs/studies/2026-07-20-synthesis
+    identity: { minSimilarity: 0.35, meanSimilarity: 0.45, maxNoFaceFrames: 0 },
+    anatomy: { maxTeleportationFrames: 0, maxImplausibleHandFrames: 0 },
+    temporalStability: {
+      maxGlobalFlickerMean: 12,
+      maxThirdFlickerMean: 16,
+      maxExposureJitterVariance: 100,
+      maxLocalWarpGradientMean: 40,
+    },
+    sharpness: { minLaplacianVariance: 100 },
+    masterProperties: {
+      minWidth: 1080,
+      minHeight: 1920,
+      targetFps: 30,
+      fpsTolerance: 0.05,
+      minDurationSeconds: 11,
+      maxDurationSeconds: 13,
+      minVideoBitrateKbps: 12_000,
+      maxVideoBitrateKbps: 20_000,
+      maxNearBlackFrameRatio: 0.05,
+      videoCodecs: ['h264', 'hevc'] as const,
+      audioCodecs: ['aac', 'opus'] as const,
+    },
+    loop: {
+      required: true,
+      maxNormalizedAbsoluteDifference: 0.12,
+      minHistogramCorrelation: 0.9,
+    },
+  },
+} as const;
+
+export type VisualGateThresholdProfileId = keyof typeof VISUAL_GATE_THRESHOLDS;
+
+export interface EvaluatedVisualGateReport {
+  report: VisualGateReport;
+  gateResults: GateResult[];
+  reportSha256: string;
+}
+
+function objectAt(value: unknown, location: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Visual gate report ${location} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], location: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`Visual gate report ${location} fields are invalid; expected exactly: ${keys.join(', ')}`);
+  }
+}
+
+function finiteNumber(value: unknown, location: string, minimum?: number, maximum?: number): number {
+  if (
+    typeof value !== 'number' || !Number.isFinite(value) ||
+    (minimum !== undefined && value < minimum) || (maximum !== undefined && value > maximum)
+  ) {
+    throw new Error(`Visual gate report ${location} must be a finite number${minimum !== undefined ? ` >= ${minimum}` : ''}`);
+  }
+  return value;
+}
+
+function integer(value: unknown, location: string, minimum = 0): number {
+  const parsed = finiteNumber(value, location, minimum);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`Visual gate report ${location} must be a safe integer`);
+  return parsed;
+}
+
+function booleanAt(value: unknown, location: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`Visual gate report ${location} must be boolean`);
+  return value;
+}
+
+function stringAt(value: unknown, location: string): string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`Visual gate report ${location} must be a non-empty string`);
+  return value;
+}
+
+function arrayAt(value: unknown, location: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`Visual gate report ${location} must be an array`);
+  return value;
+}
+
+function frameReference(value: unknown, location: string): VisualGateFrameReference {
+  const record = objectAt(value, location);
+  exactKeys(record, ['frameIndex', 'timestampSeconds'], location);
+  return {
+    frameIndex: integer(record.frameIndex, `${location}.frameIndex`),
+    timestampSeconds: finiteNumber(record.timestampSeconds, `${location}.timestampSeconds`, 0),
+  };
+}
+
+function identityFrame(value: unknown, location: string): VisualGateIdentityFrame {
+  const record = objectAt(value, location);
+  exactKeys(record, ['frameIndex', 'timestampSeconds', 'similarity'], location);
+  return {
+    frameIndex: integer(record.frameIndex, `${location}.frameIndex`),
+    timestampSeconds: finiteNumber(record.timestampSeconds, `${location}.timestampSeconds`, 0),
+    similarity: finiteNumber(record.similarity, `${location}.similarity`, -1, 1),
+  };
+}
+
+function parseIdentity(value: unknown): VisualGateIdentityMetrics {
+  const record = objectAt(value, 'metrics.identity');
+  exactKeys(record, [
+    'evaluatedFrameCount', 'detectedFaceCount', 'minSimilarity', 'meanSimilarity',
+    'stdDevSimilarity', 'lowSimilarityFrames', 'noFace',
+  ], 'metrics.identity');
+  const result: VisualGateIdentityMetrics = {
+    evaluatedFrameCount: integer(record.evaluatedFrameCount, 'metrics.identity.evaluatedFrameCount', 1),
+    detectedFaceCount: integer(record.detectedFaceCount, 'metrics.identity.detectedFaceCount'),
+    minSimilarity: finiteNumber(record.minSimilarity, 'metrics.identity.minSimilarity', -1, 1),
+    meanSimilarity: finiteNumber(record.meanSimilarity, 'metrics.identity.meanSimilarity', -1, 1),
+    stdDevSimilarity: finiteNumber(record.stdDevSimilarity, 'metrics.identity.stdDevSimilarity', 0),
+    lowSimilarityFrames: arrayAt(record.lowSimilarityFrames, 'metrics.identity.lowSimilarityFrames')
+      .map((item, index) => identityFrame(item, `metrics.identity.lowSimilarityFrames[${index}]`)),
+    noFace: arrayAt(record.noFace, 'metrics.identity.noFace')
+      .map((item, index) => frameReference(item, `metrics.identity.noFace[${index}]`)),
+  };
+  if (result.detectedFaceCount + result.noFace.length !== result.evaluatedFrameCount) {
+    throw new Error('Visual gate report identity face counts are inconsistent');
+  }
+  return result;
+}
+
+function integerArray(value: unknown, location: string): number[] {
+  return arrayAt(value, location).map((item, index) => integer(item, `${location}[${index}]`));
+}
+
+function anatomyFrame(value: unknown, location: string): VisualGateAnatomyFrame {
+  const record = objectAt(value, location);
+  exactKeys(record, [
+    'frameIndex', 'timestampSeconds', 'lowVisibilityLandmarkCount', 'detectedHandFingerCounts',
+    'implausibleFingerCounts', 'teleportation',
+  ], location);
+  return {
+    frameIndex: integer(record.frameIndex, `${location}.frameIndex`),
+    timestampSeconds: finiteNumber(record.timestampSeconds, `${location}.timestampSeconds`, 0),
+    lowVisibilityLandmarkCount: integer(record.lowVisibilityLandmarkCount, `${location}.lowVisibilityLandmarkCount`),
+    detectedHandFingerCounts: integerArray(record.detectedHandFingerCounts, `${location}.detectedHandFingerCounts`),
+    implausibleFingerCounts: integerArray(record.implausibleFingerCounts, `${location}.implausibleFingerCounts`),
+    teleportation: booleanAt(record.teleportation, `${location}.teleportation`),
+  };
+}
+
+function teleportationFrame(value: unknown, location: string): VisualGateTeleportationFrame {
+  const record = objectAt(value, location);
+  exactKeys(record, ['frameIndex', 'timestampSeconds', 'landmarkIndices', 'maxNormalizedDelta'], location);
+  return {
+    frameIndex: integer(record.frameIndex, `${location}.frameIndex`),
+    timestampSeconds: finiteNumber(record.timestampSeconds, `${location}.timestampSeconds`, 0),
+    landmarkIndices: integerArray(record.landmarkIndices, `${location}.landmarkIndices`),
+    maxNormalizedDelta: finiteNumber(record.maxNormalizedDelta, `${location}.maxNormalizedDelta`, 0),
+  };
+}
+
+function parseAnatomy(value: unknown): VisualGateAnatomyMetrics {
+  const record = objectAt(value, 'metrics.anatomy');
+  exactKeys(record, ['evaluatedFrameCount', 'suspectFrameCount', 'suspiciousFrames', 'teleportationFrames'], 'metrics.anatomy');
+  const result: VisualGateAnatomyMetrics = {
+    evaluatedFrameCount: integer(record.evaluatedFrameCount, 'metrics.anatomy.evaluatedFrameCount', 1),
+    suspectFrameCount: integer(record.suspectFrameCount, 'metrics.anatomy.suspectFrameCount'),
+    suspiciousFrames: arrayAt(record.suspiciousFrames, 'metrics.anatomy.suspiciousFrames')
+      .map((item, index) => anatomyFrame(item, `metrics.anatomy.suspiciousFrames[${index}]`)),
+    teleportationFrames: arrayAt(record.teleportationFrames, 'metrics.anatomy.teleportationFrames')
+      .map((item, index) => teleportationFrame(item, `metrics.anatomy.teleportationFrames[${index}]`)),
+  };
+  if (result.suspectFrameCount !== result.suspiciousFrames.length) {
+    throw new Error('Visual gate report anatomy suspect frame count is inconsistent');
+  }
+  return result;
+}
+
+function parseTemporalStability(value: unknown): VisualGateTemporalStabilityMetrics {
+  const record = objectAt(value, 'metrics.temporalStability');
+  exactKeys(record, [
+    'framePairCount', 'globalFlickerMean', 'thirdsFlickerMean',
+    'exposureJitterVariance', 'localWarpGradientMean',
+  ], 'metrics.temporalStability');
+  const thirds = objectAt(record.thirdsFlickerMean, 'metrics.temporalStability.thirdsFlickerMean');
+  exactKeys(thirds, ['top', 'middle', 'bottom'], 'metrics.temporalStability.thirdsFlickerMean');
+  return {
+    framePairCount: integer(record.framePairCount, 'metrics.temporalStability.framePairCount'),
+    globalFlickerMean: finiteNumber(record.globalFlickerMean, 'metrics.temporalStability.globalFlickerMean', 0),
+    thirdsFlickerMean: {
+      top: finiteNumber(thirds.top, 'metrics.temporalStability.thirdsFlickerMean.top', 0),
+      middle: finiteNumber(thirds.middle, 'metrics.temporalStability.thirdsFlickerMean.middle', 0),
+      bottom: finiteNumber(thirds.bottom, 'metrics.temporalStability.thirdsFlickerMean.bottom', 0),
+    },
+    exposureJitterVariance: finiteNumber(record.exposureJitterVariance, 'metrics.temporalStability.exposureJitterVariance', 0),
+    localWarpGradientMean: finiteNumber(record.localWarpGradientMean, 'metrics.temporalStability.localWarpGradientMean', 0),
+  };
+}
+
+function sharpnessFrame(value: unknown, location: string): VisualGateSharpnessFrame {
+  const record = objectAt(value, location);
+  exactKeys(record, ['frameIndex', 'timestampSeconds', 'laplacianVariance'], location);
+  return {
+    frameIndex: integer(record.frameIndex, `${location}.frameIndex`),
+    timestampSeconds: finiteNumber(record.timestampSeconds, `${location}.timestampSeconds`, 0),
+    laplacianVariance: finiteNumber(record.laplacianVariance, `${location}.laplacianVariance`, 0),
+  };
+}
+
+function parseSharpness(value: unknown): VisualGateSharpnessMetrics {
+  const record = objectAt(value, 'metrics.sharpness');
+  exactKeys(record, [
+    'evaluatedFrameCount', 'minLaplacianVariance', 'meanLaplacianVariance', 'lowSharpnessFrames',
+  ], 'metrics.sharpness');
+  return {
+    evaluatedFrameCount: integer(record.evaluatedFrameCount, 'metrics.sharpness.evaluatedFrameCount', 1),
+    minLaplacianVariance: finiteNumber(record.minLaplacianVariance, 'metrics.sharpness.minLaplacianVariance', 0),
+    meanLaplacianVariance: finiteNumber(record.meanLaplacianVariance, 'metrics.sharpness.meanLaplacianVariance', 0),
+    lowSharpnessFrames: arrayAt(record.lowSharpnessFrames, 'metrics.sharpness.lowSharpnessFrames')
+      .map((item, index) => sharpnessFrame(item, `metrics.sharpness.lowSharpnessFrames[${index}]`)),
+  };
+}
+
+function parseMasterProperties(value: unknown): VisualGateMasterProperties {
+  const record = objectAt(value, 'metrics.masterProperties');
+  exactKeys(record, [
+    'width', 'height', 'fps', 'durationSeconds', 'videoBitrateKbps', 'videoCodec',
+    'audioCodec', 'hasAudio', 'nearBlackFrameRatio',
+  ], 'metrics.masterProperties');
+  return {
+    width: integer(record.width, 'metrics.masterProperties.width', 1),
+    height: integer(record.height, 'metrics.masterProperties.height', 1),
+    fps: finiteNumber(record.fps, 'metrics.masterProperties.fps', 0.000_001),
+    durationSeconds: finiteNumber(record.durationSeconds, 'metrics.masterProperties.durationSeconds', 0.000_001),
+    videoBitrateKbps: finiteNumber(record.videoBitrateKbps, 'metrics.masterProperties.videoBitrateKbps', 0),
+    videoCodec: stringAt(record.videoCodec, 'metrics.masterProperties.videoCodec'),
+    audioCodec: stringAt(record.audioCodec, 'metrics.masterProperties.audioCodec'),
+    hasAudio: booleanAt(record.hasAudio, 'metrics.masterProperties.hasAudio'),
+    nearBlackFrameRatio: finiteNumber(record.nearBlackFrameRatio, 'metrics.masterProperties.nearBlackFrameRatio', 0, 1),
+  };
+}
+
+function parseLoop(value: unknown): VisualGateLoopMetrics | null {
+  if (value === null) return null;
+  const record = objectAt(value, 'metrics.loop');
+  exactKeys(record, ['normalizedAbsoluteDifference', 'histogramCorrelation'], 'metrics.loop');
+  return {
+    normalizedAbsoluteDifference: finiteNumber(record.normalizedAbsoluteDifference, 'metrics.loop.normalizedAbsoluteDifference', 0, 1),
+    histogramCorrelation: finiteNumber(record.histogramCorrelation, 'metrics.loop.histogramCorrelation', -1, 1),
+  };
+}
+
+export function parseVisualGateReport(json: unknown): VisualGateReport {
+  const report = objectAt(json, 'root');
+  exactKeys(report, ['schemaVersion', 'generatedAt', 'clipSha256', 'profile', 'sampleFps', 'metrics'], 'root');
+  if (report.schemaVersion !== 1) {
+    throw new Error(`Unsupported visual gate report schemaVersion: ${String(report.schemaVersion)}`);
+  }
+  const generatedAt = stringAt(report.generatedAt, 'generatedAt');
+  if (!ISO_UTC.test(generatedAt) || !Number.isFinite(Date.parse(generatedAt))) {
+    throw new Error('Visual gate report generatedAt must be an ISO UTC timestamp');
+  }
+  if (report.clipSha256 !== null && (typeof report.clipSha256 !== 'string' || !SHA256.test(report.clipSha256))) {
+    throw new Error('Visual gate report clipSha256 must be null or a lowercase SHA-256');
+  }
+  if (report.profile !== 'native-fashion-v1' && report.profile !== 'legacy-localized-v1') {
+    throw new Error(`Unknown visual gate report profile: ${String(report.profile)}`);
+  }
+  const metrics = objectAt(report.metrics, 'metrics');
+  exactKeys(metrics, ['identity', 'anatomy', 'temporalStability', 'sharpness', 'masterProperties', 'loop'], 'metrics');
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    clipSha256: report.clipSha256,
+    profile: report.profile,
+    sampleFps: finiteNumber(report.sampleFps, 'sampleFps', 0.000_001),
+    metrics: {
+      identity: parseIdentity(metrics.identity),
+      anatomy: parseAnatomy(metrics.anatomy),
+      temporalStability: parseTemporalStability(metrics.temporalStability),
+      sharpness: parseSharpness(metrics.sharpness),
+      masterProperties: parseMasterProperties(metrics.masterProperties),
+      loop: parseLoop(metrics.loop),
+    },
+  };
+}
+
+export function assertReportMatchesClip(report: VisualGateReport, clipSha256: string): void {
+  if (!SHA256.test(clipSha256)) throw new Error('Expected clip digest must be a lowercase SHA-256');
+  if (report.clipSha256 === null) {
+    throw new Error('Visual gate report has no clipSha256 and cannot authorize a clip');
+  }
+  if (report.clipSha256 !== clipSha256) throw new Error('Visual gate report clip SHA-256 mismatch');
+}
+
+function frameList(frames: readonly VisualGateFrameReference[]): string {
+  return frames.length ? frames.map((frame) => frame.frameIndex).join(',') : 'none';
+}
+
+export function evaluateVisualGates(
+  report: VisualGateReport,
+  profileId: VisualGateThresholdProfileId,
+  humanConfirmed: HumanConfirmedVisualGates = {},
+): GateResult[] {
+  if (report.profile !== profileId) {
+    throw new Error(`Visual gate report profile mismatch: report=${report.profile}, expected=${profileId}`);
+  }
+  const thresholds = VISUAL_GATE_THRESHOLDS[profileId];
+  const { identity, anatomy, temporalStability, sharpness, masterProperties, loop } = report.metrics;
+  const identityPass = identity.detectedFaceCount > 0 &&
+    identity.minSimilarity >= thresholds.identity.minSimilarity &&
+    identity.meanSimilarity >= thresholds.identity.meanSimilarity &&
+    identity.noFace.length <= thresholds.identity.maxNoFaceFrames;
+  const implausibleHandFrames = anatomy.suspiciousFrames.filter((frame) => frame.implausibleFingerCounts.length > 0);
+  const anatomyPass = anatomy.teleportationFrames.length <= thresholds.anatomy.maxTeleportationFrames &&
+    implausibleHandFrames.length <= thresholds.anatomy.maxImplausibleHandFrames;
+  const thirdFlickerMax = Math.max(
+    temporalStability.thirdsFlickerMean.top,
+    temporalStability.thirdsFlickerMean.middle,
+    temporalStability.thirdsFlickerMean.bottom,
+  );
+  const temporalPass = temporalStability.framePairCount > 0 &&
+    temporalStability.globalFlickerMean <= thresholds.temporalStability.maxGlobalFlickerMean &&
+    thirdFlickerMax <= thresholds.temporalStability.maxThirdFlickerMean &&
+    temporalStability.exposureJitterVariance <= thresholds.temporalStability.maxExposureJitterVariance &&
+    temporalStability.localWarpGradientMean <= thresholds.temporalStability.maxLocalWarpGradientMean;
+  const master = thresholds.masterProperties;
+  const sharpnessPass = sharpness.minLaplacianVariance >= thresholds.sharpness.minLaplacianVariance;
+  const loopPass = loop !== null &&
+    loop.normalizedAbsoluteDifference <= thresholds.loop.maxNormalizedAbsoluteDifference &&
+    loop.histogramCorrelation >= thresholds.loop.minHistogramCorrelation;
+  const masterPass = masterProperties.width >= master.minWidth && masterProperties.height >= master.minHeight &&
+    masterProperties.height > masterProperties.width &&
+    Math.abs(masterProperties.fps - master.targetFps) <= master.fpsTolerance &&
+    masterProperties.durationSeconds >= master.minDurationSeconds &&
+    masterProperties.durationSeconds <= master.maxDurationSeconds &&
+    masterProperties.videoBitrateKbps >= master.minVideoBitrateKbps &&
+    masterProperties.videoBitrateKbps <= master.maxVideoBitrateKbps &&
+    masterProperties.nearBlackFrameRatio <= master.maxNearBlackFrameRatio &&
+    master.videoCodecs.some((codec) => codec === masterProperties.videoCodec) &&
+    masterProperties.hasAudio && master.audioCodecs.some((codec) => codec === masterProperties.audioCodec) &&
+    (!thresholds.loop.required || loopPass) && sharpnessPass;
+
+  return [
+    {
+      gate: 'identity',
+      pass: identityPass,
+      evidence: `min=${identity.minSimilarity.toFixed(4)}, mean=${identity.meanSimilarity.toFixed(4)}, noFace frames=${frameList(identity.noFace)}, lowSimilarity frames=${frameList(identity.lowSimilarityFrames)}`,
+    },
+    {
+      gate: 'anatomy',
+      pass: anatomyPass,
+      evidence: `teleportation frames=${frameList(anatomy.teleportationFrames)}, implausible-hand frames=${frameList(implausibleHandFrames)}, suspect frames=${frameList(anatomy.suspiciousFrames)}`,
+    },
+    {
+      gate: 'temporal-stability',
+      pass: temporalPass,
+      evidence: `flicker=${temporalStability.globalFlickerMean.toFixed(4)}, max-third=${thirdFlickerMax.toFixed(4)}, jitter=${temporalStability.exposureJitterVariance.toFixed(4)}, warp=${temporalStability.localWarpGradientMean.toFixed(4)}, pairs=${temporalStability.framePairCount}`,
+    },
+    {
+      gate: 'outfit',
+      pass: humanConfirmed.outfit === true,
+      evidence: humanConfirmed.outfit === true ? 'human-confirmed' : 'not-measured — human review required',
+    },
+    {
+      gate: 'decor-framing',
+      pass: humanConfirmed.decorFraming === true,
+      evidence: humanConfirmed.decorFraming === true ? 'human-confirmed' : 'not-measured — human review required',
+    },
+    {
+      gate: 'master-properties',
+      pass: masterPass,
+      evidence: `master=${masterProperties.width}x${masterProperties.height}@${masterProperties.fps.toFixed(3)}, duration=${masterProperties.durationSeconds.toFixed(3)}s, bitrate=${masterProperties.videoBitrateKbps.toFixed(1)}kbps, codec=${masterProperties.videoCodec}/${masterProperties.audioCodec}, black=${masterProperties.nearBlackFrameRatio.toFixed(4)}, sharpness-min=${sharpness.minLaplacianVariance.toFixed(4)} low-sharpness frames=${frameList(sharpness.lowSharpnessFrames)}, loop=${loop === null ? 'not-measured' : `diff:${loop.normalizedAbsoluteDifference.toFixed(4)},corr:${loop.histogramCorrelation.toFixed(4)}`}`,
+    },
+  ];
+}
+
+async function readRegularReport(filename: string): Promise<Buffer> {
+  const resolved = path.resolve(filename);
+  const handle = await open(resolved, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile() || info.size <= 0 || info.size > 10 * 1024 * 1024) {
+      throw new Error('Visual gate report must be a regular non-symlink JSON file no larger than 10 MiB');
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function loadAndEvaluateVisualGateReport(
+  filename: string,
+  clipSha256: string,
+  profileId: VisualGateThresholdProfileId,
+  humanConfirmed: HumanConfirmedVisualGates = {},
+): Promise<EvaluatedVisualGateReport> {
+  const bytes = await readRegularReport(filename);
+  let json: unknown;
+  try {
+    json = JSON.parse(bytes.toString('utf8')) as unknown;
+  } catch (error) {
+    throw new Error(`Visual gate report is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const report = parseVisualGateReport(json);
+  assertReportMatchesClip(report, clipSha256);
+  return {
+    report,
+    gateResults: evaluateVisualGates(report, profileId, humanConfirmed),
+    reportSha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}

--- a/src/tools/video/voice-rights-registry.ts
+++ b/src/tools/video/voice-rights-registry.ts
@@ -1,0 +1,176 @@
+/** Fail-closed commercial voice rights registry shared by CLI and Cowork. */
+
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { canonicalizeLocale } from './localized-media.js';
+
+export interface VoiceProfileBase {
+  id: string;
+  locale: string;
+  commercialUseApproved: boolean;
+  provenanceRef: string;
+}
+
+/** Runtime voice identity used by the rights registry (kept local to this lot). */
+export type ResolvedVoiceProfile =
+  | (VoiceProfileBase & {
+      provider: 'pocket';
+      voice: string;
+      language: string;
+      highQuality?: boolean;
+    })
+  | (VoiceProfileBase & {
+      provider: 'piper';
+      modelPath: string;
+    });
+
+export type VerifiedVoiceProfile = ResolvedVoiceProfile & {
+  registryRevision: string;
+  evidenceSha256: string;
+  modelSha256?: string;
+  scopes: string[];
+  reviewedAt: string;
+  reviewer: string;
+  expiresAt?: string;
+};
+
+interface RegistryFile {
+  schemaVersion: 2;
+  profiles: unknown[];
+}
+
+export async function loadVoiceRightsRegistry(
+  filename: string,
+  requiredScope = 'commercial-youtube',
+  now = new Date(),
+): Promise<Map<string, VerifiedVoiceProfile>> {
+  const registryPath = await regularSecureFile(filename, 'Voice rights registry');
+  const registryBytes = await fs.readFile(registryPath);
+  const registryRevision = createHash('sha256').update(registryBytes).digest('hex');
+  const raw = JSON.parse(registryBytes.toString('utf8')) as Partial<RegistryFile>;
+  if (raw.schemaVersion !== 2 || !Array.isArray(raw.profiles)) {
+    throw new Error('Voice rights registry must use schemaVersion 2 and contain profiles');
+  }
+  const profiles = new Map<string, VerifiedVoiceProfile>();
+  for (const candidate of raw.profiles) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      throw new Error('Voice rights registry contains an invalid profile');
+    }
+    const item = candidate as Record<string, unknown>;
+    const id = boundedText(item.id, 'voice profile id', 120);
+    if (profiles.has(id)) throw new Error(`Duplicate voice profile: ${id}`);
+    if (item.status !== 'approved' || item.revoked === true) throw new Error(`Voice profile ${id} is not approved`);
+    const scopes = Array.isArray(item.scopes)
+      ? item.scopes.filter((scope): scope is string => typeof scope === 'string' && Boolean(scope.trim()))
+      : [];
+    if (!scopes.includes(requiredScope)) throw new Error(`Voice profile ${id} lacks scope ${requiredScope}`);
+    const reviewedAt = isoDate(item.reviewedAt, `Voice profile ${id} reviewedAt`);
+    const reviewer = boundedText(item.reviewer, `Voice profile ${id} reviewer`, 120);
+    const expiresAt = item.expiresAt === undefined ? undefined : isoDate(item.expiresAt, `Voice profile ${id} expiresAt`);
+    if (expiresAt && new Date(expiresAt).getTime() <= now.getTime()) throw new Error(`Voice profile ${id} approval has expired`);
+    const provenance = item.provenance;
+    if (!provenance || typeof provenance !== 'object' || Array.isArray(provenance)) {
+      throw new Error(`Voice profile ${id} lacks provenance evidence`);
+    }
+    const evidence = provenance as Record<string, unknown>;
+    const provenanceRef = boundedText(evidence.ref, `Voice profile ${id} provenance ref`, 500);
+    const evidencePath = boundedText(evidence.evidencePath, `Voice profile ${id} evidence path`, 2_000);
+    const evidenceSha256 = shaText(evidence.evidenceSha256, `Voice profile ${id} evidence SHA-256`);
+    const canonicalEvidence = await regularSecureFile(evidencePath, `Voice profile ${id} evidence`);
+    if (await sha256File(canonicalEvidence) !== evidenceSha256) throw new Error(`Voice profile ${id} evidence digest mismatch`);
+    const locale = canonicalizeLocale(boundedText(item.locale, `Voice profile ${id} locale`, 40));
+    const provider = item.provider;
+    let profile: VerifiedVoiceProfile;
+    if (provider === 'pocket') {
+      profile = {
+        id,
+        locale,
+        provider,
+        voice: boundedText(item.voice, `Voice profile ${id} voice`, 120),
+        language: boundedText(item.language, `Voice profile ${id} language`, 80),
+        ...(typeof item.highQuality === 'boolean' ? { highQuality: item.highQuality } : {}),
+        commercialUseApproved: true,
+        provenanceRef,
+        registryRevision,
+        evidenceSha256,
+        scopes,
+        reviewedAt,
+        reviewer,
+        ...(expiresAt ? { expiresAt } : {}),
+      };
+    } else if (provider === 'piper') {
+      const modelPath = boundedText(item.modelPath, `Voice profile ${id} model path`, 2_000);
+      const modelSha256 = shaText(item.modelSha256, `Voice profile ${id} model SHA-256`);
+      const canonicalModel = await regularSecureFile(modelPath, `Voice profile ${id} Piper model`);
+      if (await sha256File(canonicalModel) !== modelSha256) throw new Error(`Voice profile ${id} model digest mismatch`);
+      profile = {
+        id,
+        locale,
+        provider,
+        modelPath: canonicalModel,
+        modelSha256,
+        commercialUseApproved: true,
+        provenanceRef,
+        registryRevision,
+        evidenceSha256,
+        scopes,
+        reviewedAt,
+        reviewer,
+        ...(expiresAt ? { expiresAt } : {}),
+      };
+    } else {
+      throw new Error(`Voice profile ${id} uses an unsupported provider`);
+    }
+    profiles.set(id, profile);
+  }
+  return profiles;
+}
+
+export function voiceProfileRevision(profile: ResolvedVoiceProfile): string {
+  const verified = profile as ResolvedVoiceProfile & Partial<VerifiedVoiceProfile>;
+  const provider = profile.provider === 'pocket'
+    ? { provider: profile.provider, voice: profile.voice, language: profile.language, highQuality: profile.highQuality ?? false }
+    : { provider: profile.provider, modelPath: profile.modelPath, modelSha256: verified.modelSha256 };
+  return createHash('sha256').update(JSON.stringify({
+    id: profile.id,
+    locale: canonicalizeLocale(profile.locale),
+    commercialUseApproved: profile.commercialUseApproved,
+    provenanceRef: profile.provenanceRef,
+    registryRevision: verified.registryRevision,
+    evidenceSha256: verified.evidenceSha256,
+    ...provider,
+  })).digest('hex');
+}
+
+async function regularSecureFile(filename: string, label: string): Promise<string> {
+  if (!path.isAbsolute(filename) || filename.includes('\0')) throw new Error(`${label} path must be absolute`);
+  const info = await fs.lstat(filename);
+  if (info.isSymbolicLink() || !info.isFile()) throw new Error(`${label} must be a regular non-symlink file`);
+  if (process.platform !== 'win32' && (info.mode & 0o077) !== 0) throw new Error(`${label} permissions must not grant group or other access`);
+  return fs.realpath(filename);
+}
+
+async function sha256File(filename: string): Promise<string> {
+  return createHash('sha256').update(await fs.readFile(filename)).digest('hex');
+}
+
+function boundedText(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > maximum ||
+      [...value].some((character) => character.charCodeAt(0) <= 31 || character.charCodeAt(0) === 127)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value.trim();
+}
+
+function shaText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !/^[a-f0-9]{64}$/u.test(value)) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function isoDate(value: unknown, label: string): string {
+  const text = boundedText(value, label, 40);
+  if (Number.isNaN(Date.parse(text))) throw new Error(`${label} is invalid`);
+  return text;
+}

--- a/src/tools/video/youtube-master-quality.ts
+++ b/src/tools/video/youtube-master-quality.ts
@@ -1,0 +1,540 @@
+/** Technical, human-review and private-bundle gates for YouTube masters. */
+
+import { execFile as realExecFile } from 'child_process';
+import { createHash } from 'crypto';
+import { constants as fsConstants } from 'fs';
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  open,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from 'fs/promises';
+import path from 'path';
+import { promisify } from 'util';
+
+import { canonicalSha256 } from './google-flow-handoff.js';
+
+const execFile = promisify(realExecFile);
+const SHA256 = /^[a-f0-9]{64}$/u;
+const SAFE_FILE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/u;
+
+export const YOUTUBE_MASTER_PROFILES = {
+  'legacy-localized-v1': {
+    version: 1,
+    minWidth: 720,
+    minHeight: 1280,
+    minDuration: 6,
+    maxDuration: 15,
+    maxBlackRatio: 0.15,
+    sourceCount: 3,
+    requireNativeSources: false,
+  },
+  'native-fashion-v1': {
+    version: 2,
+    minWidth: 1080,
+    minHeight: 1920,
+    minVideoBitrateKbps: 12_000,
+    maxVideoBitrateKbps: 20_000,
+    minDuration: 11,
+    maxDuration: 13,
+    maxBlackRatio: 0.05,
+    sourceCount: 1,
+    requireNativeSources: true,
+  },
+} as const;
+
+export type YouTubeMasterProfileId = keyof typeof YOUTUBE_MASTER_PROFILES;
+
+export interface YouTubeMasterProfileRef {
+  id: YouTubeMasterProfileId;
+  version: 1 | 2;
+}
+
+export interface YouTubeSourceClipReceipt {
+  file: string;
+  sha256: string;
+  width: number;
+  height: number;
+  fps: number;
+  durationMs: number;
+  generationMode: 'legacy' | 'native';
+  upscaled: boolean;
+}
+
+export interface YouTubeMasterProbe {
+  duration: number;
+  width: number;
+  height: number;
+  fps: number;
+  videoCodec: string;
+  audioCodec: string;
+  hasAudio: boolean;
+  videoBitrateKbps?: number;
+}
+
+export interface YouTubeMasterSignalAnalysis {
+  meanVolumeDb: number | null;
+  maxVolumeDb: number | null;
+  blackSeconds: number;
+}
+
+export interface YouTubeTechnicalReport {
+  schemaVersion: 4;
+  status: 'technical-approved';
+  videoFile: string;
+  sidecarFile: string;
+  captionFile: string;
+  videoSha256: string;
+  sidecarSha256: string;
+  captionSha256: string;
+  qualityProfile: YouTubeMasterProfileRef;
+  sourceClips: YouTubeSourceClipReceipt[];
+  checkedAt: string;
+  probe: YouTubeMasterProbe;
+  signal: YouTubeMasterSignalAnalysis;
+  autoPublish: false;
+}
+
+export interface YouTubeHumanReviewChecks {
+  voice: boolean;
+  lipSync: boolean;
+  identity: boolean;
+  anatomy: boolean;
+  captions: boolean;
+  disclosure: boolean;
+  editorial: boolean;
+}
+
+export interface YouTubeHumanReviewReceipt {
+  schemaVersion: 1;
+  status: 'ready-for-private-upload';
+  videoSha256: string;
+  sidecarSha256: string;
+  captionSha256: string;
+  technicalReportSha256: string;
+  visualGateReportSha256?: string;
+  reviewer: string;
+  reason: string;
+  checks: YouTubeHumanReviewChecks;
+  reviewedAt: string;
+  visibility: 'private';
+  autoPublish: false;
+}
+
+export interface YouTubeChangesRequestedReceipt {
+  schemaVersion: 1;
+  status: 'changes-requested';
+  videoSha256: string;
+  sidecarSha256: string;
+  captionSha256: string;
+  technicalReportSha256: string;
+  visualGateReportSha256?: string;
+  reviewer: string;
+  reason: string;
+  checks: YouTubeHumanReviewChecks;
+  reviewedAt: string;
+  visibility: 'blocked';
+  autoPublish: false;
+}
+
+export interface YouTubePrivateBundleManifest {
+  schemaVersion: 1;
+  status: 'ready-for-private-upload';
+  visibility: 'private';
+  autoPublish: false;
+  videoSha256: string;
+  technicalReportSha256: string;
+  humanReviewSha256: string;
+  createdAt: string;
+  files: Array<{ role: 'video' | 'captions' | 'youtube-sidecar' | 'technical-report' | 'human-review'; file: string; sha256: string }>;
+  bundleSha256: string;
+}
+
+export async function validateYouTubeMasterBundle(input: {
+  videoPath: string;
+  sidecarPath?: string;
+  probe?: (filename: string) => Promise<YouTubeMasterProbe>;
+  analyze?: (filename: string) => Promise<YouTubeMasterSignalAnalysis>;
+  now?: () => Date;
+}): Promise<YouTubeTechnicalReport> {
+  const videoPath = await regularFile(input.videoPath, 'YouTube master');
+  const videoDirectory = path.dirname(videoPath);
+  const sidecarPath = await regularFile(input.sidecarPath ?? `${videoPath}.youtube.json`, 'YouTube sidecar');
+  if (path.dirname(sidecarPath) !== videoDirectory) throw new Error('YouTube sidecar must be beside its master');
+  const sidecar = JSON.parse((await readRegularNoFollow(sidecarPath, 'YouTube sidecar')).toString('utf8')) as Record<string, unknown>;
+  const video = sidecar.video as Record<string, unknown> | undefined;
+  const captions = sidecar.captionTracks;
+  const youtube = sidecar.youtube as Record<string, unknown> | undefined;
+  const status = youtube?.status as Record<string, unknown> | undefined;
+  const snippet = youtube?.snippet as Record<string, unknown> | undefined;
+  const rights = sidecar.narrationRights as Record<string, unknown> | undefined;
+  const audioRights = sidecar.audioRights as Record<string, unknown> | undefined;
+  const sourceClips = sidecar.sourceClips;
+  const qualityProfile = sidecar.qualityProfile as Record<string, unknown> | undefined;
+  const profile = qualityProfile && typeof qualityProfile.id === 'string'
+    ? YOUTUBE_MASTER_PROFILES[qualityProfile.id as YouTubeMasterProfileId]
+    : undefined;
+  const validatedRights = rights ?? audioRights;
+  if (
+    sidecar.schemaVersion !== 3 || sidecar.autoPublish !== false || sidecar.humanReviewRequired !== true ||
+    sidecar.containsSyntheticMedia !== true || !video || video.file !== path.basename(videoPath) ||
+    !Array.isArray(captions) || captions.length !== 1 || status?.privacyStatus !== 'private' ||
+    status.selfDeclaredMadeForKids !== false || typeof snippet?.title !== 'string' || snippet.title.trim().length < 8 ||
+    typeof snippet.description !== 'string' || snippet.description.trim().length < 30 ||
+    validatedRights?.commercialUseApproved !== true || typeof validatedRights.provenanceRef !== 'string' ||
+    !validatedRights.provenanceRef.trim() || typeof validatedRights.profileRevision !== 'string' ||
+    !SHA256.test(validatedRights.profileRevision) || !profile || qualityProfile?.version !== profile.version ||
+    !Array.isArray(sourceClips) || sourceClips.length !== profile.sourceCount
+  ) throw new Error('YouTube sidecar contract, rights or private-publication gate is incomplete or unsafe');
+  const validatedSourceClips = sourceClips.map((item, index) => {
+    const clip = item as Record<string, unknown>;
+    if (
+      typeof clip.file !== 'string' || !SAFE_FILE.test(clip.file) ||
+      typeof clip.sha256 !== 'string' || !SHA256.test(clip.sha256) ||
+      !Number.isInteger(clip.width) || Number(clip.width) <= 0 ||
+      !Number.isInteger(clip.height) || Number(clip.height) <= Number(clip.width) ||
+      typeof clip.fps !== 'number' || !Number.isFinite(clip.fps) || clip.fps <= 0 ||
+      !Number.isInteger(clip.durationMs) || Number(clip.durationMs) <= 0 ||
+      !['legacy', 'native'].includes(String(clip.generationMode)) || typeof clip.upscaled !== 'boolean'
+    ) {
+      throw new Error(`YouTube source clip ${index + 1} is incomplete`);
+    }
+    return {
+      file: clip.file,
+      sha256: clip.sha256,
+      width: Number(clip.width),
+      height: Number(clip.height),
+      fps: Number(clip.fps),
+      durationMs: Number(clip.durationMs),
+      generationMode: clip.generationMode as 'legacy' | 'native',
+      upscaled: clip.upscaled,
+    };
+  });
+  if (new Set(validatedSourceClips.map((clip) => clip.file)).size !== profile.sourceCount) {
+    throw new Error('YouTube source clips must be distinct');
+  }
+
+  const videoSha256 = await sha256NoFollow(videoPath, 'YouTube master');
+  if (video.sha256 !== videoSha256) throw new Error('YouTube master digest does not match its sidecar');
+  const caption = captions[0] as Record<string, unknown>;
+  if (typeof caption.file !== 'string' || !SAFE_FILE.test(caption.file)) throw new Error('Caption path is invalid');
+  const captionPath = await regularFile(path.join(videoDirectory, caption.file), 'WebVTT caption');
+  if (path.dirname(captionPath) !== videoDirectory) throw new Error('WebVTT caption must be beside its master');
+  const captionSha256 = await sha256NoFollow(captionPath, 'WebVTT caption');
+  if (caption.sha256 !== captionSha256) throw new Error('Caption digest does not match its sidecar');
+  validateWebVtt((await readRegularNoFollow(captionPath, 'WebVTT caption')).toString('utf8'), Number(video.durationMs));
+
+  const [probe, signal] = await Promise.all([
+    (input.probe ?? probeMaster)(videoPath),
+    (input.analyze ?? analyzeMasterSignals)(videoPath),
+  ]);
+  const blackRatio = probe.duration > 0 ? signal.blackSeconds / probe.duration : 1;
+  const isPortrait = probe.height > probe.width;
+  const nativeSourcesPass = !profile.requireNativeSources || validatedSourceClips.every((clip) =>
+    clip.generationMode === 'native' && clip.upscaled === false &&
+    clip.width >= probe.width && clip.height >= probe.height &&
+    Math.abs(clip.fps - probe.fps) <= 0.1,
+  );
+  const bitratePass = !('minVideoBitrateKbps' in profile) || (
+    typeof probe.videoBitrateKbps === 'number' && Number.isFinite(probe.videoBitrateKbps) &&
+    probe.videoBitrateKbps >= profile.minVideoBitrateKbps &&
+    probe.videoBitrateKbps <= profile.maxVideoBitrateKbps
+  );
+  if (
+    probe.width < profile.minWidth || probe.height < profile.minHeight || !isPortrait ||
+    Math.abs(probe.fps - 30) > 0.05 || probe.duration < profile.minDuration ||
+    probe.duration > profile.maxDuration || !probe.hasAudio || !nativeSourcesPass || !bitratePass ||
+    !['h264', 'hevc'].includes(probe.videoCodec) || !['aac', 'opus'].includes(probe.audioCodec) ||
+    Math.abs(probe.duration * 1_000 - Number(video.durationMs)) > 250 ||
+    signal.meanVolumeDb === null || signal.meanVolumeDb <= -60 || signal.maxVolumeDb === null ||
+    signal.maxVolumeDb > 0 || !Number.isFinite(signal.blackSeconds) || signal.blackSeconds < 0 ||
+    blackRatio > profile.maxBlackRatio
+  ) throw new Error('YouTube master failed profile, native-source, bitrate, duration, FPS, codec, audio or black-frame checks');
+  return {
+    schemaVersion: 4,
+    status: 'technical-approved',
+    videoFile: path.basename(videoPath),
+    sidecarFile: path.basename(sidecarPath),
+    captionFile: path.basename(captionPath),
+    videoSha256,
+    sidecarSha256: await sha256NoFollow(sidecarPath, 'YouTube sidecar'),
+    captionSha256,
+    qualityProfile: {
+      id: qualityProfile!.id as YouTubeMasterProfileId,
+      version: profile.version,
+    },
+    sourceClips: validatedSourceClips,
+    checkedAt: (input.now ?? (() => new Date()))().toISOString(),
+    probe,
+    signal,
+    autoPublish: false,
+  };
+}
+
+export async function reviewYouTubeMaster(input: {
+  report: YouTubeTechnicalReport;
+  expectedVideoSha256: string;
+  reviewer: string;
+  reason: string;
+  checks: YouTubeHumanReviewChecks;
+  now?: () => Date;
+}): Promise<YouTubeHumanReviewReceipt> {
+  if (
+    input.report.schemaVersion !== 4 || input.report.status !== 'technical-approved' ||
+    !SHA256.test(input.expectedVideoSha256) || input.report.videoSha256 !== input.expectedVideoSha256
+  ) throw new Error('Human review must target the current technically approved master digest');
+  if (Object.values(input.checks).some((passed) => passed !== true)) throw new Error('Every human review check must pass');
+  if (input.reviewer.trim().length < 2 || input.reason.trim().length < 3) throw new Error('Reviewer and reason are required');
+  return {
+    schemaVersion: 1,
+    status: 'ready-for-private-upload',
+    videoSha256: input.report.videoSha256,
+    sidecarSha256: input.report.sidecarSha256,
+    captionSha256: input.report.captionSha256,
+    technicalReportSha256: canonicalSha256(input.report),
+    reviewer: input.reviewer.trim(),
+    reason: input.reason.trim(),
+    checks: input.checks,
+    reviewedAt: (input.now ?? (() => new Date()))().toISOString(),
+    visibility: 'private',
+    autoPublish: false,
+  };
+}
+
+/** Record a digest-bound negative visual review. This receipt can never authorize an upload bundle. */
+export async function requestYouTubeMasterChanges(input: {
+  report: YouTubeTechnicalReport;
+  expectedVideoSha256: string;
+  reviewer: string;
+  reason: string;
+  checks: YouTubeHumanReviewChecks;
+  now?: () => Date;
+}): Promise<YouTubeChangesRequestedReceipt> {
+  if (
+    input.report.schemaVersion !== 4 || input.report.status !== 'technical-approved' ||
+    !SHA256.test(input.expectedVideoSha256) || input.report.videoSha256 !== input.expectedVideoSha256
+  ) throw new Error('Change request must target the current technically approved master digest');
+  if (Object.values(input.checks).some((passed) => typeof passed !== 'boolean')) {
+    throw new Error('Every human review check must be recorded as true or false');
+  }
+  if (Object.values(input.checks).every((passed) => passed)) {
+    throw new Error('A change request must identify at least one failed human review check');
+  }
+  if (input.reviewer.trim().length < 2 || input.reason.trim().length < 3) {
+    throw new Error('Reviewer and reason are required');
+  }
+  return {
+    schemaVersion: 1,
+    status: 'changes-requested',
+    videoSha256: input.report.videoSha256,
+    sidecarSha256: input.report.sidecarSha256,
+    captionSha256: input.report.captionSha256,
+    technicalReportSha256: canonicalSha256(input.report),
+    reviewer: input.reviewer.trim(),
+    reason: input.reason.trim(),
+    checks: input.checks,
+    reviewedAt: (input.now ?? (() => new Date()))().toISOString(),
+    visibility: 'blocked',
+    autoPublish: false,
+  };
+}
+
+/** Create a local immutable handoff. This function never calls YouTube or changes visibility. */
+export async function createPrivateYouTubeBundle(input: {
+  videoPath: string;
+  report: YouTubeTechnicalReport;
+  review: YouTubeHumanReviewReceipt;
+  outputRoot: string;
+  probe?: (filename: string) => Promise<YouTubeMasterProbe>;
+  analyze?: (filename: string) => Promise<YouTubeMasterSignalAnalysis>;
+  now?: () => Date;
+}): Promise<{ directory: string; manifest: YouTubePrivateBundleManifest }> {
+  if (
+    input.report.schemaVersion !== 4 || input.report.status !== 'technical-approved' ||
+    input.review.schemaVersion !== 1 || input.review.status !== 'ready-for-private-upload' ||
+    input.review.visibility !== 'private' || input.review.autoPublish !== false ||
+    input.review.videoSha256 !== input.report.videoSha256 || input.review.sidecarSha256 !== input.report.sidecarSha256 ||
+    input.review.captionSha256 !== input.report.captionSha256 ||
+    input.review.technicalReportSha256 !== canonicalSha256(input.report) ||
+    Object.values(input.review.checks).some((passed) => passed !== true) ||
+    input.review.reviewer.trim().length < 2 || input.review.reason.trim().length < 3
+  ) throw new Error('Private bundle requires matching technical and human-review receipts');
+  const videoPath = await regularFile(input.videoPath, 'YouTube master');
+  const directory = path.dirname(videoPath);
+  const sidecarPath = await regularFile(path.join(directory, input.report.sidecarFile), 'YouTube sidecar');
+  const captionPath = await regularFile(path.join(directory, input.report.captionFile), 'WebVTT caption');
+  const freshReport = await validateYouTubeMasterBundle({
+    videoPath,
+    sidecarPath,
+    ...(input.probe ? { probe: input.probe } : {}),
+    ...(input.analyze ? { analyze: input.analyze } : {}),
+  });
+  const current = await Promise.all([
+    sha256NoFollow(videoPath, 'YouTube master'),
+    sha256NoFollow(sidecarPath, 'YouTube sidecar'),
+    sha256NoFollow(captionPath, 'WebVTT caption'),
+  ]);
+  if (
+    current[0] !== input.report.videoSha256 || current[1] !== input.report.sidecarSha256 ||
+    current[2] !== input.report.captionSha256 || freshReport.videoSha256 !== input.report.videoSha256 ||
+    freshReport.sidecarSha256 !== input.report.sidecarSha256 || freshReport.captionSha256 !== input.report.captionSha256
+  ) throw new Error('A reviewed YouTube bundle file changed after approval');
+
+  const outputRoot = await confinedOutputRoot(input.outputRoot);
+  const bundleName = `private-${input.report.videoSha256.slice(0, 20)}`;
+  const destination = path.join(outputRoot, bundleName);
+  const temporary = path.join(outputRoot, `.${bundleName}-${process.pid}-${Date.now()}.tmp`);
+  await mkdir(temporary, { mode: 0o700 });
+  try {
+    const fileInputs = [
+      { role: 'video' as const, source: videoPath, file: input.report.videoFile, sha256: input.report.videoSha256 },
+      { role: 'captions' as const, source: captionPath, file: input.report.captionFile, sha256: input.report.captionSha256 },
+      { role: 'youtube-sidecar' as const, source: sidecarPath, file: input.report.sidecarFile, sha256: input.report.sidecarSha256 },
+    ];
+    for (const item of fileInputs) {
+      await copyFile(item.source, path.join(temporary, item.file), fsConstants.COPYFILE_EXCL);
+      if (await sha256NoFollow(path.join(temporary, item.file), `Bundled ${item.role}`) !== item.sha256) {
+        throw new Error(`Bundled ${item.role} changed while it was copied`);
+      }
+    }
+    const technicalBytes = Buffer.from(`${JSON.stringify(input.report, null, 2)}\n`);
+    const reviewBytes = Buffer.from(`${JSON.stringify(input.review, null, 2)}\n`);
+    await Promise.all([
+      writeFile(path.join(temporary, 'technical-report.json'), technicalBytes, { flag: 'wx', mode: 0o600 }),
+      writeFile(path.join(temporary, 'human-review.json'), reviewBytes, { flag: 'wx', mode: 0o600 }),
+    ]);
+    const unsigned = {
+      schemaVersion: 1 as const,
+      status: 'ready-for-private-upload' as const,
+      visibility: 'private' as const,
+      autoPublish: false as const,
+      videoSha256: input.report.videoSha256,
+      technicalReportSha256: input.review.technicalReportSha256,
+      humanReviewSha256: createHash('sha256').update(reviewBytes).digest('hex'),
+      createdAt: (input.now ?? (() => new Date()))().toISOString(),
+      files: [
+        ...fileInputs.map(({ role, file, sha256 }) => ({ role, file, sha256 })),
+        {
+          role: 'technical-report' as const,
+          file: 'technical-report.json',
+          sha256: createHash('sha256').update(technicalBytes).digest('hex'),
+        },
+        {
+          role: 'human-review' as const,
+          file: 'human-review.json',
+          sha256: createHash('sha256').update(reviewBytes).digest('hex'),
+        },
+      ],
+    };
+    const manifest: YouTubePrivateBundleManifest = { ...unsigned, bundleSha256: canonicalSha256(unsigned) };
+    await writeFile(path.join(temporary, 'bundle.json'), `${JSON.stringify(manifest, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+    await rename(temporary, destination);
+    return { directory: destination, manifest };
+  } catch (error) {
+    await rm(temporary, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function probeMaster(filename: string): Promise<YouTubeMasterProbe> {
+  const { stdout } = await execFile('ffprobe', [
+    '-v', 'error', '-show_entries',
+    'format=duration,size:stream=codec_type,codec_name,width,height,r_frame_rate,bit_rate',
+    '-of', 'json', filename,
+  ], { timeout: 30_000, maxBuffer: 1024 * 1024 });
+  const parsed = JSON.parse(stdout) as {
+    format?: { duration?: string; size?: string };
+    streams?: Array<Record<string, unknown>>;
+  };
+  const video = parsed.streams?.find((stream) => stream.codec_type === 'video');
+  const audio = parsed.streams?.find((stream) => stream.codec_type === 'audio');
+  const [rawNumerator = 0, rawDenominator = 1] = String(video?.r_frame_rate ?? '0/1').split('/').map(Number);
+  const duration = Number(parsed.format?.duration);
+  const streamBitrate = Number(video?.bit_rate);
+  const fallbackBitrate = Number(parsed.format?.size) * 8 / duration;
+  const videoBitrateKbps = Number.isFinite(streamBitrate) && streamBitrate > 0
+    ? streamBitrate / 1_000
+    : fallbackBitrate / 1_000;
+  return {
+    duration,
+    width: Number(video?.width),
+    height: Number(video?.height),
+    fps: rawDenominator ? rawNumerator / rawDenominator : 0,
+    videoCodec: String(video?.codec_name ?? ''),
+    audioCodec: String(audio?.codec_name ?? ''),
+    hasAudio: Boolean(audio),
+    videoBitrateKbps: Math.round(videoBitrateKbps * 1_000) / 1_000,
+  };
+}
+
+async function analyzeMasterSignals(filename: string): Promise<YouTubeMasterSignalAnalysis> {
+  const { stderr } = await execFile('ffmpeg', [
+    '-hide_banner', '-nostats', '-i', filename,
+    '-vf', 'blackdetect=d=0.1:pic_th=0.98', '-af', 'volumedetect', '-f', 'null', '-',
+  ], { timeout: 5 * 60_000, maxBuffer: 4 * 1024 * 1024 });
+  const mean = stderr.match(/mean_volume:\s*(-?(?:\d+(?:\.\d+)?|inf))\s*dB/iu)?.[1];
+  const max = stderr.match(/max_volume:\s*(-?(?:\d+(?:\.\d+)?|inf))\s*dB/iu)?.[1];
+  const blackSeconds = [...stderr.matchAll(/black_duration:([0-9]+(?:\.[0-9]+)?)/gu)]
+    .reduce((total, match) => total + Number(match[1]), 0);
+  return {
+    meanVolumeDb: mean && mean.toLowerCase() !== '-inf' ? Number(mean) : null,
+    maxVolumeDb: max && max.toLowerCase() !== '-inf' ? Number(max) : null,
+    blackSeconds,
+  };
+}
+
+function validateWebVtt(value: string, durationMs: number): void {
+  if (!value.startsWith('WEBVTT') || !Number.isFinite(durationMs) || durationMs <= 0) {
+    throw new Error('WebVTT header or duration is invalid');
+  }
+  const cuePattern = /(\d{2}:\d{2}:\d{2}\.\d{3}) --> (\d{2}:\d{2}:\d{2}\.\d{3})/gu;
+  let count = 0;
+  let previousEnd = 0;
+  for (const match of value.matchAll(cuePattern)) {
+    const start = timestampMs(match[1]!);
+    const end = timestampMs(match[2]!);
+    if (start < previousEnd || end <= start || end > durationMs) throw new Error('WebVTT cues are unordered or outside the master');
+    previousEnd = end;
+    count += 1;
+  }
+  if (!count) throw new Error('WebVTT contains no valid cue');
+}
+
+function timestampMs(value: string): number {
+  const [hours, minutes, seconds] = value.split(':');
+  return Number(hours) * 3_600_000 + Number(minutes) * 60_000 + Number(seconds) * 1_000;
+}
+
+async function regularFile(filename: string, label: string): Promise<string> {
+  if (!path.isAbsolute(filename) || filename.includes('\0')) throw new Error(`${label} path must be absolute`);
+  const info = await lstat(filename);
+  if (info.isSymbolicLink() || !info.isFile()) throw new Error(`${label} must be a regular non-symlink file`);
+  return realpath(filename);
+}
+
+async function readRegularNoFollow(filename: string, label: string): Promise<Buffer> {
+  const handle = await open(filename, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile() || info.size <= 0) throw new Error(`${label} must be a non-empty regular file`);
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function sha256NoFollow(filename: string, label: string): Promise<string> {
+  return createHash('sha256').update(await readRegularNoFollow(filename, label)).digest('hex');
+}
+
+async function confinedOutputRoot(value: string): Promise<string> {
+  if (!path.isAbsolute(value) || value.includes('\0')) throw new Error('Private bundle output root must be absolute');
+  await mkdir(value, { recursive: true, mode: 0o700 });
+  const info = await lstat(value);
+  if (info.isSymbolicLink() || !info.isDirectory()) throw new Error('Private bundle output root must be a regular directory');
+  return realpath(value);
+}

--- a/tests/tools/video/approved-media-source.test.ts
+++ b/tests/tools/video/approved-media-source.test.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadApprovedImageSource } from '../../../src/tools/video/approved-media-source.js';
+
+const roots: string[] = [];
+const png = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('fixture'),
+]);
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(): Promise<{ root: string; file: string; sha256: string }> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), 'approved-media-'));
+  roots.push(root);
+  const file = path.join(root, 'portrait.png');
+  await fs.writeFile(file, png);
+  return { root, file, sha256: createHash('sha256').update(png).digest('hex') };
+}
+
+describe('loadApprovedImageSource', () => {
+  it('returns digest-pinned bytes and detects MIME from the signature', async () => {
+    const value = await fixture();
+    await expect(loadApprovedImageSource(value.file, value.root, value.sha256)).resolves.toMatchObject({
+      contentType: 'image/png',
+      sha256: value.sha256,
+      realPath: value.file,
+    });
+  });
+
+  it('rejects digest mismatches and fake image extensions', async () => {
+    const value = await fixture();
+    await expect(loadApprovedImageSource(value.file, value.root, 'a'.repeat(64))).rejects.toThrow('digest');
+    const fake = path.join(value.root, 'fake.png');
+    await fs.writeFile(fake, 'not an image');
+    const digest = createHash('sha256').update('not an image').digest('hex');
+    await expect(loadApprovedImageSource(fake, value.root, digest)).rejects.toThrow('signature');
+  });
+
+  it('rejects symlinks and files outside the approved root', async () => {
+    const value = await fixture();
+    const outsideRoot = await fs.mkdtemp(path.join(tmpdir(), 'outside-media-'));
+    roots.push(outsideRoot);
+    const outside = path.join(outsideRoot, 'outside.png');
+    await fs.writeFile(outside, png);
+    const link = path.join(value.root, 'linked.png');
+    await fs.symlink(outside, link);
+    await expect(loadApprovedImageSource(link, value.root, value.sha256)).rejects.toThrow('non-symlink');
+    await expect(loadApprovedImageSource(outside, value.root, value.sha256)).rejects.toThrow('escapes');
+  });
+});

--- a/tests/tools/video/approved-media-source.test.ts
+++ b/tests/tools/video/approved-media-source.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
 });
 
 async function fixture(): Promise<{ root: string; file: string; sha256: string }> {
-  const root = await fs.mkdtemp(path.join(tmpdir(), 'approved-media-'));
+  const root = await fs.realpath(await fs.mkdtemp(path.join(tmpdir(), 'approved-media-')));
   roots.push(root);
   const file = path.join(root, 'portrait.png');
   await fs.writeFile(file, png);
@@ -45,7 +45,7 @@ describe('loadApprovedImageSource', () => {
 
   it('rejects symlinks and files outside the approved root', async () => {
     const value = await fixture();
-    const outsideRoot = await fs.mkdtemp(path.join(tmpdir(), 'outside-media-'));
+    const outsideRoot = await fs.realpath(await fs.mkdtemp(path.join(tmpdir(), 'outside-media-')));
     roots.push(outsideRoot);
     const outside = path.join(outsideRoot, 'outside.png');
     await fs.writeFile(outside, png);

--- a/tests/tools/video/book-manuscript-source.test.ts
+++ b/tests/tools/video/book-manuscript-source.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  extractCandidateExcerpts,
+  loadBookManuscript,
+} from '../../../src/tools/video/book-manuscript-source.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryBook(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'book-manuscript-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('loadBookManuscript', () => {
+  it('loads Markdown chapters in natural order and prefers a frontmatter title', async () => {
+    const directory = await temporaryBook();
+    await fs.writeFile(path.join(directory, 'chapter-10.md'), '# La fin\n\nLa pluie frappe la vitre.\n');
+    await fs.writeFile(path.join(directory, 'chapter-2.md'), '# Le seuil\n\nMara ouvre la porte.\n');
+    await fs.writeFile(
+      path.join(directory, 'chapter-1.md'),
+      '---\ntitle: "Les Veilleurs"\n---\n# Commencement\n\nLa maison demeure silencieuse.\n',
+    );
+    await fs.writeFile(path.join(directory, 'cover.webp'), 'cover');
+
+    const manuscript = await loadBookManuscript(directory);
+
+    expect(manuscript.title).toBe('Les Veilleurs');
+    expect(manuscript.chapters.map((chapter) => chapter.file)).toEqual([
+      'chapter-1.md',
+      'chapter-2.md',
+      'chapter-10.md',
+    ]);
+    expect(manuscript.chapters.map((chapter) => chapter.heading)).toEqual([
+      'Commencement',
+      'Le seuil',
+      'La fin',
+    ]);
+    expect(manuscript.coverPath).toBe(path.join(directory, 'cover.webp'));
+  });
+
+  it('rejects an empty directory and one without Markdown', async () => {
+    const empty = await temporaryBook();
+    await expect(loadBookManuscript(empty)).rejects.toThrow(/empty/i);
+
+    const withoutMarkdown = await temporaryBook();
+    await fs.writeFile(path.join(withoutMarkdown, 'notes.txt'), 'notes');
+    await expect(loadBookManuscript(withoutMarkdown)).rejects.toThrow(/no Markdown/i);
+  });
+
+  it('fails closed before reading a chapter beyond the configured limit', async () => {
+    const directory = await temporaryBook();
+    await fs.writeFile(path.join(directory, '01.md'), '# Livre\n\n' + 'x'.repeat(128));
+
+    await expect(loadBookManuscript(directory, { maxBytesPerFile: 32 })).rejects.toThrow(
+      /32-byte limit/i,
+    );
+  });
+});
+
+describe('extractCandidateExcerpts', () => {
+  it('selects visual/tension passages with exact chapter and line provenance', async () => {
+    const directory = await temporaryBook();
+    await fs.writeFile(
+      path.join(directory, '01-arrivee.md'),
+      '# Arrivée\n\nLe jardin semblait paisible.\n\n— Ferme la porte ! crie Mara. Une ombre court derrière la fenêtre. Le couteau tombe sur le sol.\n',
+    );
+    await fs.writeFile(
+      path.join(directory, '02-nuit.md'),
+      '# Nuit\n\nLa pluie frappe la maison. Elias découvre une lettre couverte de sang.\n',
+    );
+    const manuscript = await loadBookManuscript(directory);
+
+    const excerpts = extractCandidateExcerpts(manuscript, { limit: 3 });
+    const dialogue = excerpts.find((excerpt) => excerpt.text.startsWith('— Ferme'));
+
+    expect(dialogue).toMatchObject({
+      chapterIndex: 0,
+      lineStart: 5,
+      lineEnd: 5,
+      manuscriptSource: {
+        file: '01-arrivee.md',
+        locator: 'chapter:1;lines:5-5',
+      },
+    });
+    expect(dialogue?.text).toContain('Une ombre court derrière la fenêtre.');
+  });
+
+  it('is deterministic for the same manuscript and options', async () => {
+    const directory = await temporaryBook();
+    await fs.writeFile(
+      path.join(directory, 'book.md'),
+      '# La chambre\n\nNora ouvre la fenêtre. Le feu gagne la maison.\n\n— Cours ! hurle Elias dans la nuit.\n',
+    );
+    const manuscript = await loadBookManuscript(directory);
+
+    expect(extractCandidateExcerpts(manuscript)).toEqual(extractCandidateExcerpts(manuscript));
+  });
+});

--- a/tests/tools/video/book-manuscript-source.test.ts
+++ b/tests/tools/video/book-manuscript-source.test.ts
@@ -12,7 +12,7 @@ import {
 const temporaryDirectories: string[] = [];
 
 async function temporaryBook(): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'book-manuscript-'));
+  const directory = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'book-manuscript-')));
   temporaryDirectories.push(directory);
   return directory;
 }

--- a/tests/tools/video/character-in-location.test.ts
+++ b/tests/tools/video/character-in-location.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCharacterInLocationWorkflow,
+  buildFaceProtectedCharacterInLocationWorkflow,
+  buildInsertionPrompt,
+  INSERT_QWEN_TEMPLATE_CONTRACT,
+  type SignatureLocation,
+} from '../../../src/tools/video/character-in-location.js';
+import {
+  assertAllSeedsPinned,
+  loadWorkflowTemplate,
+  type ComfyWorkflowGraph,
+} from '../../../src/tools/video/comfy-workflow-template.js';
+
+function insertionGraph(): ComfyWorkflowGraph {
+  return {
+    '1': { class_type: 'UnetLoaderGGUF', inputs: { unet_name: 'Qwen-Image-Edit-2509-Q4_K_M.gguf' } },
+    '2': { class_type: 'CLIPLoader', inputs: { clip_name: 'qwen_2.5_vl_7b_fp8_scaled.safetensors' } },
+    '3': { class_type: 'VAELoader', inputs: { vae_name: 'qwen_image_vae.safetensors' } },
+    '4': { class_type: 'LoadImage', inputs: { image: 'character-old.png' }, _meta: { title: 'Character' } },
+    '5': { class_type: 'LoadImage', inputs: { image: 'location-old.png' }, _meta: { title: 'Location' } },
+    '6': { class_type: 'TextEncodeQwenImageEditPlus', inputs: { prompt: '', image1: ['4', 0], image2: ['5', 0] } },
+    '7': { class_type: 'ModelSamplingAuraFlow', inputs: { model: ['1', 0] } },
+    '8': { class_type: 'KSampler', inputs: { seed: -1, model: ['7', 0] } },
+    '9': { class_type: 'VAEDecode', inputs: { samples: ['8', 0], vae: ['3', 0] } },
+    '10': { class_type: 'SaveImage', inputs: { filename_prefix: '', images: ['9', 0] } },
+    '11': { class_type: 'VAEEncode', inputs: { pixels: ['5', 0] } },
+  };
+}
+
+describe('Qwen character-in-location workflow', () => {
+  it('accepts the exact contract and rejects a missing required class', () => {
+    expect(() => loadWorkflowTemplate(insertionGraph(), INSERT_QWEN_TEMPLATE_CONTRACT)).not.toThrow();
+    const invalid = insertionGraph();
+    delete invalid['1'];
+    expect(() => loadWorkflowTemplate(invalid, INSERT_QWEN_TEMPLATE_CONTRACT))
+      .toThrow(/requires exactly 1 UnetLoaderGGUF.*found 0/u);
+  });
+
+  it('patches the two LoadImage roles by title and pins every seed', () => {
+    const source = insertionGraph();
+    const graph = buildCharacterInLocationWorkflow(source, {
+      characterImage: 'uploads/lisa.png',
+      locationImage: 'uploads/loft.png',
+      location: 'cozy-loft-interior',
+      seed: 61_084,
+      outputPrefix: 'insertions/lisa-loft',
+    });
+
+    expect(graph['4']?.inputs.image).toBe('uploads/lisa.png');
+    expect(graph['5']?.inputs.image).toBe('uploads/loft.png');
+    expect(graph['6']?.inputs.prompt).toBe(buildInsertionPrompt('cozy-loft-interior'));
+    expect(graph['8']?.inputs.seed).toBe(61_084);
+    expect(graph['10']?.inputs.filename_prefix).toBe('insertions/lisa-loft');
+    expect(source['4']?.inputs.image).toBe('character-old.png');
+    expect(() => assertAllSeedsPinned(graph)).not.toThrow();
+  });
+
+  it('fails when Character and Location titles do not disambiguate the images', () => {
+    const graph = insertionGraph();
+    graph['5']!._meta = { title: 'Background' };
+    expect(() => loadWorkflowTemplate(graph, INSERT_QWEN_TEMPLATE_CONTRACT))
+      .toThrow(/locationImage.*titled "Location"/u);
+  });
+
+  it('builds a deterministic prompt without textual decor from the catalog', () => {
+    const location: SignatureLocation = {
+      locationId: 'european-street-goldenhour',
+      label: 'European Street at Golden Hour',
+      description: 'A quiet old-European shopping street forms Lisa\'s warm urban landmark.',
+      lightingSpec: 'Golden hour at 18:40, warm sunlight from camera-left',
+      paletteTag: 'honey-stone-burgundy',
+    };
+    const first = buildInsertionPrompt(location);
+    const second = buildInsertionPrompt(location);
+    expect(first).toBe(second);
+    expect(first).toBe(
+      'place the woman from image 1 into the scene from image 2, keep her identity/pose/scale, ' +
+      'match the scene lighting and perspective, photorealistic',
+    );
+    expect(first).not.toContain(location.label);
+    expect(first).not.toContain(location.description);
+    expect(first).not.toContain(location.paletteTag);
+    expect(first).not.toContain(location.lightingSpec);
+  });
+
+  it('can require a measurable frontal medium shot without changing the default prompt', () => {
+    expect(buildInsertionPrompt('cozy-loft-interior', { frontalMedium: true }))
+      .toContain('frontal medium shot looking directly at camera');
+  });
+
+  it('protects the canonical face in latent sampling and restores it after decode', () => {
+    const source = insertionGraph();
+    source['8']!.inputs.latent_image = ['11', 0];
+    const graph = buildFaceProtectedCharacterInLocationWorkflow(source, {
+      characterImage: 'uploads/ambre.png',
+      locationImage: 'uploads/protected-base.png',
+      editMaskImage: 'uploads/edit-mask.png',
+      location: 'cozy-loft-interior',
+      seed: 81_001,
+      outputPrefix: 'insertions/ambre-protected',
+    });
+    const latentMask = Object.values(graph).find((node) => node.class_type === 'SetLatentNoiseMask');
+    const composite = Object.values(graph).find((node) => node.class_type === 'ImageCompositeMasked');
+    const finalMask = Object.values(graph).find((node) => node.class_type === 'GrowMask');
+    expect(latentMask).toBeDefined();
+    expect(finalMask?.inputs.expand).toBe(-16);
+    expect(composite).toBeDefined();
+    expect(graph['8']?.inputs.latent_image).toEqual(
+      [Object.entries(graph).find(([, node]) => node === latentMask)?.[0], 0],
+    );
+    expect(graph['10']?.inputs.images).toEqual(
+      [Object.entries(graph).find(([, node]) => node === composite)?.[0], 0],
+    );
+  });
+});

--- a/tests/tools/video/cinematic-trailer-plan.test.ts
+++ b/tests/tools/video/cinematic-trailer-plan.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  REQUIRED_NARRATIVE_TOKENS,
+  compileTrailerPreview,
+  validateCinematicTrailerPlan,
+  type CinematicTrailerPlan,
+  type TrailerShot,
+} from '../../../src/tools/video/cinematic-trailer-plan.js';
+import type { HybridVideoCapacity } from '../../../src/tools/video/hybrid-video-router.js';
+
+const SHA = 'a'.repeat(64);
+
+const capacity: HybridVideoCapacity = {
+  darkstar: true,
+  ministar: true,
+  googleFlow: true,
+  remainingFlowCredits: 25_000,
+  maxFlowCreditsPerBatch: 5_000,
+};
+
+function shot(overrides: Partial<TrailerShot> & Pick<TrailerShot, 'id' | 'token' | 'durationSeconds'>): TrailerShot {
+  const editorial = overrides.token === 'brand' || overrides.token === 'cta';
+  return {
+    information: 'a single clue appears',
+    action: 'turns',
+    cameraMove: 'slow push-in',
+    characters: [],
+    entryHandle: true,
+    exitHandle: true,
+    burnedInText: false,
+    rejectionConditions: ['off-model face'],
+    useCase: 'hero-shot',
+    ...(editorial ? {} : { manuscriptSource: { file: 'ch01.md', locator: 'scene 3' } }),
+    ...overrides,
+  };
+}
+
+/** A fully valid plan that legitimately reaches APPROVED_FOR_PUBLICATION. */
+function validPlan(): CinematicTrailerPlan {
+  return {
+    schemaVersion: 1,
+    status: 'APPROVED_FOR_PUBLICATION',
+    contentTier: 'safe',
+    book: {
+      title: 'Les Oubliés',
+      genre: 'thriller',
+      stagingSentence: 'We move from silence to a scream, seen from the child, without revealing who survives.',
+      spoilerLimit: 'no death is shown',
+      commercialAction: 'read the book',
+    },
+    masterDurationSeconds: 72,
+    characters: [
+      {
+        id: 'lisa',
+        identityVersion: 'lisa-v3',
+        reference: 'refs/lisa-approved.png',
+        referenceSha256: SHA,
+        castingApproved: true,
+      },
+    ],
+    shots: [
+      shot({ id: 's1', token: 'hook', durationSeconds: 6, characters: ['lisa'] }),
+      shot({ id: 's2', token: 'world', durationSeconds: 10 }),
+      shot({ id: 's3', token: 'protagonist', durationSeconds: 10, characters: ['lisa'] }),
+      shot({ id: 's4', token: 'escalation', durationSeconds: 12, characters: ['lisa'] }),
+      shot({ id: 's5', token: 'price', durationSeconds: 12 }),
+      shot({ id: 's6', token: 'withheld', durationSeconds: 10 }),
+      shot({ id: 's7', token: 'brand', durationSeconds: 8 }),
+      shot({ id: 's8', token: 'cta', durationSeconds: 4 }),
+    ],
+    overlays: [{ timecodeSeconds: 68, text: 'Les Oubliés', source: 'editorial', safeZone: true }],
+    sound: {
+      layers: ['ambience', 'foley', 'motif', 'speech'],
+      masters: ['music-approved.wav', 'sound-design-approved.wav'],
+    },
+    retention: {
+      hookA: 'the empty crib',
+      hookB: 'the scream over black',
+      promise: 'a disappearance you cannot explain',
+      proofWithinThreeSeconds: 'the crib is shown at 0-2s',
+      deeperPayoff: 'the note found later',
+      singleAbVariable: 'hook image',
+    },
+    cost: {
+      displayedInUi: true,
+      estimatedFlowCredits: 800,
+      approvedCeilingFlowCredits: 5_000,
+      approvedBy: 'patrice',
+    },
+    approvals: {
+      narrativeReviewed: true,
+      castingReviewed: true,
+      costApproved: true,
+      publicationApproved: true,
+    },
+    publication: {
+      visibility: 'private',
+      autoPublish: false,
+      containsSyntheticMedia: true,
+      humanReviewRequired: true,
+    },
+  };
+}
+
+describe('validateCinematicTrailerPlan', () => {
+  it('accepts a complete plan at every gate (happy path)', () => {
+    const v = validateCinematicTrailerPlan(validPlan());
+    expect(v.blockers).toEqual([]);
+    expect(v.qualifiedStatus).toBe('APPROVED_FOR_PUBLICATION');
+    expect(v.status).toBe('APPROVED_FOR_PUBLICATION');
+  });
+
+  it('exposes the required narrative tokens without revelation/false-resolution', () => {
+    expect(REQUIRED_NARRATIVE_TOKENS).toContain('withheld');
+    expect(REQUIRED_NARRATIVE_TOKENS).not.toContain('revelation');
+    expect(REQUIRED_NARRATIVE_TOKENS).not.toContain('false-resolution');
+  });
+
+  it('downgrades a lying status fail-closed and reports narrative blockers', () => {
+    const plan = validPlan();
+    plan.shots = plan.shots.filter((s) => s.token !== 'price'); // drop a required function
+    plan.masterDurationSeconds = 60; // keep close-ish but timeline now mismatches too
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.claimedStatus).toBe('APPROVED_FOR_PUBLICATION');
+    expect(v.qualifiedStatus).toBe('INCOMPLETE');
+    expect(v.status).toBe('INCOMPLETE');
+    expect(v.blockers).toContain('missing-function:price');
+  });
+
+  it('requires a manuscript source for every narrative shot but not editorial shots', () => {
+    const plan = validPlan();
+    const hook = plan.shots.find((s) => s.id === 's1')!;
+    delete hook.manuscriptSource;
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('missing-manuscript-source:s1');
+  });
+
+  it('rejects shots packing more than one action or camera move', () => {
+    const plan = validPlan();
+    plan.shots[0]!.action = 'turns then runs';
+    plan.shots[1]!.cameraMove = 'push-in while panning';
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('multiple-action:s1');
+    expect(v.blockers).toContain('multiple-camera-move:s2');
+  });
+
+  it('forbids text baked into the generated frame', () => {
+    const plan = validPlan();
+    plan.shots[0]!.burnedInText = true;
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('burned-in-text-forbidden:s1');
+  });
+
+  it('flags a timeline that does not sum to the master duration', () => {
+    const plan = validPlan();
+    plan.shots[0]!.durationSeconds = 3; // 72 -> 69, still in [60,90] but mismatched
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('timeline-duration-mismatch');
+  });
+
+  it('requires approved SHA-256 references for recurring characters', () => {
+    const plan = validPlan();
+    plan.status = 'APPROVED_FOR_GENERATION';
+    plan.characters[0]!.referenceSha256 = 'not-a-hash';
+    plan.characters[0]!.castingApproved = false;
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('invalid-character-sha:lisa');
+    expect(v.blockers).toContain('character-casting-not-approved:lisa');
+    expect(v.qualifiedStatus).toBe('READY_FOR_PREFLIGHT');
+  });
+
+  it('keeps generation blocked until cost is displayed AND approved within ceiling', () => {
+    const plan = validPlan();
+    plan.status = 'APPROVED_FOR_GENERATION';
+    plan.cost.estimatedFlowCredits = 6_000; // over ceiling 5000
+    plan.approvals.costApproved = false;
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('cost-not-approved');
+    expect(v.blockers).toContain('cost-exceeds-ceiling');
+    expect(v.qualifiedStatus).toBe('READY_FOR_PREFLIGHT');
+  });
+
+  it('blocks generation on NaN / negative cost estimate or ceiling', () => {
+    const plan = validPlan();
+    plan.status = 'APPROVED_FOR_GENERATION';
+    plan.cost.estimatedFlowCredits = Number.NaN;
+    const nanV = validateCinematicTrailerPlan(plan);
+    expect(nanV.blockers).toContain('invalid-cost-estimate');
+    // A NaN estimate must not sneak past the ceiling comparison as "not >".
+    expect(nanV.blockers).not.toContain('cost-exceeds-ceiling');
+    expect(nanV.qualifiedStatus).toBe('READY_FOR_PREFLIGHT');
+
+    const negative = validPlan();
+    negative.status = 'APPROVED_FOR_GENERATION';
+    negative.cost.estimatedFlowCredits = -10;
+    negative.cost.approvedCeilingFlowCredits = Number.NaN;
+    const negV = validateCinematicTrailerPlan(negative);
+    expect(negV.blockers).toContain('invalid-cost-estimate');
+    expect(negV.blockers).toContain('invalid-cost-ceiling');
+    expect(negV.qualifiedStatus).toBe('READY_FOR_PREFLIGHT');
+  });
+
+  it('blocks an overlay timecode that is NaN or outside [0, masterDuration]', () => {
+    const plan = validPlan();
+    plan.overlays = [
+      { timecodeSeconds: Number.NaN, text: 'a', source: 'editorial', safeZone: true },
+      { timecodeSeconds: -1, text: 'b', source: 'editorial', safeZone: true },
+      { timecodeSeconds: 999, text: 'c', source: 'editorial', safeZone: true }, // > 72
+    ];
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('overlay-timecode-out-of-range:NaN');
+    expect(v.blockers).toContain('overlay-timecode-out-of-range:-1');
+    expect(v.blockers).toContain('overlay-timecode-out-of-range:999');
+    expect(v.qualifiedStatus).toBe('INCOMPLETE');
+  });
+
+  it('requires four DISTINCT non-empty sound layers, not repeats', () => {
+    const plan = validPlan();
+    plan.sound.layers = ['ambience', 'ambience', 'AMBIENCE', '  ']; // one real layer
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('incomplete-sound-layers');
+    expect(v.qualifiedStatus).toBe('INCOMPLETE');
+  });
+
+  it('blocks empty and duplicate character declarations', () => {
+    const plan = validPlan();
+    plan.characters = [
+      { id: '  ', identityVersion: 'v', reference: 'r', referenceSha256: SHA, castingApproved: true },
+      { id: 'lisa', identityVersion: 'lisa-v3', reference: 'refs/lisa.png', referenceSha256: SHA, castingApproved: true },
+      { id: 'lisa', identityVersion: 'lisa-v3', reference: 'refs/lisa.png', referenceSha256: SHA, castingApproved: true },
+    ];
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('empty-character-id');
+    expect(v.blockers).toContain('duplicate-character-declaration:lisa');
+  });
+
+  it('does not treat a character repeated within one shot as recurring', () => {
+    const plan = validPlan();
+    plan.status = 'APPROVED_FOR_GENERATION';
+    // "bob" declared but appears twice in ONE shot only — not recurring across shots.
+    plan.characters.push({
+      id: 'bob',
+      identityVersion: '',
+      reference: '',
+      referenceSha256: 'not-a-hash',
+      castingApproved: false,
+    });
+    plan.shots[1]!.characters = ['bob', 'bob'];
+    const v = validateCinematicTrailerPlan(plan);
+    // Deduped to a single appearance ⇒ no recurring-identity blockers for bob.
+    expect(v.blockers.some((b) => b.endsWith(':bob'))).toBe(false);
+  });
+
+  it('flags a character used in shots but never declared', () => {
+    const plan = validPlan();
+    plan.status = 'APPROVED_FOR_GENERATION';
+    plan.shots[1]!.characters = ['ghost'];
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('undeclared-character:ghost');
+  });
+
+  it('always surfaces narrative/structural blockers even when the claim is INCOMPLETE', () => {
+    const plan = validPlan();
+    plan.status = 'INCOMPLETE';
+    plan.shots = plan.shots.filter((s) => s.token !== 'price');
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.claimedStatus).toBe('INCOMPLETE');
+    // Diagnostic narrative blockers are visible despite the humble claim.
+    expect(v.blockers).toContain('missing-function:price');
+  });
+
+  it('accepts an unknown / malformed value without throwing (null and {})', () => {
+    const nullV = validateCinematicTrailerPlan(null);
+    expect(nullV.status).toBe('INCOMPLETE');
+    expect(nullV.qualifiedStatus).toBe('INCOMPLETE');
+    expect(nullV.blockers).toContain('malformed-plan');
+
+    const emptyV = validateCinematicTrailerPlan({});
+    expect(emptyV.status).toBe('INCOMPLETE');
+    expect(emptyV.blockers).toContain('malformed-plan:book');
+    expect(emptyV.blockers).toContain('malformed-plan:shots');
+    // Business problems that survive coercion are not masked.
+    expect(emptyV.blockers).toContain('missing-book-metadata');
+  });
+
+  it('treats publication approval as a separate gate', () => {
+    const plan = validPlan();
+    plan.approvals.publicationApproved = false;
+    const v = validateCinematicTrailerPlan(plan);
+    // Generation is fully met, only publication is missing.
+    expect(v.qualifiedStatus).toBe('APPROVED_FOR_GENERATION');
+    expect(v.blockers).toContain('publication-not-approved');
+  });
+
+  it('enforces private visibility and autoPublish false', () => {
+    const plan = validPlan();
+    // Deliberately unsafe publication to prove the gate bites (cast around the literal type).
+    plan.publication = {
+      visibility: 'public',
+      autoPublish: true,
+      containsSyntheticMedia: true,
+      humanReviewRequired: true,
+    } as unknown as CinematicTrailerPlan['publication'];
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('unsafe-publication-gate');
+  });
+
+  it('rejects a non-safe content tier for advertiser-facing trailers', () => {
+    const plan = validPlan();
+    plan.contentTier = 'sensual';
+    const v = validateCinematicTrailerPlan(plan);
+    expect(v.blockers).toContain('non-safe-trailer-tier:sensual');
+    expect(v.qualifiedStatus).toBe('INCOMPLETE');
+  });
+});
+
+describe('compileTrailerPreview', () => {
+  it('estimates and distributes without ever authorizing execution or publication', () => {
+    const preview = compileTrailerPreview(validPlan(), capacity);
+    expect(preview.executionAuthorized).toBe(false);
+    expect(preview.publicationAuthorized).toBe(false);
+    expect(preview.readyForGeneration).toBe(true);
+    expect(preview.readyForPublication).toBe(true);
+    expect(preview.requests).toHaveLength(8);
+    expect(preview.routing.routes).toHaveLength(8);
+    expect(preview.routing.estimatedFlowCredits).toBeGreaterThan(0);
+  });
+
+  it('propagates the plan content tier into hybrid requests and stays unauthorized when incomplete', () => {
+    const plan = validPlan();
+    plan.shots = plan.shots.slice(0, 4); // narrative incomplete
+    plan.masterDurationSeconds = 38;
+    const preview = compileTrailerPreview(plan, capacity);
+    expect(preview.executionAuthorized).toBe(false);
+    expect(preview.readyForGeneration).toBe(false);
+    expect(preview.requests.every((r) => r.contentTier === 'safe')).toBe(true);
+    expect(preview.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('never throws on a malformed / unknown plan; yields empty requests and routing', () => {
+    for (const bad of [null, {}, 42, 'nope', []] as unknown[]) {
+      const preview = compileTrailerPreview(bad, capacity);
+      expect(preview.executionAuthorized).toBe(false);
+      expect(preview.publicationAuthorized).toBe(false);
+      expect(preview.readyForGeneration).toBe(false);
+      expect(preview.readyForPublication).toBe(false);
+      expect(preview.requests).toEqual([]);
+      expect(preview.routing.routes).toEqual([]);
+      expect(preview.status).toBe('INCOMPLETE');
+      expect(preview.blockers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never throws when the router has no available engine — surfaces a diagnostic blocker', () => {
+    const noEngines: HybridVideoCapacity = {
+      darkstar: false,
+      ministar: false,
+      googleFlow: false,
+      remainingFlowCredits: 0,
+      maxFlowCreditsPerBatch: 0,
+    };
+    const preview = compileTrailerPreview(validPlan(), noEngines);
+    expect(preview.routing.routes).toEqual([]);
+    expect(preview.readyForGeneration).toBe(false);
+    expect(preview.readyForPublication).toBe(false);
+    expect(preview.blockers.some((b) => b.startsWith('routing-unavailable:'))).toBe(true);
+  });
+
+  it('blocks when the actually-routed cost exceeds the approved ceiling', () => {
+    const plan = validPlan();
+    // The declared estimate is honest against a low ceiling, so validation passes…
+    plan.cost.estimatedFlowCredits = 200;
+    plan.cost.approvedCeilingFlowCredits = 300;
+    const gateOnly = validateCinematicTrailerPlan(plan);
+    expect(gateOnly.qualifiedStatus).toBe('APPROVED_FOR_PUBLICATION');
+    // …but the router distributes ~800 credits, which busts the 300 ceiling.
+    const preview = compileTrailerPreview(plan, capacity);
+    expect(preview.routing.estimatedFlowCredits).toBeGreaterThan(300);
+    expect(preview.blockers.some((b) => b.startsWith('routed-cost-exceeds-ceiling:'))).toBe(true);
+    expect(preview.readyForGeneration).toBe(false);
+    expect(preview.readyForPublication).toBe(false);
+  });
+});

--- a/tests/tools/video/comfy-client.test.ts
+++ b/tests/tools/video/comfy-client.test.ts
@@ -1,0 +1,96 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { probeComfy, submitAndAwait } from '../../../src/tools/video/comfy-client.js';
+import type { ComfyWorkflowGraph } from '../../../src/tools/video/comfy-workflow-template.js';
+
+const roots: string[] = [];
+const graph: ComfyWorkflowGraph = { '1': { class_type: 'SaveImage', inputs: { filename_prefix: 'test' } } };
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('headless ComfyUI client', () => {
+  it('probes system devices', async () => {
+    const fetchImpl = vi.fn(async () => json({ devices: [{ name: 'RTX 3090', type: 'cuda' }] }));
+    await expect(probeComfy('http://comfy.test', fetchImpl)).resolves.toEqual({
+      ok: true,
+      devices: [{ name: 'RTX 3090', type: 'cuda' }],
+    });
+  });
+
+  it('submits, polls until done, and downloads image/video/gif outputs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'comfy-client-test-'));
+    roots.push(root);
+    let historyCalls = 0;
+    const paths: string[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+      paths.push(url.pathname);
+      if (url.pathname === '/prompt') return json({ prompt_id: 'prompt-1' });
+      if (url.pathname === '/history/prompt-1') {
+        historyCalls += 1;
+        if (historyCalls === 1) return json({});
+        return json({
+          'prompt-1': {
+            status: { completed: true, status_str: 'success' },
+            outputs: {
+              '10': { images: [{ filename: 'frame.png', subfolder: '', type: 'output' }] },
+              '11': { videos: [{ filename: 'clip.mp4', subfolder: 'batch', type: 'output' }] },
+              '12': { gifs: [{ filename: 'preview.gif', subfolder: '', type: 'output' }] },
+            },
+          },
+        });
+      }
+      if (url.pathname === '/view') return new Response(Buffer.from(`bytes:${url.searchParams.get('filename')}`));
+      return json({ error: 'not found' }, 404);
+    });
+
+    const result = await submitAndAwait('http://comfy.test/', graph, {
+      clientId: 'client-1', timeoutMs: 1000, pollMs: 0, fetchImpl, workDir: root, sleep: async () => {},
+    });
+    expect(result.promptId).toBe('prompt-1');
+    expect(result.outputs.map((output) => output.kind)).toEqual(['image', 'video', 'gif']);
+    expect(await Promise.all(result.outputs.map((output) => fs.readFile(output.path, 'utf8'))))
+      .toEqual(['bytes:frame.png', 'bytes:clip.mp4', 'bytes:preview.gif']);
+    expect(paths).toEqual(['/prompt', '/history/prompt-1', '/history/prompt-1', '/view', '/view', '/view']);
+  });
+
+  it('surfaces the failing node exception message from history', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+      if (url.pathname === '/prompt') return json({ prompt_id: 'bad-prompt' });
+      return json({
+        'bad-prompt': {
+          status: {
+            status_str: 'error',
+            messages: [['execution_error', { node_id: '42', exception_message: 'CUDA out of memory' }]],
+          },
+        },
+      });
+    });
+    await expect(submitAndAwait('http://comfy.test', graph, {
+      clientId: 'client', timeoutMs: 100, pollMs: 0, fetchImpl, sleep: async () => {},
+    })).rejects.toThrow(/node 42: CUDA out of memory/u);
+  });
+
+  it('times out frankly when history never completes', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+      return url.pathname === '/prompt' ? json({ prompt_id: 'slow' }) : json({});
+    });
+    let clock = 0;
+    await expect(submitAndAwait('http://comfy.test', graph, {
+      clientId: 'client', timeoutMs: 10, pollMs: 0, fetchImpl,
+      now: () => { clock += 6; return clock; }, sleep: async () => {},
+    })).rejects.toThrow(/timed out after 10ms/u);
+  });
+});

--- a/tests/tools/video/comfy-client.test.ts
+++ b/tests/tools/video/comfy-client.test.ts
@@ -28,7 +28,7 @@ describe('headless ComfyUI client', () => {
   });
 
   it('submits, polls until done, and downloads image/video/gif outputs', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'comfy-client-test-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'comfy-client-test-')));
     roots.push(root);
     let historyCalls = 0;
     const paths: string[] = [];

--- a/tests/tools/video/comfy-workflow-template.test.ts
+++ b/tests/tools/video/comfy-workflow-template.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAllSeedsPinned,
+  I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT,
+  loadWorkflowTemplate,
+  patchWorkflow,
+  type ComfyWorkflowGraph,
+  type TemplateContract,
+} from '../../../src/tools/video/comfy-workflow-template.js';
+
+function i2vGraph(): ComfyWorkflowGraph {
+  return {
+    '1': { class_type: 'WanVideoModelLoader', inputs: { model: 'high.safetensors' }, _meta: { title: 'High Noise' } },
+    '2': { class_type: 'WanVideoModelLoader', inputs: { model: 'low.safetensors' }, _meta: { title: 'Low Noise' } },
+    '3': { class_type: 'WanVideoSampler', inputs: { seed: -1, steps: 4, cfg: 1 }, _meta: { title: 'High Sampler' } },
+    '4': { class_type: 'WanVideoSampler', inputs: { seed: -1, steps: 4, cfg: 1 }, _meta: { title: 'Low Sampler' } },
+    '5': { class_type: 'WanVideoImageToVideoEncode', inputs: { width: 832, height: 480, num_frames: 81 } },
+    '6': { class_type: 'WanVideoTextEncode', inputs: { positive_prompt: '', negative_prompt: '' } },
+    '7': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+    '8': { class_type: 'VHS_VideoCombine', inputs: { filename_prefix: 'video' } },
+  };
+}
+
+describe('ComfyUI workflow template contracts', () => {
+  it('accepts the exact required node multiplicities and rejects a missing class', () => {
+    expect(() => loadWorkflowTemplate(i2vGraph(), I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT)).not.toThrow();
+    const missing = i2vGraph();
+    delete missing['5'];
+    expect(() => loadWorkflowTemplate(missing, I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT))
+      .toThrow(/requires exactly 1 WanVideoImageToVideoEncode.*found 0/u);
+  });
+
+  it('patches every typed role and leaves the source template unchanged', () => {
+    const original = i2vGraph();
+    const snapshot = structuredClone(original);
+    const loaded = loadWorkflowTemplate(original, I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT);
+    const patched = patchWorkflow(loaded, [
+      { role: 'seed', value: 4201 },
+      { role: 'prompt', value: 'stable fashion motion' },
+      { role: 'negative', value: 'flicker' },
+      { role: 'inputImage', value: 'approved.png' },
+      { role: 'frames', value: 81 },
+      { role: 'resolution', value: { width: 720, height: 1280 } },
+      { role: 'outputPrefix', value: 'batch/segment-1' },
+    ]);
+
+    expect(patched['3']?.inputs.seed).toBe(4201);
+    expect(patched['4']?.inputs.seed).toBe(4201);
+    expect(patched['5']?.inputs).toMatchObject({ width: 720, height: 1280, num_frames: 81 });
+    expect(patched['6']?.inputs).toMatchObject({ positive_prompt: 'stable fashion motion', negative_prompt: 'flicker' });
+    expect(patched['7']?.inputs.image).toBe('approved.png');
+    expect(patched['8']?.inputs.filename_prefix).toBe('batch/segment-1');
+    expect(original).toEqual(snapshot);
+  });
+
+  it('fails explicitly on an ambiguous role without _meta.title disambiguation', () => {
+    const contract: TemplateContract = {
+      id: 'keyframe-flux',
+      required: [{ classType: 'CLIPTextEncode', count: 2 }],
+      roles: { prompt: [{ classType: 'CLIPTextEncode', input: 'text' }] },
+    };
+    const graph: ComfyWorkflowGraph = {
+      '1': { class_type: 'CLIPTextEncode', inputs: { text: '' } },
+      '2': { class_type: 'CLIPTextEncode', inputs: { text: '' } },
+    };
+    expect(() => loadWorkflowTemplate(graph, contract)).toThrow(/ambiguous.*_meta\.title/u);
+  });
+
+  it('rejects an unresolved patch role', () => {
+    const loaded = loadWorkflowTemplate(i2vGraph(), I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT);
+    expect(() => patchWorkflow(loaded, [{ role: 'inputVideo', value: 'clip.mp4' }]))
+      .toThrow(/does not resolve patch role inputVideo/u);
+  });
+
+  it('rejects unpinned seeds and accepts all explicitly pinned seed inputs', () => {
+    expect(() => assertAllSeedsPinned(i2vGraph())).toThrow(/3\.seed/u);
+    const loaded = loadWorkflowTemplate(i2vGraph(), I2V_WAN_LIGHTX2V_TEMPLATE_CONTRACT);
+    const pinned = patchWorkflow(loaded, [{ role: 'seed', value: 7 }]);
+    expect(() => assertAllSeedsPinned(pinned)).not.toThrow();
+  });
+});

--- a/tests/tools/video/google-flow-driver.test.ts
+++ b/tests/tools/video/google-flow-driver.test.ts
@@ -1,0 +1,214 @@
+import path from 'path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  attachToBrowser,
+  assertCreditBudget,
+  assertLoopbackCdpUrl,
+  assertSufficientCreditBalance,
+  estimateCreditCost,
+  FLOW_SELECTORS,
+  FlowDriver,
+  GOOGLE_FLOW_URL,
+  type FlowDownload,
+  type FlowPage,
+} from '../../../src/tools/video/google-flow-driver.js';
+
+interface FakeElement {
+  visible?: boolean;
+  enabled?: boolean;
+  text?: string;
+  count?: number;
+  source?: string | null;
+  click?: () => void;
+  fill?: (value: string) => void;
+  files?: (files: string[]) => void;
+}
+
+class FakeLocator {
+  constructor(private readonly element: FakeElement) {}
+
+  first(): FakeLocator {
+    return this;
+  }
+
+  async waitFor(): Promise<void> {
+    if (!this.element.visible) throw new Error('not visible');
+  }
+
+  async isVisible(): Promise<boolean> {
+    return this.element.visible ?? false;
+  }
+
+  async isEnabled(): Promise<boolean> {
+    return this.element.enabled ?? true;
+  }
+
+  async click(): Promise<void> {
+    this.element.click?.();
+  }
+
+  async fill(value: string): Promise<void> {
+    this.element.fill?.(value);
+  }
+
+  async setInputFiles(files: string[]): Promise<void> {
+    this.element.files?.(files);
+  }
+
+  async textContent(): Promise<string | null> {
+    return this.element.text ?? null;
+  }
+
+  async count(): Promise<number> {
+    return this.element.count ?? (this.element.visible ? 1 : 0);
+  }
+
+  async getAttribute(name: string): Promise<string | null> {
+    return name === 'src' ? this.element.source ?? null : null;
+  }
+}
+
+class FakeFlowPage implements FlowPage {
+  readonly requestedSelectors: string[] = [];
+  readonly elements = new Map<string, FakeElement>();
+  currentUrl = GOOGLE_FLOW_URL;
+
+  url(): string {
+    return this.currentUrl;
+  }
+
+  locator(selector: string): FakeLocator {
+    this.requestedSelectors.push(selector);
+    return new FakeLocator(this.elements.get(selector) ?? {});
+  }
+
+  async goto(url: string): Promise<void> {
+    this.currentUrl = url;
+  }
+
+  async waitForTimeout(): Promise<void> {}
+
+  async waitForEvent(): Promise<FlowDownload> {
+    throw new Error('download not configured');
+  }
+}
+
+function readyPage(): FakeFlowPage {
+  const page = new FakeFlowPage();
+  for (const selector of [
+    FLOW_SELECTORS.appRoot,
+    FLOW_SELECTORS.creditBalance,
+    FLOW_SELECTORS.modelMenu,
+    FLOW_SELECTORS.aspectMenu,
+    FLOW_SELECTORS.ingredientsInput,
+    FLOW_SELECTORS.promptInput,
+    FLOW_SELECTORS.submitButton,
+  ]) page.elements.set(selector, { visible: true, enabled: true });
+  page.elements.set(FLOW_SELECTORS.creditBalance, { visible: true, text: '24 970 crédits' });
+  page.elements.set(FLOW_SELECTORS.signIn, { visible: false });
+  page.elements.set(FLOW_SELECTORS.errorBanner, { visible: false });
+  page.elements.set(FLOW_SELECTORS.ingredientRemoveButton, { visible: false, count: 0 });
+  page.elements.set(FLOW_SELECTORS.ingredientsPreview, { visible: false, count: 0 });
+  page.elements.set(FLOW_SELECTORS.generationProgress, { visible: false, count: 0 });
+  page.elements.set(FLOW_SELECTORS.resultReady, { visible: false, count: 0, source: null });
+  return page;
+}
+
+describe('Google Flow CDP driver', () => {
+  it('estimates Fast and Quality costs and rejects unsafe budgets', () => {
+    expect(estimateCreditCost([{}, {}, {}], 'fast')).toBe(30);
+    expect(estimateCreditCost([{}, {}, {}], 'quality')).toBe(300);
+    expect(() => assertSufficientCreditBalance(29, 30)).toThrow(/insufficient/i);
+    expect(() => assertCreditBudget(10, 10, 19)).toThrow(/max-credit/i);
+    expect(() => assertCreditBudget(10, 10, 20)).not.toThrow();
+  });
+
+  it('restricts CDP attachment to credential-free loopback URLs', () => {
+    expect(assertLoopbackCdpUrl('http://127.0.0.1:9222')).toBe('http://127.0.0.1:9222');
+    expect(() => assertLoopbackCdpUrl('http://browser.internal:9222')).toThrow(/loopback/i);
+    expect(() => assertLoopbackCdpUrl('http://user:secret@127.0.0.1:9222')).toThrow(/credentials/i);
+  });
+
+  it('attaches to an existing Flow tab and verifies the centralized selectors', async () => {
+    const page = readyPage();
+    const newPage = vi.fn(async () => page);
+    const connector = vi.fn(async () => ({ contexts: () => [{ pages: () => [page], newPage }] }));
+
+    const attached = await attachToBrowser({ connector, timeoutMs: 50 });
+
+    expect(attached.driver).toBeInstanceOf(FlowDriver);
+    expect(connector).toHaveBeenCalledWith('http://127.0.0.1:9222');
+    expect(newPage).not.toHaveBeenCalled();
+    expect(page.requestedSelectors).toEqual(expect.arrayContaining([
+      FLOW_SELECTORS.appRoot,
+      FLOW_SELECTORS.promptInput,
+      FLOW_SELECTORS.creditBalance,
+    ]));
+    await expect(attached.driver.readCreditBalance()).resolves.toBe(24_970);
+  });
+
+  it('opens Flow when needed but never tries to handle a Google login', async () => {
+    const blank = readyPage();
+    blank.currentUrl = 'about:blank';
+    const flow = readyPage();
+    const newPage = vi.fn(async () => flow);
+    await attachToBrowser({
+      timeoutMs: 50,
+      connector: async () => ({ contexts: () => [{ pages: () => [blank], newPage }] }),
+    });
+    expect(newPage).toHaveBeenCalledTimes(1);
+    expect(flow.currentUrl).toBe(GOOGLE_FLOW_URL);
+
+    const login = readyPage();
+    login.currentUrl = 'https://accounts.google.com/signin';
+    login.elements.set(FLOW_SELECTORS.signIn, { visible: true });
+    await expect(attachToBrowser({
+      timeoutMs: 50,
+      connector: async () => ({ contexts: () => [{ pages: () => [], newPage: async () => login }] }),
+    })).rejects.toThrow(/connecte-toi d'abord dans le navigateur/i);
+  });
+
+  it('maps atomic actions to the fake DOM without blind clicks', async () => {
+    const page = readyPage();
+    const selected: string[] = [];
+    page.elements.set(FLOW_SELECTORS.modelMenu, { visible: true, click: () => selected.push('model-menu') });
+    page.elements.set(FLOW_SELECTORS.modelOption['veo-3.1-fast'], {
+      visible: true,
+      click: () => selected.push('fast'),
+    });
+    page.elements.set(FLOW_SELECTORS.aspectMenu, { visible: true, click: () => selected.push('aspect-menu') });
+    page.elements.set(FLOW_SELECTORS.aspectOption['9:16'], { visible: true, click: () => selected.push('9:16') });
+    const preview = page.elements.get(FLOW_SELECTORS.ingredientsPreview)!;
+    page.elements.set(FLOW_SELECTORS.ingredientsInput, {
+      visible: true,
+      files: (files) => {
+        selected.push(...files.map((filename) => path.basename(filename)));
+        preview.count = files.length;
+        preview.visible = true;
+      },
+    });
+    const result = page.elements.get(FLOW_SELECTORS.resultReady)!;
+    page.elements.set(FLOW_SELECTORS.submitButton, {
+      visible: true,
+      click: () => {
+        result.count = 1;
+        result.visible = true;
+        result.source = 'blob:new-result';
+      },
+    });
+    const prompt = vi.fn();
+    page.elements.set(FLOW_SELECTORS.promptInput, { visible: true, fill: prompt });
+    const driver = new FlowDriver(page, { actionTimeoutMs: 50, generationTimeoutMs: 50, pollIntervalMs: 1 });
+
+    await driver.setModel('veo-3.1-fast');
+    await driver.setAspect('9:16');
+    await driver.setIngredients(['/approved/hero.png']);
+    await driver.submitPrompt('A safe cinematic move');
+
+    expect(selected).toEqual(['model-menu', 'fast', 'aspect-menu', '9:16', 'hero.png']);
+    expect(prompt).toHaveBeenCalledWith('A safe cinematic move');
+    expect(page.requestedSelectors).toContain(FLOW_SELECTORS.resultReady);
+  });
+});

--- a/tests/tools/video/google-flow-handoff.test.ts
+++ b/tests/tools/video/google-flow-handoff.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGoogleFlowPrompt,
+  canonicalSha256,
+  createGoogleFlowHandoff,
+  verifyGoogleFlowHandoffDigest,
+} from '../../../src/tools/video/google-flow-handoff.js';
+
+const SOURCE_PLAN_SHA256 = 'f'.repeat(64);
+
+const shots = [1, 2, 3].map((index) => ({
+  id: `lisa-shot-${index}`,
+  characterName: 'Lisa',
+  declaredAdultAge: 28,
+  sourcePath: `/catalog/lisa-${index}.png`,
+  sourceSha256: String(index).repeat(64),
+  motionPrompt: `distinct cinematic movement ${index}`,
+  role: index === 1 ? 'hero' as const : index === 3 ? 'transition' as const : 'b-roll' as const,
+  consumerShortIds: [`lisa-pilot-${index}`],
+  consumers: [{ shortId: `lisa-pilot-${index}`, shotIndex: index }],
+}));
+
+describe('Google Flow handoff', () => {
+  it('creates a bounded Ultra-credit Fast batch without API billing or lip sync', () => {
+    const handoff = createGoogleFlowHandoff(shots, {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: 'lisa-pilot-en',
+      model: 'fast',
+      locale: 'en-US',
+      durationSeconds: 8,
+      aspectRatio: '9:16',
+      upscale4k: false,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 25_000,
+        maxFlowCreditsPerBatch: 100,
+      },
+    });
+    expect(handoff).toMatchObject({
+      schemaVersion: 2,
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      provider: 'google-flow-web',
+      billingMode: 'google-ai-ultra-flow-credits',
+      apiBillingAllowed: false,
+      estimatedCredits: 30,
+      remainingCreditsAfterEstimate: 24_970,
+      humanFlowSessionRequired: true,
+      autoPublish: false,
+    });
+    expect(verifyGoogleFlowHandoffDigest(handoff)).toBe(true);
+    expect(handoff.handoffSha256).toBe(canonicalSha256((({ handoffSha256: _digest, ...unsigned }) => unsigned)(handoff)));
+    expect(handoff.jobs).toHaveLength(3);
+    expect(handoff.jobs[0]).toMatchObject({
+      engine: 'google-flow-veo31-fast',
+      estimatedCredits: 10,
+      settings: { lipSync: false, audio: 'ambient-only' },
+    });
+  });
+
+  it('reserves Quality for bounded premium batches and refuses credit overflow', () => {
+    expect(createGoogleFlowHandoff(shots, {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: 'quality-pilot',
+      model: 'quality',
+      locale: 'fr-FR',
+      durationSeconds: 8,
+      aspectRatio: '16:9',
+      upscale4k: false,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 25_000,
+        maxFlowCreditsPerBatch: 300,
+      },
+    }).estimatedCredits).toBe(300);
+    expect(() => createGoogleFlowHandoff(shots, {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: 'quality-overflow',
+      model: 'quality',
+      locale: 'fr-FR',
+      durationSeconds: 8,
+      aspectRatio: '16:9',
+      upscale4k: true,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 25_000,
+        maxFlowCreditsPerBatch: 300,
+      },
+    })).toThrow('reduce or split');
+  });
+
+  it('forces safe identity and no-dialogue prompt constraints', () => {
+    const prompt = buildGoogleFlowPrompt(shots[0]!, '9:16');
+    expect(prompt).toContain('clearly age 28');
+    expect(prompt).toContain('preserve face');
+    expect(prompt).toContain('No speech');
+    expect(prompt).toContain('no visible lip synchronization');
+  });
+
+  it('rejects unsupported Quality durations before spending credits', () => {
+    expect(() => createGoogleFlowHandoff([shots[0]!], {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: 'invalid-quality-duration',
+      model: 'quality',
+      locale: 'fr-FR',
+      durationSeconds: 4,
+      aspectRatio: '9:16',
+      upscale4k: false,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 25_000,
+        maxFlowCreditsPerBatch: 100,
+      },
+    })).toThrow('only supports 8-second');
+  });
+
+  it('rejects a batch ID that could escape a generated output path', () => {
+    expect(() => createGoogleFlowHandoff([shots[0]!], {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: '../../outside',
+      model: 'fast',
+      locale: 'fr-FR',
+      durationSeconds: 4,
+      aspectRatio: '9:16',
+      upscale4k: false,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 100,
+        maxFlowCreditsPerBatch: 100,
+      },
+    })).toThrow('safe batch ID');
+  });
+
+  it('detects any mutation after the handoff was digest-bound', () => {
+    const handoff = createGoogleFlowHandoff([shots[0]!], {
+      sourcePlanSha256: SOURCE_PLAN_SHA256,
+      batchId: 'digest-pilot',
+      model: 'fast',
+      locale: 'fr-FR',
+      durationSeconds: 4,
+      aspectRatio: '9:16',
+      upscale4k: false,
+      capacity: {
+        darkstar: true,
+        ministar: true,
+        googleFlow: true,
+        remainingFlowCredits: 100,
+        maxFlowCreditsPerBatch: 100,
+      },
+    });
+    handoff.jobs[0]!.prompt = 'mutated after approval';
+    expect(verifyGoogleFlowHandoffDigest(handoff)).toBe(false);
+  });
+});

--- a/tests/tools/video/google-flow-plan-export.test.ts
+++ b/tests/tools/video/google-flow-plan-export.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { exportGoogleFlowHandoffFromPlan } from '../../../src/tools/video/google-flow-plan-export.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-plan-'));
+  temporaryDirectories.push(root);
+  const filename = path.join(root, 'lisa.png');
+  const bytes = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.from('approved-fictional-adult-source'),
+  ]);
+  await fs.writeFile(filename, bytes);
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const plannedShort = (shortId: string, locale: string) => ({
+    shortId,
+    locale,
+    profile: { name: 'Lisa', declaredAdultAge: 28 },
+    render: {
+      shots: [{
+        assetId: 'lisa-safe-1',
+        sourceSha256: sha256,
+        referenceImagePath: filename,
+        contentTier: 'safe',
+        qaStatus: 'approved',
+        motionPrompt: 'gentle camera push, natural blink and subtle hair movement',
+      }],
+    },
+    publication: {
+      visibility: 'private',
+      autoPublish: false,
+      containsSyntheticMedia: true,
+      reviewStatus: 'pending-human-review',
+    },
+  });
+  return {
+    root,
+    plan: {
+      schemaVersion: 3,
+      sourceDigests: {
+        imageManifestSha256: 'a'.repeat(64),
+        imageCatalogSha256: 'b'.repeat(64),
+        factoryConfigSha256: 'c'.repeat(64),
+        assetApprovalsSha256: 'd'.repeat(64),
+        productionLedgerSha256: 'e'.repeat(64),
+      },
+      policy: {
+        contentTier: 'safe',
+        qaStatus: 'approved',
+        autoPublish: false,
+        initialVisibility: 'private',
+        syntheticMediaDisclosureRequired: true,
+      },
+      shorts: [plannedShort('lisa-fr', 'fr-FR'), plannedShort('lisa-en', 'en-US')],
+    },
+  };
+}
+
+function options(root: string) {
+  return {
+    approvedAssetRoot: root,
+    batchId: 'pilot',
+    includeAllShorts: true,
+    model: 'fast' as const,
+    durationSeconds: 4 as const,
+    aspectRatio: '9:16' as const,
+    upscale4k: false,
+    remainingFlowCredits: 25_000,
+    maxFlowCreditsPerBatch: 100,
+    darkstarAvailable: true,
+    ministarAvailable: true,
+  };
+}
+
+describe('Google Flow plan export', () => {
+  it('verifies assets and reuses an identical visual across localized masters', async () => {
+    const { root, plan } = await fixture();
+    const handoff = await exportGoogleFlowHandoffFromPlan(plan, options(root));
+    expect(handoff).toMatchObject({
+      schemaVersion: 2,
+      locale: 'multilingual-shared-visuals',
+      estimatedCredits: 10,
+      autoPublish: false,
+    });
+    expect(handoff.jobs).toHaveLength(1);
+    expect(handoff.jobs[0]?.consumerShortIds).toEqual(['lisa-fr', 'lisa-en']);
+    expect(handoff.jobs[0]?.consumers).toEqual([
+      { shortId: 'lisa-fr', shotIndex: 1 },
+      { shortId: 'lisa-en', shotIndex: 1 },
+    ]);
+    expect(handoff.sourcePlanSha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(handoff.handoffSha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it('fails closed when a source digest no longer matches', async () => {
+    const { root, plan } = await fixture();
+    plan.shorts[0]!.render.shots[0]!.sourceSha256 = '0'.repeat(64);
+    await expect(exportGoogleFlowHandoffFromPlan(plan, options(root))).rejects.toThrow('digest does not match');
+  });
+
+  it('defaults to the first Short when all is not explicitly requested', async () => {
+    const { root, plan } = await fixture();
+    const exportOptions = options(root);
+    delete (exportOptions as Partial<typeof exportOptions>).includeAllShorts;
+    const handoff = await exportGoogleFlowHandoffFromPlan(plan, exportOptions);
+    expect(handoff.locale).toBe('fr-FR');
+    expect(handoff.jobs[0]?.consumerShortIds).toEqual(['lisa-fr']);
+  });
+
+  it('rejects legacy plans even when their publication policy looks safe', async () => {
+    const { root, plan } = await fixture();
+    plan.schemaVersion = 2;
+    await expect(exportGoogleFlowHandoffFromPlan(plan, options(root))).rejects.toThrow('not safe');
+  });
+
+  it('requires exactly the five source digests accepted by the renderer', async () => {
+    const missing = await fixture();
+    delete (missing.plan.sourceDigests as Record<string, string>).assetApprovalsSha256;
+    await expect(exportGoogleFlowHandoffFromPlan(missing.plan, options(missing.root))).rejects.toThrow('not safe');
+
+    const extra = await fixture();
+    (extra.plan.sourceDigests as Record<string, string>).legacyDigest = 'f'.repeat(64);
+    await expect(exportGoogleFlowHandoffFromPlan(extra.plan, options(extra.root))).rejects.toThrow('not safe');
+
+    const malformed = await fixture();
+    malformed.plan.sourceDigests.productionLedgerSha256 = 'not-a-sha256';
+    await expect(exportGoogleFlowHandoffFromPlan(malformed.plan, options(malformed.root))).rejects.toThrow('not safe');
+  });
+});

--- a/tests/tools/video/google-flow-plan-export.test.ts
+++ b/tests/tools/video/google-flow-plan-export.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 });
 
 async function fixture() {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-plan-'));
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'flow-plan-')));
   temporaryDirectories.push(root);
   const filename = path.join(root, 'lisa.png');
   const bytes = Buffer.concat([

--- a/tests/tools/video/google-flow-result-import.test.ts
+++ b/tests/tools/video/google-flow-result-import.test.ts
@@ -19,8 +19,8 @@ const FFMPEG = spawnSync('ffmpeg', ['-version'], { stdio: 'ignore' }).status ===
 afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
 
 async function fixture() {
-  const resultsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-results-'));
-  const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-import-'));
+  const resultsRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'flow-results-')));
+  const outputRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'flow-import-')));
   roots.push(resultsRoot, outputRoot);
   const handoff = createGoogleFlowHandoff([{
     id: 'pilot-flow-01', characterName: 'Lisa', declaredAdultAge: 28,

--- a/tests/tools/video/google-flow-result-import.test.ts
+++ b/tests/tools/video/google-flow-result-import.test.ts
@@ -1,0 +1,232 @@
+import { execFile as rawExecFile, spawnSync } from 'child_process';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createGoogleFlowHandoff } from '../../../src/tools/video/google-flow-handoff.js';
+import {
+  buildNormalizeFlowResultArgs,
+  importGoogleFlowResults,
+  reviewGoogleFlowImport,
+} from '../../../src/tools/video/google-flow-result-import.js';
+
+const roots: string[] = [];
+const execFile = promisify(rawExecFile);
+const FFMPEG = spawnSync('ffmpeg', ['-version'], { stdio: 'ignore' }).status === 0 &&
+  spawnSync('ffprobe', ['-version'], { stdio: 'ignore' }).status === 0;
+afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
+
+async function fixture() {
+  const resultsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-results-'));
+  const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'flow-import-'));
+  roots.push(resultsRoot, outputRoot);
+  const handoff = createGoogleFlowHandoff([{
+    id: 'pilot-flow-01', characterName: 'Lisa', declaredAdultAge: 28,
+    sourcePath: '/catalog/lisa.png', sourceSha256: 'a'.repeat(64),
+    motionPrompt: 'gentle cinematic movement', consumerShortIds: ['pilot-fr'], role: 'hero',
+  }], {
+    sourcePlanSha256: 'f'.repeat(64),
+    batchId: 'pilot', model: 'fast', locale: 'fr-FR', durationSeconds: 4,
+    aspectRatio: '9:16', upscale4k: false,
+    capacity: { darkstar: true, ministar: true, googleFlow: true, remainingFlowCredits: 100, maxFlowCreditsPerBatch: 100 },
+  });
+  const handoffBytes = Buffer.from(JSON.stringify(handoff));
+  return { resultsRoot, outputRoot, handoff, handoffBytes };
+}
+
+function mp4(): Buffer {
+  return Buffer.concat([Buffer.from([0, 0, 0, 24]), Buffer.from('ftypisom'), Buffer.alloc(24)]);
+}
+
+describe('Google Flow result import', () => {
+  it('keeps the default normalization argv byte-for-byte compatible', () => {
+    expect(buildNormalizeFlowResultArgs('/input.mp4', '/output.mp4')).toEqual([
+      '-v', 'error', '-n', '-i', '/input.mp4', '-map', '0:v:0', '-an', '-c:v', 'copy',
+      '-movflags', '+faststart', '/output.mp4',
+    ]);
+  });
+
+  it('copies content-addressed MP4s and leaves them pending human review', async () => {
+    const input = await fixture();
+    await fs.writeFile(path.join(input.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    const receipt = await importGoogleFlowResults({
+      ...input,
+      now: () => new Date('2026-07-18T12:00:00Z'),
+      normalize: async (source, destination) => fs.copyFile(source, destination),
+      probe: async (filename) => ({
+        durationSeconds: 4,
+        width: 720,
+        height: 1280,
+        hasVideo: true,
+        hasAudio: !filename.includes('-silent.mp4'),
+      }),
+    });
+    expect(receipt).toMatchObject({
+      schemaVersion: 2,
+      audioPolicy: 'removed-on-import',
+      autoPublish: false,
+      humanReviewRequired: true,
+    });
+    expect(receipt.jobs[0]).toMatchObject({
+      id: 'pilot-flow-01',
+      role: 'hero',
+      sourceHadAudio: true,
+      probe: { hasAudio: false },
+      qaStatus: 'pending-human-review',
+    });
+    expect(receipt.receiptSha256).toMatch(/^[a-f0-9]{64}$/u);
+    await expect(fs.readFile(path.join(input.outputRoot, 'pilot', 'receipt.json'))).resolves.toBeInstanceOf(Buffer);
+    expect(reviewGoogleFlowImport({
+      receipt,
+      expectedReceiptSha256: receipt.receiptSha256,
+      reviewer: 'Patrice',
+      reason: 'Identity and motion checked frame by frame',
+      checks: {
+        identity: true,
+        anatomy: true,
+        motion: true,
+        cleanEnd: true,
+        noSpeech: true,
+        noTextOrLogo: true,
+        safeContent: true,
+      },
+    })).toMatchObject({ status: 'approved-for-editing', autoPublish: false });
+  });
+
+  it('enforces an explicit minimum resolution and accepts a conforming result', async () => {
+    const tooSmall = await fixture();
+    await fs.writeFile(path.join(tooSmall.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    await expect(importGoogleFlowResults({
+      ...tooSmall,
+      minWidth: 1080,
+      minHeight: 1920,
+      normalize: async (source, destination) => fs.copyFile(source, destination),
+      probe: async () => ({
+        durationSeconds: 4, width: 720, height: 1280, hasVideo: true, hasAudio: false,
+      }),
+    })).rejects.toThrow('resolution');
+
+    const conforming = await fixture();
+    await fs.writeFile(path.join(conforming.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    await expect(importGoogleFlowResults({
+      ...conforming,
+      minWidth: 1080,
+      minHeight: 1920,
+      normalize: async (source, destination) => fs.copyFile(source, destination),
+      probe: async () => ({
+        durationSeconds: 4, width: 1080, height: 1920, hasVideo: true, hasAudio: false,
+      }),
+    })).resolves.toMatchObject({ jobs: [{ probe: { width: 1080, height: 1920 } }] });
+  });
+
+  it('preserves and re-encodes audio only when explicitly requested', async () => {
+    const input = await fixture();
+    await fs.writeFile(path.join(input.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    const args = buildNormalizeFlowResultArgs('/input.mp4', '/output.mp4', true);
+    expect(args).not.toContain('-an');
+    expect(args).toEqual(expect.arrayContaining(['-map', '0:a:0', '-c:a', 'aac']));
+
+    const receipt = await importGoogleFlowResults({
+      ...input,
+      preserveAudio: true,
+      normalize: async (source, destination) => fs.copyFile(source, destination),
+      probe: async () => ({
+        durationSeconds: 4,
+        width: 720,
+        height: 1280,
+        hasVideo: true,
+        hasAudio: true,
+        audioCodec: 'aac',
+        audioChannels: 2,
+        audioSampleRate: 48_000,
+      }),
+    });
+    expect(receipt).toMatchObject({
+      audioPolicy: 'preserved-on-import',
+      audioPreserved: true,
+      humanReviewRequired: true,
+      jobs: [{
+        audioPreserved: true,
+        probe: { hasAudio: true, audioCodec: 'aac', audioChannels: 2, audioSampleRate: 48_000 },
+        qaStatus: 'pending-human-review',
+      }],
+    });
+  });
+
+  it('rejects missing, disguised and symlinked results', async () => {
+    const missing = await fixture();
+    await expect(importGoogleFlowResults(missing)).rejects.toThrow();
+    const disguised = await fixture();
+    await fs.writeFile(path.join(disguised.resultsRoot, 'pilot-flow-01.mp4'), 'not-video');
+    await expect(importGoogleFlowResults(disguised)).rejects.toThrow('not an MP4');
+    const linked = await fixture();
+    const outside = path.join(linked.outputRoot, 'outside.mp4');
+    await fs.writeFile(outside, mp4());
+    await fs.symlink(outside, path.join(linked.resultsRoot, 'pilot-flow-01.mp4'));
+    await expect(importGoogleFlowResults(linked)).rejects.toThrow();
+  });
+
+  it('rejects modified handoffs, unexpected result files and stale review hashes', async () => {
+    const modified = await fixture();
+    await fs.writeFile(path.join(modified.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    modified.handoff.jobs[0]!.prompt = 'changed after handoff';
+    modified.handoffBytes = Buffer.from(JSON.stringify(modified.handoff));
+    await expect(importGoogleFlowResults(modified)).rejects.toThrow('modified');
+
+    const extra = await fixture();
+    await Promise.all([
+      fs.writeFile(path.join(extra.resultsRoot, 'pilot-flow-01.mp4'), mp4()),
+      fs.writeFile(path.join(extra.resultsRoot, 'unexpected.mp4'), mp4()),
+    ]);
+    await expect(importGoogleFlowResults(extra)).rejects.toThrow('exactly one MP4');
+
+    const review = await fixture();
+    await fs.writeFile(path.join(review.resultsRoot, 'pilot-flow-01.mp4'), mp4());
+    const receipt = await importGoogleFlowResults({
+      ...review,
+      normalize: async (source, destination) => fs.copyFile(source, destination),
+      probe: async (filename) => ({
+        durationSeconds: 4,
+        width: 720,
+        height: 1280,
+        hasVideo: true,
+        hasAudio: !filename.includes('-silent.mp4'),
+      }),
+    });
+    expect(() => reviewGoogleFlowImport({
+      receipt,
+      expectedReceiptSha256: '0'.repeat(64),
+      reviewer: 'Patrice',
+      reason: 'Full review completed',
+      checks: {
+        identity: true,
+        anatomy: true,
+        motion: true,
+        cleanEnd: true,
+        noSpeech: true,
+        noTextOrLogo: true,
+        safeContent: true,
+      },
+    })).toThrow('SHA-256');
+  });
+
+  it.skipIf(!FFMPEG)('removes a real audio track and reprobes the normalized MP4', async () => {
+    const input = await fixture();
+    const source = path.join(input.resultsRoot, 'pilot-flow-01.mp4');
+    await execFile('ffmpeg', [
+      '-v', 'error', '-y',
+      '-f', 'lavfi', '-i', 'color=c=blue:s=720x1280:r=30:d=4',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=4',
+      '-c:v', 'mpeg4', '-q:v', '8', '-c:a', 'aac', '-shortest', source,
+    ], { timeout: 30_000 });
+    const receipt = await importGoogleFlowResults(input);
+    expect(receipt.jobs[0]).toMatchObject({ sourceHadAudio: true, probe: { hasAudio: false } });
+    const imported = path.join(input.outputRoot, receipt.jobs[0]!.outputFile);
+    const { stdout } = await execFile('ffprobe', [
+      '-v', 'error', '-select_streams', 'a', '-show_entries', 'stream=codec_type', '-of', 'csv=p=0', imported,
+    ]);
+    expect(stdout.trim()).toBe('');
+  }, 30_000);
+});

--- a/tests/tools/video/hybrid-video-router.test.ts
+++ b/tests/tools/video/hybrid-video-router.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  routeHybridVideo,
+  routeHybridVideoBatch,
+  type HybridVideoCapacity,
+} from '../../../src/tools/video/hybrid-video-router.js';
+
+const capacity: HybridVideoCapacity = {
+  darkstar: true,
+  ministar: true,
+  googleFlow: true,
+  remainingFlowCredits: 25_000,
+  maxFlowCreditsPerBatch: 500,
+};
+
+describe('routeHybridVideo', () => {
+  it('routes lip sync to LongCat and premium safe shots to Veo Quality', () => {
+    expect(routeHybridVideo({
+      id: 'lisa-en-dialogue',
+      useCase: 'avatar-lipsync',
+      contentTier: 'safe',
+      quantity: 3,
+      requiresLipSync: true,
+      premium: false,
+    }, capacity)).toMatchObject({
+      primary: 'darkstar-longcat',
+      estimatedFlowCredits: 0,
+      executionMode: 'automatic-local',
+    });
+    expect(routeHybridVideo({
+      id: 'opening-hero',
+      useCase: 'hero-shot',
+      contentTier: 'safe',
+      quantity: 2,
+      requiresLipSync: false,
+      premium: true,
+    }, capacity)).toMatchObject({
+      primary: 'google-flow-veo31-quality',
+      estimatedFlowCredits: 200,
+      executionMode: 'browser-assisted',
+    });
+  });
+
+  it('keeps adult content local and falls back when a Flow batch is too costly', () => {
+    expect(routeHybridVideo({
+      id: 'private-variation',
+      useCase: 'bulk-variation',
+      contentTier: 'sensual',
+      quantity: 10,
+      requiresLipSync: false,
+      premium: false,
+    }, capacity).primary).toBe('darkstar-comfyui');
+    expect(routeHybridVideo({
+      id: 'too-many-heroes',
+      useCase: 'hero-shot',
+      contentTier: 'safe',
+      quantity: 6,
+      requiresLipSync: false,
+      premium: true,
+    }, capacity)).toMatchObject({
+      primary: 'darkstar-comfyui',
+      estimatedFlowCredits: 0,
+    });
+  });
+
+  it('decrements the batch credit ceiling between routes', () => {
+    const result = routeHybridVideoBatch([
+      {
+        id: 'quality-a',
+        useCase: 'hero-shot',
+        contentTier: 'safe',
+        quantity: 3,
+        requiresLipSync: false,
+        premium: true,
+      },
+      {
+        id: 'quality-b',
+        useCase: 'hero-shot',
+        contentTier: 'safe',
+        quantity: 3,
+        requiresLipSync: false,
+        premium: true,
+      },
+    ], capacity);
+    expect(result.estimatedFlowCredits).toBe(300);
+    expect(result.routes.map((route) => route.primary)).toEqual([
+      'google-flow-veo31-quality',
+      'darkstar-comfyui',
+    ]);
+  });
+});

--- a/tests/tools/video/localized-media.test.ts
+++ b/tests/tools/video/localized-media.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assessAudioFit,
+  buildWebVtt,
+  canonicalizeLocale,
+  formatWebVttTimestamp,
+  localePathSlug,
+  renderCacheKey,
+} from '../../../src/tools/video/localized-media.js';
+
+describe('localized media locale helpers', () => {
+  it('canonicalizes supported BCP-47 tags and creates stable path slugs', () => {
+    expect(canonicalizeLocale('en-us', ['fr-FR', 'en-US'])).toBe('en-US');
+    expect(localePathSlug('pt-BR')).toBe('pt-br');
+  });
+
+  it.each(['fr_FR', 'und', 'en-US-u-ca-gregory', 'x-private', ''])('rejects %j', (locale) => {
+    expect(() => canonicalizeLocale(locale)).toThrow('locale tag');
+  });
+
+  it('rejects a valid locale that is not enabled', () => {
+    expect(() => canonicalizeLocale('es-ES', ['fr-FR', 'en-US'])).toThrow('not enabled');
+  });
+});
+
+describe('assessAudioFit', () => {
+  const policy = {
+    slotDurationMs: 4_000,
+    leadInMs: 200,
+    tailOutMs: 200,
+    maxSpeedup: 1.08,
+  };
+
+  it('distinguishes padding, bounded speedup and overflow', () => {
+    expect(assessAudioFit(3_500, policy)).toEqual({
+      status: 'fits',
+      playbackRate: 1,
+      availableSpeechMs: 3_600,
+    });
+    expect(assessAudioFit(3_800, policy)).toMatchObject({ status: 'speedup', playbackRate: 1.0556 });
+    expect(assessAudioFit(4_500, policy)).toMatchObject({ status: 'overflow', overflowMs: 612 });
+  });
+});
+
+describe('WebVTT', () => {
+  it('formats millisecond timestamps and Unicode cues', () => {
+    expect(formatWebVttTimestamp(3_723)).toBe('00:00:03.723');
+    expect(
+      buildWebVtt(
+        [
+          { id: 'shot-01', startMs: 200, endMs: 3_200, text: 'Ça commence <ici>.' },
+          { id: 'shot-02', startMs: 3_220, endMs: 6_000, text: 'Et ensuite --> demain.' },
+        ],
+        6_100,
+      ),
+    ).toBe(
+      'WEBVTT\n\nshot-01\n00:00:00.200 --> 00:00:03.200\nÇa commence &lt;ici&gt;.\n\n' +
+        'shot-02\n00:00:03.220 --> 00:00:06.000\nEt ensuite --&gt; demain.\n',
+    );
+  });
+
+  it('rejects overlaps, out-of-range cues and NUL bytes', () => {
+    expect(() =>
+      buildWebVtt(
+        [
+          { startMs: 0, endMs: 1_000, text: 'one' },
+          { startMs: 999, endMs: 1_500, text: 'two' },
+        ],
+        2_000,
+      ),
+    ).toThrow('overlaps');
+    expect(() => buildWebVtt([{ startMs: 0, endMs: 2_001, text: 'x' }], 2_000)).toThrow('Invalid');
+    expect(() => buildWebVtt([{ startMs: 0, endMs: 1, text: '\0' }], 2_000)).toThrow('NUL');
+  });
+});
+
+describe('renderCacheKey', () => {
+  const base = {
+    rendererVersion: 'youtube-short-v2',
+    sourceSha256: 'a'.repeat(64),
+    motionPrompt: 'natural blink',
+    locale: 'en-US',
+    voiceProfileId: 'lisa-en-v1',
+    voiceProfileRevision: 'rights-revision-1',
+    voiceLine: 'Hello',
+    clipDurationMs: 3_720,
+    visualSpeechMode: 'localized-lipsync' as const,
+  };
+
+  it('is deterministic and invalidates on locale, voice or text changes', () => {
+    const key = renderCacheKey(base);
+    expect(renderCacheKey(base)).toBe(key);
+    expect(renderCacheKey({ ...base, locale: 'fr-FR' })).not.toBe(key);
+    expect(renderCacheKey({ ...base, voiceProfileId: 'lisa-en-v2' })).not.toBe(key);
+    expect(renderCacheKey({ ...base, voiceProfileRevision: 'rights-revision-2' })).not.toBe(key);
+    expect(renderCacheKey({ ...base, voiceLine: 'Hi' })).not.toBe(key);
+  });
+});

--- a/tests/tools/video/long-form-plan.test.ts
+++ b/tests/tools/video/long-form-plan.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assessLongFormPlan,
+  type LongFormEpisodePlan,
+} from '../../../src/tools/video/long-form-plan.js';
+
+function plan(): LongFormEpisodePlan {
+  const words = Array.from({ length: 26 }, (_, index) => `word${index}`).join(' ');
+  return {
+    schemaVersion: 1,
+    episodeId: 'why-humans-keep-imperfect-photos',
+    locale: 'en-US',
+    title: 'Why we keep imperfect photos',
+    description: 'An original chaptered story about memory and imperfect images.',
+    chapters: Array.from({ length: 5 }, (_, chapterIndex) => ({
+      id: `chapter-${chapterIndex + 1}`,
+      title: `Chapter ${chapterIndex + 1}`,
+      scenes: Array.from({ length: 5 }, (_, sceneIndex) => ({
+        id: `chapter-${chapterIndex + 1}-scene-${sceneIndex + 1}`,
+        durationSeconds: 20,
+        narration: `${words} chapter ${chapterIndex} scene ${sceneIndex}`,
+        visualPrompt: `unique cinematic setting ${chapterIndex}-${sceneIndex}, distinct action and composition`,
+      })),
+    })),
+    publication: {
+      visibility: 'private',
+      autoPublish: false,
+      madeForKids: false,
+      containsSyntheticMedia: true,
+      humanReviewRequired: true,
+    },
+  };
+}
+
+describe('assessLongFormPlan', () => {
+  it('accepts an original eight-minute chaptered episode and proposes natural ad breaks', () => {
+    expect(assessLongFormPlan(plan())).toEqual({
+      ready: true,
+      durationSeconds: 500,
+      narrationWords: 750,
+      uniqueVisualRatio: 1,
+      midRollEligible: true,
+      suggestedAdBreakSeconds: [200, 400],
+      failures: [],
+    });
+  });
+
+  it('rejects a short repetitive mass-produced plan and unsafe publication', () => {
+    const value = plan();
+    value.chapters = value.chapters.slice(0, 2);
+    for (const chapter of value.chapters) {
+      for (const scene of chapter.scenes) {
+        scene.durationSeconds = 5;
+        scene.narration = 'same words';
+        scene.visualPrompt = 'same template';
+      }
+    }
+    value.publication.visibility = 'public' as 'private';
+    const assessment = assessLongFormPlan(value);
+    expect(assessment.ready).toBe(false);
+    expect(assessment.midRollEligible).toBe(false);
+    expect(assessment.failures).toEqual(expect.arrayContaining([
+      'insufficient-chapters',
+      'shorter-than-eight-minutes',
+      'insufficient-visual-scenes',
+      'insufficient-original-narration',
+      'repetitive-visual-plan',
+      'unsafe-publication-gate',
+    ]));
+  });
+});

--- a/tests/tools/video/long-form-production.test.ts
+++ b/tests/tools/video/long-form-production.test.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assembleLongFormMaster, compileLongFormRenderPacket, reviewLongFormMaster } from '../../../src/tools/video/long-form-production.js';
+import type { LongFormEpisodePlan } from '../../../src/tools/video/long-form-plan.js';
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
+
+function plan(): LongFormEpisodePlan {
+  const narration = Array.from({ length: 26 }, (_, index) => `word${index}`).join(' ');
+  return {
+    schemaVersion: 1, episodeId: 'episode-original', locale: 'fr-FR', title: 'Une histoire originale',
+    description: 'Une histoire longue, originale et structurée en chapitres.',
+    chapters: Array.from({ length: 5 }, (_, chapter) => ({
+      id: `chapter-${chapter}`, title: `Chapitre ${chapter}`,
+      scenes: Array.from({ length: 5 }, (_, scene) => ({ id: `c${chapter}-s${scene}`, durationSeconds: 20,
+        narration: `${narration} chapitre ${chapter} scene ${scene}`, visualPrompt: `composition unique ${chapter}-${scene}` })),
+    })),
+    publication: { visibility: 'private', autoPublish: false, madeForKids: false, containsSyntheticMedia: true, humanReviewRequired: true },
+  };
+}
+
+describe('long-form production', () => {
+  it('compiles an immutable 25-scene render packet', () => {
+    const packet = compileLongFormRenderPacket(plan());
+    expect(packet.scenes).toHaveLength(25);
+    expect(packet.scenes.filter((scene) => scene.role === 'chapter-hero')).toHaveLength(5);
+    expect(packet.publication).toEqual({ visibility: 'private', autoPublish: false, humanReviewRequired: true });
+  });
+
+  it('assembles only the exact regular scene files into a private immutable master', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'long-form-'));
+    roots.push(root);
+    const clips = path.join(root, 'clips'); await fs.mkdir(clips);
+    for (const scene of compileLongFormRenderPacket(plan()).scenes) await fs.writeFile(path.join(clips, scene.expectedFilename), Buffer.alloc(2048, 1));
+    const packet = compileLongFormRenderPacket(plan());
+    const output = path.join(root, '.codebuddy', 'media-generation', 'films', 'long-form', 'episode-original', `${packet.planSha256}.mp4`);
+    await fs.mkdir(path.dirname(output), { recursive: true }); await fs.writeFile(output, Buffer.alloc(2048, 2));
+    const assembler = vi.fn(async () => ({ kind: 'film_assemble_result' as const, success: true, outputPath: output,
+      engine: 'xfade' as const, clipCount: 25, transitionCount: 24, targetWidth: 1920, targetHeight: 1080, fps: 30,
+      estimatedDuration: 500, probedDuration: 500, hasAudio: true, transitions: [], warnings: [] }));
+    const result = await assembleLongFormMaster({ plan: plan(), clipsRoot: clips, projectRoot: root, assembler });
+    expect(result.outputPath).toBe(output);
+    expect(JSON.parse(await fs.readFile(result.metadataPath, 'utf8'))).toMatchObject({ visibility: 'private', autoPublish: false });
+    await expect(reviewLongFormMaster({
+      videoPath: output, reviewer: 'Patrice', reason: 'Episode watched from start to finish',
+      checks: { voice: true, identity: true, anatomy: true, captions: true, disclosure: true, chapters: true, editorial: true },
+    })).resolves.toMatchObject({ status: 'ready-for-private-upload', autoPublish: false });
+  });
+});

--- a/tests/tools/video/long-form-production.test.ts
+++ b/tests/tools/video/long-form-production.test.ts
@@ -32,7 +32,7 @@ describe('long-form production', () => {
   });
 
   it('assembles only the exact regular scene files into a private immutable master', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'long-form-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'long-form-')));
     roots.push(root);
     const clips = path.join(root, 'clips'); await fs.mkdir(clips);
     for (const scene of compileLongFormRenderPacket(plan()).scenes) await fs.writeFile(path.join(clips, scene.expectedFilename), Buffer.alloc(2048, 1));

--- a/tests/tools/video/native-fashion-defects.test.ts
+++ b/tests/tools/video/native-fashion-defects.test.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  appendRetryReceipt,
+  assertBatchBounded,
+  classifyDefects,
+  NATIVE_FASHION_CAUSAL_ADJUSTMENTS,
+  type GateResult,
+  type NativeFashionGate,
+  type RetryReceipt,
+} from '../../../src/tools/video/native-fashion-defects.js';
+
+const roots: string[] = [];
+const gates: NativeFashionGate[] = [
+  'identity',
+  'anatomy',
+  'temporal-stability',
+  'outfit',
+  'decor-framing',
+  'master-properties',
+];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+function receipt(overrides: Partial<RetryReceipt> = {}): RetryReceipt {
+  return {
+    attempt: 1,
+    batchId: 'fashion-pilot-batch-01',
+    sceneId: 'pilot-black-dress-turn',
+    candidateSha256: 'a'.repeat(64),
+    seed: 42,
+    adjustedParameters: [],
+    failedGates: ['identity'],
+    verdict: 'rejected',
+    at: '2026-07-20T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('native fashion defects and retry receipts', () => {
+  it('classifies every failed gate with its deterministic causal adjustment', () => {
+    const results: GateResult[] = gates.map((gate) => ({ gate, pass: false, evidence: `${gate} failed` }));
+    expect(classifyDefects(results)).toEqual(gates.map((gate) => ({
+      gate,
+      causalAdjustment: NATIVE_FASHION_CAUSAL_ADJUSTMENTS[gate],
+    })));
+    expect(classifyDefects(results.map((result) => ({ ...result, pass: true })))).toEqual([]);
+    expect(Object.values(NATIVE_FASHION_CAUSAL_ADJUSTMENTS).join(' ')).not.toMatch(/retry identical/iu);
+  });
+
+  it('appends valid receipts as JSONL without replacing earlier entries', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    roots.push(root);
+    const journalPath = path.join(root, 'retry.jsonl');
+    await appendRetryReceipt(journalPath, receipt());
+    await appendRetryReceipt(journalPath, receipt({
+      attempt: 2,
+      adjustedParameters: ['strengthen identity LoRA and face conditioning'],
+      candidateSha256: 'b'.repeat(64),
+    }));
+    const lines = (await fs.readFile(journalPath, 'utf8')).trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] ?? '{}')).toMatchObject({ attempt: 1, candidateSha256: 'a'.repeat(64) });
+    expect(JSON.parse(lines[1] ?? '{}')).toMatchObject({ attempt: 2, candidateSha256: 'b'.repeat(64) });
+  });
+
+  it('refuses an identical retry after the first attempt', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    roots.push(root);
+    await expect(appendRetryReceipt(path.join(root, 'retry.jsonl'), receipt({ attempt: 2 })))
+      .rejects.toThrow('identical retry');
+  });
+
+  it('refuses promotion while any blocking gate has failed', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    roots.push(root);
+    await expect(appendRetryReceipt(path.join(root, 'retry.jsonl'), receipt({
+      failedGates: ['outfit'],
+      verdict: 'promoted-to-human-review',
+    }))).rejects.toThrow('cannot be promoted');
+  });
+
+  it('requires the exhaustion verdict when the batch reaches its bound', () => {
+    expect(() => assertBatchBounded([
+      receipt({ attempt: 2, adjustedParameters: ['change seed'] }),
+      receipt({ attempt: 3, adjustedParameters: ['change temporal engine'], verdict: 'rejected' }),
+    ], 3)).toThrow('batch-exhausted');
+    expect(() => assertBatchBounded([
+      receipt({ attempt: 3, adjustedParameters: ['change temporal engine'], verdict: 'batch-exhausted' }),
+    ], 3)).not.toThrow();
+    expect(() => assertBatchBounded([
+      receipt({
+        attempt: 4,
+        adjustedParameters: ['record terminal diagnostic'],
+        failedGates: [],
+        verdict: 'promoted-to-human-review',
+      }),
+    ], 3)).toThrow('batch-exhausted');
+  });
+});

--- a/tests/tools/video/native-fashion-defects.test.ts
+++ b/tests/tools/video/native-fashion-defects.test.ts
@@ -54,7 +54,7 @@ describe('native fashion defects and retry receipts', () => {
   });
 
   it('appends valid receipts as JSONL without replacing earlier entries', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-')));
     roots.push(root);
     const journalPath = path.join(root, 'retry.jsonl');
     await appendRetryReceipt(journalPath, receipt());
@@ -70,14 +70,14 @@ describe('native fashion defects and retry receipts', () => {
   });
 
   it('refuses an identical retry after the first attempt', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-')));
     roots.push(root);
     await expect(appendRetryReceipt(path.join(root, 'retry.jsonl'), receipt({ attempt: 2 })))
       .rejects.toThrow('identical retry');
   });
 
   it('refuses promotion while any blocking gate has failed', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'native-fashion-retries-')));
     roots.push(root);
     await expect(appendRetryReceipt(path.join(root, 'retry.jsonl'), receipt({
       failedGates: ['outfit'],

--- a/tests/tools/video/visual-gate-report.test.ts
+++ b/tests/tools/video/visual-gate-report.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  assertReportMatchesClip,
+  evaluateVisualGates,
+  loadAndEvaluateVisualGateReport,
+  parseVisualGateReport,
+  type VisualGateReport,
+} from '../../../src/tools/video/visual-gate-report.js';
+
+const roots: string[] = [];
+const clipSha256 = 'a'.repeat(64);
+
+function validReport(): VisualGateReport {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-07-20T12:34:56.000Z',
+    clipSha256,
+    profile: 'native-fashion-v1',
+    sampleFps: 6,
+    metrics: {
+      identity: {
+        evaluatedFrameCount: 6,
+        detectedFaceCount: 6,
+        minSimilarity: 0.52,
+        meanSimilarity: 0.61,
+        stdDevSimilarity: 0.03,
+        lowSimilarityFrames: [],
+        noFace: [],
+      },
+      anatomy: {
+        evaluatedFrameCount: 6,
+        suspectFrameCount: 0,
+        suspiciousFrames: [],
+        teleportationFrames: [],
+      },
+      temporalStability: {
+        framePairCount: 359,
+        globalFlickerMean: 4.2,
+        thirdsFlickerMean: { top: 4.1, middle: 4.5, bottom: 5.2 },
+        exposureJitterVariance: 18,
+        localWarpGradientMean: 11,
+      },
+      sharpness: {
+        evaluatedFrameCount: 6,
+        minLaplacianVariance: 180,
+        meanLaplacianVariance: 260,
+        lowSharpnessFrames: [],
+      },
+      masterProperties: {
+        width: 1080,
+        height: 1920,
+        fps: 30,
+        durationSeconds: 12,
+        videoBitrateKbps: 15_000,
+        videoCodec: 'h264',
+        audioCodec: 'aac',
+        hasAudio: true,
+        nearBlackFrameRatio: 0.01,
+      },
+      loop: {
+        normalizedAbsoluteDifference: 0.05,
+        histogramCorrelation: 0.96,
+      },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('visual gate report schema', () => {
+  it('strictly parses a valid schema V1 report', () => {
+    expect(parseVisualGateReport(validReport())).toEqual(validReport());
+  });
+
+  it('rejects altered, unknown-version and incomplete reports', () => {
+    const altered = { ...validReport(), unexpected: true };
+    expect(() => parseVisualGateReport(altered)).toThrow('expected exactly');
+    expect(() => parseVisualGateReport({ ...validReport(), schemaVersion: 2 })).toThrow('schemaVersion');
+
+    const incomplete: Record<string, unknown> = structuredClone(validReport());
+    const metrics = incomplete.metrics as Record<string, unknown>;
+    const identity = metrics.identity as Record<string, unknown>;
+    delete identity.meanSimilarity;
+    expect(() => parseVisualGateReport(incomplete)).toThrow('metrics.identity');
+  });
+
+  it('fails closed when the report digest is absent or targets other clip bytes', () => {
+    expect(() => assertReportMatchesClip(validReport(), 'b'.repeat(64))).toThrow('mismatch');
+    expect(() => assertReportMatchesClip({ ...validReport(), clipSha256: null }, clipSha256))
+      .toThrow('cannot authorize');
+  });
+});
+
+describe('visual gate evaluation', () => {
+  it('passes every gate only with green measurements and explicit human confirmations', () => {
+    const results = evaluateVisualGates(validReport(), 'native-fashion-v1', {
+      outfit: true,
+      decorFraming: true,
+    });
+    expect(results).toHaveLength(6);
+    expect(results.every((result) => result.pass)).toBe(true);
+  });
+
+  it('fails unmeasured gates by default and passes only explicit confirmations', () => {
+    const unconfirmed = evaluateVisualGates(validReport(), 'native-fashion-v1');
+    expect(unconfirmed.find((result) => result.gate === 'outfit')).toEqual({
+      gate: 'outfit',
+      pass: false,
+      evidence: 'not-measured — human review required',
+    });
+    expect(unconfirmed.find((result) => result.gate === 'decor-framing')?.pass).toBe(false);
+
+    const outfitOnly = evaluateVisualGates(validReport(), 'native-fashion-v1', { outfit: true });
+    expect(outfitOnly.find((result) => result.gate === 'outfit')?.pass).toBe(true);
+    expect(outfitOnly.find((result) => result.gate === 'decor-framing')?.pass).toBe(false);
+  });
+
+  it('fails identity and names the incriminated frame', () => {
+    const report = validReport();
+    report.metrics.identity.minSimilarity = 0.2;
+    report.metrics.identity.lowSimilarityFrames = [{ frameIndex: 42, timestampSeconds: 1.4, similarity: 0.2 }];
+    const result = evaluateVisualGates(report, 'native-fashion-v1').find((gate) => gate.gate === 'identity');
+    expect(result).toMatchObject({ pass: false });
+    expect(result?.evidence).toContain('42');
+  });
+
+  it('fails anatomy and names teleporting frames', () => {
+    const report = validReport();
+    report.metrics.anatomy.suspectFrameCount = 1;
+    report.metrics.anatomy.suspiciousFrames = [{
+      frameIndex: 84,
+      timestampSeconds: 2.8,
+      lowVisibilityLandmarkCount: 0,
+      detectedHandFingerCounts: [5, 5],
+      implausibleFingerCounts: [],
+      teleportation: true,
+    }];
+    report.metrics.anatomy.teleportationFrames = [{
+      frameIndex: 84,
+      timestampSeconds: 2.8,
+      landmarkIndices: [15],
+      maxNormalizedDelta: 0.31,
+    }];
+    const result = evaluateVisualGates(report, 'native-fashion-v1').find((gate) => gate.gate === 'anatomy');
+    expect(result).toMatchObject({ pass: false });
+    expect(result?.evidence).toContain('84');
+  });
+
+  it('fails temporal stability independently', () => {
+    const report = validReport();
+    report.metrics.temporalStability.exposureJitterVariance = 101;
+    expect(evaluateVisualGates(report, 'native-fashion-v1')
+      .find((gate) => gate.gate === 'temporal-stability')).toMatchObject({ pass: false });
+  });
+
+  it.each([
+    ['sharpness', (report: VisualGateReport) => {
+      report.metrics.sharpness.minLaplacianVariance = 80;
+      report.metrics.sharpness.lowSharpnessFrames = [{
+        frameIndex: 126,
+        timestampSeconds: 4.2,
+        laplacianVariance: 80,
+      }];
+    }, '126'],
+    ['bitrate', (report: VisualGateReport) => { report.metrics.masterProperties.videoBitrateKbps = 11_999; }, '11999'],
+    ['loop', (report: VisualGateReport) => { report.metrics.loop = null; }, 'not-measured'],
+  ] as const)('fails master-properties for %s', (_case, alter, evidence) => {
+    const report = validReport();
+    alter(report);
+    const result = evaluateVisualGates(report, 'native-fashion-v1')
+      .find((gate) => gate.gate === 'master-properties');
+    expect(result).toMatchObject({ pass: false });
+    expect(result?.evidence).toContain(evidence);
+  });
+
+  it('rejects evaluation under a profile different from the report', () => {
+    expect(() => evaluateVisualGates({ ...validReport(), profile: 'legacy-localized-v1' }, 'native-fashion-v1'))
+      .toThrow('profile mismatch');
+  });
+});
+
+describe('visual gate report loader', () => {
+  it('loads, binds, evaluates and hashes the exact report bytes', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'visual-gate-report-'));
+    roots.push(root);
+    const reportPath = path.join(root, 'report.json');
+    const bytes = Buffer.from(`${JSON.stringify(validReport(), null, 2)}\n`);
+    await fs.writeFile(reportPath, bytes);
+
+    const evaluated = await loadAndEvaluateVisualGateReport(
+      reportPath,
+      clipSha256,
+      'native-fashion-v1',
+      { outfit: true, decorFraming: true },
+    );
+
+    expect(evaluated.report.clipSha256).toBe(clipSha256);
+    expect(evaluated.gateResults.every((result) => result.pass)).toBe(true);
+    expect(evaluated.reportSha256).toBe(createHash('sha256').update(bytes).digest('hex'));
+  });
+});

--- a/tests/tools/video/visual-gate-report.test.ts
+++ b/tests/tools/video/visual-gate-report.test.ts
@@ -188,7 +188,7 @@ describe('visual gate evaluation', () => {
 
 describe('visual gate report loader', () => {
   it('loads, binds, evaluates and hashes the exact report bytes', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'visual-gate-report-'));
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'visual-gate-report-')));
     roots.push(root);
     const reportPath = path.join(root, 'report.json');
     const bytes = Buffer.from(`${JSON.stringify(validReport(), null, 2)}\n`);

--- a/tests/tools/video/voice-rights-registry.test.ts
+++ b/tests/tools/video/voice-rights-registry.test.ts
@@ -1,0 +1,58 @@
+import { createHash } from 'crypto';
+import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadVoiceRightsRegistry, voiceProfileRevision } from '../../../src/tools/video/voice-rights-registry.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(overrides: Record<string, unknown> = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'voice-rights-'));
+  roots.push(root);
+  const evidencePath = path.join(root, 'license.txt');
+  await writeFile(evidencePath, 'reviewed license evidence', { mode: 0o600 });
+  const evidenceSha256 = createHash('sha256').update(await readFile(evidencePath)).digest('hex');
+  const profile = {
+    id: 'lisa-fr-pocket-v1', locale: 'fr-FR', provider: 'pocket', voice: 'estelle', language: 'french',
+    status: 'approved', revoked: false, scopes: ['commercial-youtube'], reviewer: 'Patrice',
+    reviewedAt: '2026-07-18T12:00:00.000Z',
+    provenance: { ref: 'license/lisa-fr-v1', evidencePath, evidenceSha256 },
+    ...overrides,
+  };
+  const registryPath = path.join(root, 'registry.json');
+  await writeFile(registryPath, JSON.stringify({ schemaVersion: 2, profiles: [profile] }), { mode: 0o600 });
+  await chmod(registryPath, 0o600);
+  return { root, registryPath, evidencePath };
+}
+
+describe('voice rights registry V2', () => {
+  it('derives an approved runtime profile from reviewed evidence', async () => {
+    const { registryPath } = await fixture();
+    const profiles = await loadVoiceRightsRegistry(registryPath, 'commercial-youtube', new Date('2026-07-19'));
+    const profile = profiles.get('lisa-fr-pocket-v1')!;
+    expect(profile).toMatchObject({ commercialUseApproved: true, provenanceRef: 'license/lisa-fr-v1' });
+    expect(voiceProfileRevision(profile)).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it('rejects pending, expired and modified evidence', async () => {
+    await expect(loadVoiceRightsRegistry((await fixture({ status: 'pending' })).registryPath)).rejects.toThrow('not approved');
+    await expect(loadVoiceRightsRegistry((await fixture({ expiresAt: '2026-01-01T00:00:00.000Z' })).registryPath))
+      .rejects.toThrow('expired');
+    const changed = await fixture();
+    await writeFile(changed.evidencePath, 'changed evidence', { mode: 0o600 });
+    await expect(loadVoiceRightsRegistry(changed.registryPath)).rejects.toThrow('digest mismatch');
+  });
+
+  it('rejects a symlinked registry even when its target is private', async () => {
+    const { root, registryPath } = await fixture();
+    const linked = path.join(root, 'linked.json');
+    await symlink(registryPath, linked);
+    await expect(loadVoiceRightsRegistry(linked)).rejects.toThrow('non-symlink');
+  });
+});

--- a/tests/tools/video/voice-rights-registry.test.ts
+++ b/tests/tools/video/voice-rights-registry.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from 'fs/promises';
+import { chmod, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -13,7 +13,7 @@ afterEach(async () => {
 });
 
 async function fixture(overrides: Record<string, unknown> = {}) {
-  const root = await mkdtemp(path.join(tmpdir(), 'voice-rights-'));
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), 'voice-rights-')));
   roots.push(root);
   const evidencePath = path.join(root, 'license.txt');
   await writeFile(evidencePath, 'reviewed license evidence', { mode: 0o600 });

--- a/tests/tools/video/youtube-master-quality.test.ts
+++ b/tests/tools/video/youtube-master-quality.test.ts
@@ -1,0 +1,370 @@
+import { createHash } from 'crypto';
+import { execFile as rawExecFile, spawnSync } from 'child_process';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createPrivateYouTubeBundle,
+  requestYouTubeMasterChanges,
+  reviewYouTubeMaster,
+  validateYouTubeMasterBundle,
+} from '../../../src/tools/video/youtube-master-quality.js';
+
+const roots: string[] = [];
+const execFile = promisify(rawExecFile);
+const ffmpegEncoders = spawnSync('ffmpeg', ['-hide_banner', '-encoders'], { encoding: 'utf8' });
+const REAL_MEDIA = ffmpegEncoders.status === 0 && /\blibx264\b/u.test(ffmpegEncoders.stdout ?? '') &&
+  spawnSync('ffprobe', ['-version'], { stdio: 'ignore' }).status === 0;
+afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-master-'));
+  roots.push(root);
+  const videoPath = path.join(root, 'pilot.mp4');
+  const captionPath = `${videoPath}.fr-FR.vtt`;
+  await fs.writeFile(videoPath, 'synthetic private master');
+  await fs.writeFile(captionPath, 'WEBVTT\n\n00:00:00.100 --> 00:00:10.000\nBonjour\n');
+  const sha = async (filename: string) => createHash('sha256').update(await fs.readFile(filename)).digest('hex');
+  await fs.writeFile(`${videoPath}.youtube.json`, JSON.stringify({
+    schemaVersion: 3, autoPublish: false, humanReviewRequired: true, containsSyntheticMedia: true,
+    qualityProfile: { id: 'legacy-localized-v1', version: 1 },
+    video: { file: path.basename(videoPath), durationMs: 10_160, sha256: await sha(videoPath) },
+    captionTracks: [{ file: path.basename(captionPath), sha256: await sha(captionPath) }],
+    youtube: {
+      snippet: {
+        title: 'Une histoire originale avec Lisa',
+        description: 'Une micro-histoire originale préparée pour une revue privée.',
+      },
+      status: { privacyStatus: 'private', selfDeclaredMadeForKids: false },
+    },
+    narrationRights: {
+      commercialUseApproved: true,
+      provenanceRef: 'voice-rights/lisa-fr-v2',
+      profileRevision: 'a'.repeat(64),
+    },
+    sourceClips: [1, 2, 3].map((index) => ({
+      file: `clip-${index}.mp4`,
+      sha256: String(index).repeat(64),
+      width: 544,
+      height: 704,
+      fps: 25,
+      durationMs: 3_720,
+      generationMode: 'legacy',
+      upscaled: true,
+    })),
+  }));
+  return videoPath;
+}
+
+const passingProbe = async () => ({
+  duration: 10.16,
+  width: 720,
+  height: 1280,
+  fps: 30,
+  videoCodec: 'h264',
+  audioCodec: 'aac',
+  hasAudio: true,
+});
+
+const passingSignals = async () => ({ meanVolumeDb: -20, maxVolumeDb: -0.5, blackSeconds: 0.2 });
+
+describe('YouTube master quality gate', () => {
+  it('requires technical approval before a complete digest-bound human review', async () => {
+    const videoPath = await fixture();
+    const report = await validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+    });
+    const checks = { voice: true, lipSync: true, identity: true, anatomy: true, captions: true, disclosure: true, editorial: true };
+    await expect(reviewYouTubeMaster({ report, expectedVideoSha256: report.videoSha256, reviewer: 'Patrice', reason: 'Master vérifié.', checks }))
+      .resolves.toMatchObject({ status: 'ready-for-private-upload', visibility: 'private', autoPublish: false });
+  });
+
+  it('rejects invalid probes and incomplete human checks', async () => {
+    const videoPath = await fixture();
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: async () => ({ duration: 10.16, width: 1920, height: 1080, fps: 30, videoCodec: 'h264', audioCodec: 'aac', hasAudio: true }),
+      analyze: passingSignals,
+    })).rejects.toThrow('failed');
+    const report = await validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+    });
+    await expect(reviewYouTubeMaster({
+      report, expectedVideoSha256: report.videoSha256, reviewer: 'Patrice', reason: 'À revoir.',
+      checks: { voice: false, lipSync: true, identity: true, anatomy: true, captions: true, disclosure: true, editorial: true },
+    })).rejects.toThrow('Every');
+  });
+
+  it('accepts the native fashion profile only with a native 1080x1920 source', async () => {
+    const videoPath = await fixture();
+    const sidecarPath = `${videoPath}.youtube.json`;
+    const sidecar = JSON.parse(await fs.readFile(sidecarPath, 'utf8')) as Record<string, unknown>;
+    sidecar.qualityProfile = { id: 'native-fashion-v1', version: 2 };
+    sidecar.video = { ...(sidecar.video as object), durationMs: 12_000 };
+    sidecar.sourceClips = [{
+      file: 'fashion-native.mp4',
+      sha256: 'f'.repeat(64),
+      width: 1288,
+      height: 1920,
+      fps: 30,
+      durationMs: 12_000,
+      generationMode: 'native',
+      upscaled: false,
+    }];
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    const nativeProbe = async () => ({
+      duration: 12,
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      hasAudio: true,
+      videoBitrateKbps: 16_000,
+    });
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: nativeProbe,
+      analyze: passingSignals,
+    })).resolves.toMatchObject({
+      schemaVersion: 4,
+      qualityProfile: { id: 'native-fashion-v1', version: 2 },
+      probe: { width: 1080, height: 1920, fps: 30, videoBitrateKbps: 16_000 },
+    });
+
+    (sidecar.sourceClips as Array<Record<string, unknown>>)[0]!.width = 720;
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: nativeProbe,
+      analyze: passingSignals,
+    })).rejects.toThrow('native-source');
+  });
+
+  it('rejects a fake native receipt, simple upscale and loose fashion duration', async () => {
+    const videoPath = await fixture();
+    const sidecarPath = `${videoPath}.youtube.json`;
+    const sidecar = JSON.parse(await fs.readFile(sidecarPath, 'utf8')) as Record<string, unknown>;
+    sidecar.qualityProfile = { id: 'native-fashion-v1', version: 2 };
+    sidecar.video = { ...(sidecar.video as object), durationMs: 12_000 };
+    sidecar.sourceClips = [{
+      file: 'fashion-upscaled.mp4', sha256: 'e'.repeat(64), width: 1080, height: 1920,
+      fps: 30, durationMs: 12_000, generationMode: 'native', upscaled: true,
+    }];
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: async () => ({
+        duration: 12, width: 1080, height: 1920, fps: 30,
+        videoCodec: 'h264', audioCodec: 'aac', hasAudio: true,
+        videoBitrateKbps: 16_000,
+      }),
+      analyze: passingSignals,
+    })).rejects.toThrow('native-source');
+
+    (sidecar.sourceClips as Array<Record<string, unknown>>)[0]!.upscaled = false;
+    sidecar.video = { ...(sidecar.video as object), durationMs: 14_000 };
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: async () => ({
+        duration: 14, width: 1080, height: 1920, fps: 30,
+        videoCodec: 'h264', audioCodec: 'aac', hasAudio: true,
+        videoBitrateKbps: 16_000,
+      }),
+      analyze: passingSignals,
+    })).rejects.toThrow('duration');
+  });
+
+  it('rejects native masters outside 12–20 Mb/s and reports an in-range bitrate', async () => {
+    const videoPath = await fixture();
+    const sidecarPath = `${videoPath}.youtube.json`;
+    const sidecar = JSON.parse(await fs.readFile(sidecarPath, 'utf8')) as Record<string, unknown>;
+    sidecar.qualityProfile = { id: 'native-fashion-v1', version: 2 };
+    sidecar.video = { ...(sidecar.video as object), durationMs: 12_000 };
+    sidecar.sourceClips = [{
+      file: 'fashion-native.mp4', sha256: 'f'.repeat(64), width: 1080, height: 1920,
+      fps: 30, durationMs: 12_000, generationMode: 'native', upscaled: false,
+    }];
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    const probe = (videoBitrateKbps: number) => async () => ({
+      duration: 12,
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      hasAudio: true,
+      videoBitrateKbps,
+    });
+
+    await expect(validateYouTubeMasterBundle({
+      videoPath, probe: probe(11_999), analyze: passingSignals,
+    })).rejects.toThrow('bitrate');
+    await expect(validateYouTubeMasterBundle({
+      videoPath, probe: probe(20_001), analyze: passingSignals,
+    })).rejects.toThrow('bitrate');
+    await expect(validateYouTubeMasterBundle({
+      videoPath, probe: probe(15_500), analyze: passingSignals,
+    })).resolves.toMatchObject({
+      schemaVersion: 4,
+      qualityProfile: { id: 'native-fashion-v1', version: 2 },
+      probe: { videoBitrateKbps: 15_500 },
+    });
+  });
+
+  it('keeps the legacy profile valid without bitrate bounds', async () => {
+    const videoPath = await fixture();
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+    })).resolves.toMatchObject({
+      qualityProfile: { id: 'legacy-localized-v1', version: 1 },
+      probe: { hasAudio: true },
+    });
+  });
+
+  it('records digest-bound change requests without granting upload readiness', async () => {
+    const videoPath = await fixture();
+    const report = await validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+    });
+    const checks = {
+      voice: true,
+      lipSync: true,
+      identity: false,
+      anatomy: true,
+      captions: true,
+      disclosure: true,
+      editorial: false,
+    };
+    await expect(requestYouTubeMasterChanges({
+      report,
+      expectedVideoSha256: report.videoSha256,
+      reviewer: 'Codex visual QA',
+      reason: 'Continuité visuelle et cohérence éditoriale à corriger.',
+      checks,
+      now: () => new Date('2026-07-19T08:35:00Z'),
+    })).resolves.toMatchObject({
+      status: 'changes-requested',
+      visibility: 'blocked',
+      autoPublish: false,
+      checks: { identity: false, editorial: false },
+    });
+    await expect(requestYouTubeMasterChanges({
+      report,
+      expectedVideoSha256: report.videoSha256,
+      reviewer: 'Codex visual QA',
+      reason: 'Aucune correction.',
+      checks: { ...checks, identity: true, editorial: true },
+    })).rejects.toThrow('at least one failed');
+  });
+
+  it('rejects silence, excessive black frames and incomplete source provenance', async () => {
+    const videoPath = await fixture();
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: async () => ({ meanVolumeDb: -80, maxVolumeDb: -1, blackSeconds: 2 }),
+    })).rejects.toThrow('audio or black-frame');
+
+    const sidecarPath = `${videoPath}.youtube.json`;
+    const sidecar = JSON.parse(await fs.readFile(sidecarPath, 'utf8')) as { sourceClips: unknown[] };
+    sidecar.sourceClips.pop();
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    await expect(validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+    })).rejects.toThrow('contract');
+  });
+
+  it('creates an immutable local private-upload bundle and refuses post-review changes', async () => {
+    const videoPath = await fixture();
+    const report = await validateYouTubeMasterBundle({
+      videoPath,
+      probe: passingProbe,
+      analyze: passingSignals,
+      now: () => new Date('2026-07-18T12:00:00Z'),
+    });
+    const checks = { voice: true, lipSync: true, identity: true, anatomy: true, captions: true, disclosure: true, editorial: true };
+    const review = await reviewYouTubeMaster({
+      report,
+      expectedVideoSha256: report.videoSha256,
+      reviewer: 'Patrice',
+      reason: 'Master, captions et disclosure vérifiés.',
+      checks,
+      now: () => new Date('2026-07-18T12:05:00Z'),
+    });
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-'));
+    roots.push(outputRoot);
+    const bundle = await createPrivateYouTubeBundle({
+      videoPath,
+      report,
+      review,
+      outputRoot,
+      probe: passingProbe,
+      analyze: passingSignals,
+      now: () => new Date('2026-07-18T12:10:00Z'),
+    });
+    expect(bundle.manifest).toMatchObject({
+      status: 'ready-for-private-upload',
+      visibility: 'private',
+      autoPublish: false,
+    });
+    expect(bundle.manifest.files.map((file) => file.role)).toEqual([
+      'video', 'captions', 'youtube-sidecar', 'technical-report', 'human-review',
+    ]);
+    await expect(fs.readFile(path.join(bundle.directory, 'bundle.json'), 'utf8')).resolves.toContain('ready-for-private-upload');
+
+    await fs.appendFile(videoPath, 'changed');
+    const secondRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-tampered-'));
+    roots.push(secondRoot);
+    await expect(createPrivateYouTubeBundle({
+      videoPath,
+      report,
+      review,
+      outputRoot: secondRoot,
+      probe: passingProbe,
+      analyze: passingSignals,
+    })).rejects.toThrow(/digest|changed after approval/u);
+  });
+
+  it.skipIf(!REAL_MEDIA)('probes and analyzes a real vertical H.264/AAC master', async () => {
+    const videoPath = await fixture();
+    const captionPath = `${videoPath}.fr-FR.vtt`;
+    await execFile('ffmpeg', [
+      '-v', 'error', '-y',
+      '-f', 'lavfi', '-i', 'color=c=blue:s=720x1280:r=30:d=6',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=6',
+      '-c:v', 'libx264', '-preset', 'ultrafast', '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac', '-shortest', videoPath,
+    ], { timeout: 30_000 });
+    await fs.writeFile(captionPath, 'WEBVTT\n\n00:00:00.100 --> 00:00:05.900\nBonjour\n');
+    const sha = async (filename: string) => createHash('sha256').update(await fs.readFile(filename)).digest('hex');
+    const sidecarPath = `${videoPath}.youtube.json`;
+    const sidecar = JSON.parse(await fs.readFile(sidecarPath, 'utf8')) as {
+      video: { durationMs: number; sha256: string };
+      captionTracks: Array<{ sha256: string }>;
+    };
+    sidecar.video.durationMs = 6_000;
+    sidecar.video.sha256 = await sha(videoPath);
+    sidecar.captionTracks[0]!.sha256 = await sha(captionPath);
+    await fs.writeFile(sidecarPath, JSON.stringify(sidecar));
+    await expect(validateYouTubeMasterBundle({ videoPath })).resolves.toMatchObject({
+      status: 'technical-approved',
+      qualityProfile: { id: 'legacy-localized-v1', version: 1 },
+      probe: { width: 720, height: 1280, videoCodec: 'h264', audioCodec: 'aac', hasAudio: true },
+    });
+  }, 30_000);
+});

--- a/tests/tools/video/youtube-master-quality.test.ts
+++ b/tests/tools/video/youtube-master-quality.test.ts
@@ -21,7 +21,7 @@ const REAL_MEDIA = ffmpegEncoders.status === 0 && /\blibx264\b/u.test(ffmpegEnco
 afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
 
 async function fixture() {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-master-'));
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-master-')));
   roots.push(root);
   const videoPath = path.join(root, 'pilot.mp4');
   const captionPath = `${videoPath}.fr-FR.vtt`;
@@ -306,7 +306,7 @@ describe('YouTube master quality gate', () => {
       checks,
       now: () => new Date('2026-07-18T12:05:00Z'),
     });
-    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-'));
+    const outputRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-')));
     roots.push(outputRoot);
     const bundle = await createPrivateYouTubeBundle({
       videoPath,
@@ -328,7 +328,7 @@ describe('YouTube master quality gate', () => {
     await expect(fs.readFile(path.join(bundle.directory, 'bundle.json'), 'utf8')).resolves.toContain('ready-for-private-upload');
 
     await fs.appendFile(videoPath, 'changed');
-    const secondRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-tampered-'));
+    const secondRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'youtube-private-bundle-tampered-')));
     roots.push(secondRoot);
     await expect(createPrivateYouTubeBundle({
       videoPath,


### PR DESCRIPTION
## Périmètre

Découpe (d) de la PR parapluie #70 (`feat/mysoulmate-media-pipeline`) : les 18 modules **nouveaux** de `src/tools/video/*` + leurs tests. Aucun câblage outil/registry/metadata (lot suivant).

**Hors lot (volontairement) :** `src/lora/**`, `src/tools/media-generation-tool.ts`, `scripts/**`, composants Cowork, `film-assemble.ts` / `narration.ts` (voir écartés).

## Modules

| Module | Statut | Notes |
|---|---|---|
| `comfy-workflow-template.ts` | porté | Contrats + patching pur |
| `comfy-client.ts` | porté | Client polling injectable (`fetchImpl`/`sleep`/`now`) |
| `character-in-location.ts` | adapté | Catalogue `signature-locations` absent de `main` → ids locaux, pas de `src/companion/` |
| `approved-media-source.ts` | porté | Images digest-pinnées, fail-closed |
| `localized-media.ts` | porté | Locale / WebVTT / audio-fit / cache key |
| `voice-rights-registry.ts` | adapté | `ResolvedVoiceProfile` défini ici (`narration.ts` de `main` n'a pas le type) |
| `hybrid-video-router.ts` | adapté | `ContentTier` local (`src/media/content-tier.ts` absent de `main`) |
| `google-flow-handoff.ts` | porté | Paquets browser-assisted, pas d'API officieuse |
| `google-flow-driver.ts` | adapté | Playwright optionnel via `connector` ; helpers crédit extraits de `scripts/` (hors lot) |
| `google-flow-plan-export.ts` | porté | |
| `google-flow-result-import.ts` | porté | |
| `native-fashion-defects.ts` | porté | |
| `visual-gate-report.ts` | porté | |
| `youtube-master-quality.ts` | porté | |
| `cinematic-trailer-plan.ts` | adapté | `ContentTier` importé du router, plus de `src/media/` |
| `book-manuscript-source.ts` | porté | |
| `long-form-plan.ts` | porté | |
| `long-form-production.ts` | adapté | `fit: 'cover'` retiré — `AssembleFilmInput` de `main` n'a pas `FilmFit` |
| `film-assemble.ts` (+309 PR) | **écarté** | Main a aussi divergé ; aucun test nouveau n'exerce loudnorm/LUT/`cover` (l'assembleur est injecté) |
| `narration.ts` (+323 PR) | **écarté** | ElevenLabs/Pocket/profils localisés non requis hors le type, relogé dans voice-rights |
| `tests/tools/video/video-understanding-ckg.test.ts` (+13) | **écarté** | Fichier existant, hors des 18 modules |
| `src/lora/**`, `scripts/**`, Cowork, `media-generation-tool.ts` | **écarté** | Lots séparés |

## Vérification

```
npx tsc --noEmit
# exit 0

npx eslint src/tools/video tests/tools/video
# 0 error (1 warning préexistant @typescript-eslint/no-unused-vars tests/tools/video/scene-render.test.ts)

npx vitest run tests/tools/video
# AVANT (origin/main) : Test Files 16 passed / Tests 197 passed
# APRÈS               : Test Files 34 passed / Tests 317 passed  (+18 fichiers / +120 tests)

npx vitest run tests/tools/video-stitch-tool.test.ts tests/agent/film-producer.test.ts
# Test Files 2 passed / Tests 17 passed
```

Aucun merge. Branche `feat/video-studio-modules-from-pr70` (5 commits Conventional).