### PR TITLE
style(rust): cargo fmt sur buddy-sense et buddy-memory (clippy déjà à 0)

### DIFF
--- a/buddy-memory/src/embed.rs
+++ b/buddy-memory/src/embed.rs
@@ -23,7 +23,12 @@ pub struct Embedder {
 impl Embedder {
     /// Load from a model path; tokenizer.json is resolved next to it unless given. `_dims` is the
     /// expected output dim (informational; pooling adapts to the actual model output rank).
-    pub fn load(model_path: &Path, _dims: usize, max_len: usize, needs_token_type_ids: bool) -> Result<Self, String> {
+    pub fn load(
+        model_path: &Path,
+        _dims: usize,
+        max_len: usize,
+        needs_token_type_ids: bool,
+    ) -> Result<Self, String> {
         let tok_path = resolve_tokenizer_path(model_path);
         let session = Session::builder()
             .map_err(|e| e.to_string())?
@@ -31,8 +36,14 @@ impl Embedder {
             .map_err(|e| e.to_string())?
             .commit_from_file(model_path)
             .map_err(|e| e.to_string())?;
-        let tokenizer = Tokenizer::from_file(&tok_path).map_err(|e| format!("tokenizer load failed: {e}"))?;
-        Ok(Self { session, tokenizer, max_len, needs_token_type_ids })
+        let tokenizer =
+            Tokenizer::from_file(&tok_path).map_err(|e| format!("tokenizer load failed: {e}"))?;
+        Ok(Self {
+            session,
+            tokenizer,
+            max_len,
+            needs_token_type_ids,
+        })
     }
 
     pub fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>, String> {
@@ -41,7 +52,10 @@ impl Embedder {
         }
         let encodings = self
             .tokenizer
-            .encode_batch(texts.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(), true)
+            .encode_batch(
+                texts.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(),
+                true,
+            )
             .map_err(|e| format!("tokenize failed: {e}"))?;
         let batch_size = encodings.len();
         let batch_max_len = encodings
@@ -75,12 +89,19 @@ impl Embedder {
                 .map_err(|e| e.to_string())?
         } else {
             self.session
-                .run(ort::inputs![INPUT_IDS => input_ids_tensor, ATTENTION_MASK => attention_tensor])
+                .run(
+                    ort::inputs![INPUT_IDS => input_ids_tensor, ATTENTION_MASK => attention_tensor],
+                )
                 .map_err(|e| e.to_string())?
         };
 
-        let (_, first) = outputs.iter().next().ok_or("ONNX session returned no outputs")?;
-        let tensor = first.try_extract_tensor::<f32>().map_err(|e| e.to_string())?;
+        let (_, first) = outputs
+            .iter()
+            .next()
+            .ok_or("ONNX session returned no outputs")?;
+        let tensor = first
+            .try_extract_tensor::<f32>()
+            .map_err(|e| e.to_string())?;
         let out_shape: Vec<usize> = tensor.0.iter().map(|&d| d as usize).collect();
         let data: &[f32] = tensor.1;
 
@@ -104,7 +125,8 @@ impl Embedder {
                     let mut denom = 0.0f32;
                     for t in 0..seq {
                         let m = if t < batch_max_len {
-                            attention_for_pooling[b * batch_max_len + t.min(batch_max_len - 1)] as f32
+                            attention_for_pooling[b * batch_max_len + t.min(batch_max_len - 1)]
+                                as f32
                         } else {
                             0.0
                         };
@@ -126,13 +148,19 @@ impl Embedder {
                 }
                 Ok(result)
             }
-            other => Err(format!("unexpected ONNX output rank {} (shape {:?})", other, out_shape)),
+            other => Err(format!(
+                "unexpected ONNX output rank {} (shape {:?})",
+                other, out_shape
+            )),
         }
     }
 }
 
 fn resolve_tokenizer_path(model_path: &Path) -> PathBuf {
-    model_path.parent().map(|p| p.join("tokenizer.json")).unwrap_or_else(|| PathBuf::from("tokenizer.json"))
+    model_path
+        .parent()
+        .map(|p| p.join("tokenizer.json"))
+        .unwrap_or_else(|| PathBuf::from("tokenizer.json"))
 }
 
 fn normalize_in_place(v: &mut [f32]) {

--- a/buddy-memory/src/main.rs
+++ b/buddy-memory/src/main.rs
@@ -58,7 +58,11 @@ fn main() {
         let req: Value = match serde_json::from_str(trimmed) {
             Ok(v) => v,
             Err(e) => {
-                let _ = writeln!(out, "{}", json!({"id": Value::Null, "error": format!("bad json: {}", e)}));
+                let _ = writeln!(
+                    out,
+                    "{}",
+                    json!({"id": Value::Null, "error": format!("bad json: {}", e)})
+                );
                 let _ = out.flush();
                 continue;
             }
@@ -96,7 +100,10 @@ fn dispatch(store: &mut Store, method: &str, params: &Value) -> Result<Value, St
             let query = params.get("query").and_then(|v| v.as_str()).unwrap_or("");
             let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
             let types = parse_str_array(params.get("types"));
-            Ok(serde_json::to_value(store.recall(query, limit, types.as_deref())).unwrap_or(Value::Null))
+            Ok(
+                serde_json::to_value(store.recall(query, limit, types.as_deref()))
+                    .unwrap_or(Value::Null),
+            )
         }
         "recallHybrid" => {
             let query = params.get("query").and_then(|v| v.as_str()).unwrap_or("");
@@ -104,8 +111,14 @@ fn dispatch(store: &mut Store, method: &str, params: &Value) -> Result<Value, St
             let types = parse_str_array(params.get("types"));
             #[cfg(feature = "embeddings")]
             let res = {
-                let w_sem = params.get("semanticWeight").and_then(|v| v.as_f64()).unwrap_or(0.7);
-                let mmr = params.get("mmrLambda").and_then(|v| v.as_f64()).unwrap_or(0.7);
+                let w_sem = params
+                    .get("semanticWeight")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.7);
+                let mmr = params
+                    .get("mmrLambda")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.7);
                 store.recall_hybrid(query, limit, types.as_deref(), w_sem, mmr)
             };
             // Built without embeddings → keyword recall (degrades like the TS path).
@@ -127,11 +140,18 @@ fn opt_result(r: Option<store::RecallResult>) -> Value {
 }
 
 fn s(params: &Value, key: &str) -> Option<String> {
-    params.get(key).and_then(|v| v.as_str()).map(|x| x.to_string())
+    params
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|x| x.to_string())
 }
 
 fn parse_str_array(v: Option<&Value>) -> Option<Vec<String>> {
-    v.and_then(|x| x.as_array()).map(|a| a.iter().filter_map(|i| i.as_str().map(|s| s.to_string())).collect())
+    v.and_then(|x| x.as_array()).map(|a| {
+        a.iter()
+            .filter_map(|i| i.as_str().map(|s| s.to_string()))
+            .collect()
+    })
 }
 
 fn parse_relations(params: &Value) -> Option<Vec<RememberRel>> {
@@ -144,8 +164,14 @@ fn parse_relations(params: &Value) -> Option<Vec<RememberRel>> {
                 Some(RememberRel {
                     predicate,
                     target_name,
-                    target_type: r.get("targetType").and_then(|v| v.as_str()).map(|x| x.to_string()),
-                    reason: r.get("reason").and_then(|v| v.as_str()).map(|x| x.to_string()),
+                    target_type: r
+                        .get("targetType")
+                        .and_then(|v| v.as_str())
+                        .map(|x| x.to_string()),
+                    reason: r
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .map(|x| x.to_string()),
                 })
             })
             .collect(),

--- a/buddy-memory/src/model.rs
+++ b/buddy-memory/src/model.rs
@@ -139,7 +139,11 @@ pub fn entity_id(node_type: &str, name: &str) -> String {
 
 /// sha256(`type:normalized-text`) first 16 hex chars. Mirrors TS `contentHash`.
 pub fn content_hash(node_type: &str, text: &str) -> String {
-    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase();
+    let normalized = text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
     let mut hasher = Sha256::new();
     hasher.update(format!("{}:{}", node_type, normalized).as_bytes());
     let digest = hasher.finalize();
@@ -159,7 +163,12 @@ pub fn corroboration_boost(distinct_agents: usize) -> f64 {
 }
 
 /// salience = ln(mentions+1) * exp(-0.693 * days_since_update / half_life). Mirrors TS `computeSalience`.
-pub fn compute_salience(mentions: u64, days_since_update: f64, half_life_days: f64, base_sim: f64) -> f64 {
+pub fn compute_salience(
+    mentions: u64,
+    days_since_update: f64,
+    half_life_days: f64,
+    base_sim: f64,
+) -> f64 {
     let reinforcement = ((mentions as f64) + 1.0).ln();
     let recency = (-0.693 * days_since_update / half_life_days).exp();
     base_sim * reinforcement * recency
@@ -181,9 +190,15 @@ mod tests {
 
     #[test]
     fn entity_id_and_hash_stable() {
-        assert_eq!(entity_id("lesson", "Voice Agent Model"), "lesson:collective:voice-agent-model");
+        assert_eq!(
+            entity_id("lesson", "Voice Agent Model"),
+            "lesson:collective:voice-agent-model"
+        );
         // accented fold
-        assert_eq!(entity_id("fact", "Métformine à 9h"), "fact:collective:metformine-a-9h");
+        assert_eq!(
+            entity_id("fact", "Métformine à 9h"),
+            "fact:collective:metformine-a-9h"
+        );
         let h1 = content_hash("fact", "Hello   world");
         let h2 = content_hash("fact", "hello world");
         assert_eq!(h1, h2); // whitespace-collapsed + lowercased

--- a/buddy-memory/src/store.rs
+++ b/buddy-memory/src/store.rs
@@ -221,7 +221,11 @@ impl Store {
         if let Some(dir) = self.ledger_path.parent() {
             let _ = fs::create_dir_all(dir);
         }
-        if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&self.ledger_path) {
+        if let Ok(mut f) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.ledger_path)
+        {
             let line = serde_json::to_string(ev).unwrap_or_default();
             let _ = writeln!(f, "{}", line);
         }
@@ -270,7 +274,9 @@ impl Store {
             Ok(s) if s.version == 1 => s,
             _ => return,
         };
-        let ledger_len = fs::metadata(&self.ledger_path).map(|m| m.len()).unwrap_or(0);
+        let ledger_len = fs::metadata(&self.ledger_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
         if snap.offset > ledger_len {
             return; // snapshot ahead of the ledger (truncated/rebuilt) → ignore, replay fully
         }
@@ -300,7 +306,8 @@ impl Store {
                 if !ev.agent_id.is_empty() {
                     cur.contributors.insert(ev.agent_id.clone());
                 }
-                cur.confidence = corroborated_confidence(cur.base_confidence, cur.contributors.len());
+                cur.confidence =
+                    corroborated_confidence(cur.base_confidence, cur.contributors.len());
                 cur.updated_at = ev.recorded_at.clone();
                 return;
             }
@@ -323,7 +330,10 @@ impl Store {
                 source_id: id,
                 target_id: target,
                 rel_type: "supersedes".to_string(),
-                reason: Some(format!("fact changed (was {})", &old_hash[..old_hash.len().min(8)])),
+                reason: Some(format!(
+                    "fact changed (was {})",
+                    &old_hash[..old_hash.len().min(8)]
+                )),
                 mentions: 1,
             });
             return;
@@ -351,8 +361,11 @@ impl Store {
     }
     fn rebuild_index(&mut self) {
         self.index.clear();
-        let entries: Vec<(String, String, String)> =
-            self.current.values().map(|e| (e.id.clone(), e.name.clone(), e.text.clone())).collect();
+        let entries: Vec<(String, String, String)> = self
+            .current
+            .values()
+            .map(|e| (e.id.clone(), e.name.clone(), e.text.clone()))
+            .collect();
         for (id, name, text) in entries {
             self.index_add(&id, &name, &text);
         }
@@ -374,7 +387,11 @@ impl Store {
             confidence: base,
             mentions: 1,
             contributors,
-            agent_id: if ev.agent_id.is_empty() { None } else { Some(ev.agent_id.clone()) },
+            agent_id: if ev.agent_id.is_empty() {
+                None
+            } else {
+                Some(ev.agent_id.clone())
+            },
             source: ev.source.clone(),
             valid_to: None,
             created_at: ev.recorded_at.clone(),
@@ -394,11 +411,24 @@ impl Store {
         }
         self.relations.insert(
             rel_id.clone(),
-            MemRelation { id: rel_id, source_id, target_id, rel_type, reason: ev.reason.clone(), mentions: 1 },
+            MemRelation {
+                id: rel_id,
+                source_id,
+                target_id,
+                rel_type,
+                reason: ev.reason.clone(),
+                mentions: 1,
+            },
         );
     }
 
-    fn make_event(&self, kind: &str, content_hash: String, agent_id: String, source: Option<String>) -> LedgerEvent {
+    fn make_event(
+        &self,
+        kind: &str,
+        content_hash: String,
+        agent_id: String,
+        source: Option<String>,
+    ) -> LedgerEvent {
         LedgerEvent {
             v: 1,
             kind: kind.to_string(),
@@ -424,13 +454,19 @@ impl Store {
         if text.is_empty() {
             return None;
         }
-        let node_type = input.node_type.clone().unwrap_or_else(|| "fact".to_string());
+        let node_type = input
+            .node_type
+            .clone()
+            .unwrap_or_else(|| "fact".to_string());
         let name = match &input.name {
             Some(n) if !n.trim().is_empty() => n.trim().to_string(),
             _ => normalize_name(text),
         };
         let id = entity_id(&node_type, &name);
-        let agent = input.agent_id.clone().unwrap_or_else(|| self.default_agent.clone());
+        let agent = input
+            .agent_id
+            .clone()
+            .unwrap_or_else(|| self.default_agent.clone());
         let ch = content_hash(&node_type, text);
         let conf = clamp01(input.confidence.unwrap_or(0.8));
 
@@ -444,10 +480,17 @@ impl Store {
 
         if let Some(rels) = &input.relations {
             for rel in rels {
-                let target_type = rel.target_type.clone().unwrap_or_else(|| "concept".to_string());
+                let target_type = rel
+                    .target_type
+                    .clone()
+                    .unwrap_or_else(|| "concept".to_string());
                 let target_id = entity_id(&target_type, &rel.target_name);
-                let rel_ch = content_hash("relation", &format!("{}|{}|{}", id, rel.predicate, target_id));
-                let mut rev = self.make_event("relation", rel_ch, agent.clone(), input.source.clone());
+                let rel_ch = content_hash(
+                    "relation",
+                    &format!("{}|{}|{}", id, rel.predicate, target_id),
+                );
+                let mut rev =
+                    self.make_event("relation", rel_ch, agent.clone(), input.source.clone());
                 rev.source_id = Some(id.clone());
                 rev.target_id = Some(target_id.clone());
                 rev.rel_type = Some(rel.predicate.clone());
@@ -468,15 +511,26 @@ impl Store {
         self.current.get(&id).map(|e| self.to_result(e, None, None))
     }
 
-    pub fn recall(&mut self, query: &str, limit: usize, types: Option<&[String]>) -> Vec<RecallResult> {
+    pub fn recall(
+        &mut self,
+        query: &str,
+        limit: usize,
+        types: Option<&[String]>,
+    ) -> Vec<RecallResult> {
         self.load_incremental();
         let q = tokenize(query);
         let mut scored: Vec<(f64, &MemEntity)> = Vec::new();
         let score_entity = |e: &MemEntity, kw: f64| -> f64 {
             let salience = compute_salience(e.mentions, days_since(&e.updated_at), 60.0, 1.0);
-            (if kw == 0.0 { 1.0 } else { kw }) * salience * corroboration_boost(e.contributors.len())
+            (if kw == 0.0 { 1.0 } else { kw })
+                * salience
+                * corroboration_boost(e.contributors.len())
         };
-        let passes_type = |e: &MemEntity| types.map(|ts| ts.iter().any(|t| t == &e.node_type)).unwrap_or(true);
+        let passes_type = |e: &MemEntity| {
+            types
+                .map(|ts| ts.iter().any(|t| t == &e.node_type))
+                .unwrap_or(true)
+        };
 
         if q.is_empty() {
             // No query terms → rank everything by salience (rare; e.g. "what's salient lately").
@@ -508,12 +562,19 @@ impl Store {
             }
         }
         scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-        scored.into_iter().take(limit).map(|(s, e)| self.to_result(e, Some(s), None)).collect()
+        scored
+            .into_iter()
+            .take(limit)
+            .map(|(s, e)| self.to_result(e, Some(s), None))
+            .collect()
     }
 
     pub fn get_superseded(&mut self) -> Vec<RecallResult> {
         self.load_incremental();
-        self.superseded.values().map(|e| self.to_result(e, None, None)).collect()
+        self.superseded
+            .values()
+            .map(|e| self.to_result(e, None, None))
+            .collect()
     }
 
     pub fn stats(&mut self) -> Stats {
@@ -526,19 +587,30 @@ impl Store {
         }
     }
 
-    fn to_result(&self, e: &MemEntity, salience: Option<f64>, similarity: Option<f64>) -> RecallResult {
+    fn to_result(
+        &self,
+        e: &MemEntity,
+        salience: Option<f64>,
+        similarity: Option<f64>,
+    ) -> RecallResult {
         let relations: Vec<RelOut> = self
             .relations
             .values()
             .filter(|r| r.source_id == e.id)
-            .map(|r| RelOut { predicate: r.rel_type.clone(), target: r.target_id.clone(), reason: r.reason.clone() })
+            .map(|r| RelOut {
+                predicate: r.rel_type.clone(),
+                target: r.target_id.clone(),
+                reason: r.reason.clone(),
+            })
             .collect();
         RecallResult {
             id: e.id.clone(),
             node_type: e.node_type.clone(),
             name: e.name.clone(),
             text: e.text.clone(),
-            salience: salience.unwrap_or_else(|| compute_salience(e.mentions, days_since(&e.updated_at), 60.0, 1.0)),
+            salience: salience.unwrap_or_else(|| {
+                compute_salience(e.mentions, days_since(&e.updated_at), 60.0, 1.0)
+            }),
             mentions: e.mentions,
             confidence: e.confidence,
             corroborations: e.contributors.len(),
@@ -568,7 +640,9 @@ impl Store {
         if !path.exists() {
             return;
         }
-        let needs_tt = std::env::var("BUDDY_MEMORY_EMBED_TOKEN_TYPE").map(|v| v != "false").unwrap_or(true);
+        let needs_tt = std::env::var("BUDDY_MEMORY_EMBED_TOKEN_TYPE")
+            .map(|v| v != "false")
+            .unwrap_or(true);
         if let Ok(e) = crate::embed::Embedder::load(path, 384, 256, needs_tt) {
             self.embedder = Some(e);
         }
@@ -667,9 +741,10 @@ impl Store {
             for (j, cand) in items.iter().enumerate() {
                 let mut max_sim = 0f32;
                 for p in &picked {
-                    if let (Some(a), Some(b)) =
-                        (self.emb_cache.get(&cands[cand.0].ch), self.emb_cache.get(&cands[p.0].ch))
-                    {
+                    if let (Some(a), Some(b)) = (
+                        self.emb_cache.get(&cands[cand.0].ch),
+                        self.emb_cache.get(&cands[p.0].ch),
+                    ) {
                         max_sim = max_sim.max(crate::embed::cosine(a, b));
                     }
                 }
@@ -685,7 +760,9 @@ impl Store {
         picked
             .into_iter()
             .filter_map(|(idx, rel, sem)| {
-                self.current.get(&cands[idx].id).map(|e| self.to_result(e, Some(rel), Some(sem as f64)))
+                self.current
+                    .get(&cands[idx].id)
+                    .map(|e| self.to_result(e, Some(rel), Some(sem as f64)))
             })
             .collect()
     }
@@ -701,7 +778,13 @@ mod hybrid_tests {
             .map(|p| std::path::Path::new(&p).exists())
             .unwrap_or_else(|| {
                 std::env::var("HOME")
-                    .map(|h| std::path::Path::new(&format!("{}/.codebuddy/models/buddy-memory/model.onnx", h)).exists())
+                    .map(|h| {
+                        std::path::Path::new(&format!(
+                            "{}/.codebuddy/models/buddy-memory/model.onnx",
+                            h
+                        ))
+                        .exists()
+                    })
                     .unwrap_or(false)
             })
     }
@@ -716,12 +799,30 @@ mod hybrid_tests {
         std::fs::create_dir_all(&dir).unwrap();
         let ledger = dir.join("ledger.jsonl");
         let mut s = Store::new(ledger, "test/repo".to_string());
-        s.remember(&RememberInput { text: "La réponse vocale du robot est beaucoup trop lente.".into(), node_type: Some("discovery".into()), ..Default::default() });
-        s.remember(&RememberInput { text: "La recette de gâteau demande trois œufs et du beurre.".into(), node_type: Some("discovery".into()), ..Default::default() });
+        s.remember(&RememberInput {
+            text: "La réponse vocale du robot est beaucoup trop lente.".into(),
+            node_type: Some("discovery".into()),
+            ..Default::default()
+        });
+        s.remember(&RememberInput {
+            text: "La recette de gâteau demande trois œufs et du beurre.".into(),
+            node_type: Some("discovery".into()),
+            ..Default::default()
+        });
         // Paraphrase with no shared keywords → semantic must surface the voice discovery.
-        let hits = s.recall_hybrid("mon assistant parle avec beaucoup de retard", 2, None, 0.7, 0.7);
+        let hits = s.recall_hybrid(
+            "mon assistant parle avec beaucoup de retard",
+            2,
+            None,
+            0.7,
+            0.7,
+        );
         assert!(!hits.is_empty());
-        assert!(hits[0].text.contains("vocale"), "top hit should be the voice discovery, got {:?}", hits[0].text);
+        assert!(
+            hits[0].text.contains("vocale"),
+            "top hit should be the voice discovery, got {:?}",
+            hits[0].text
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
@@ -740,7 +841,13 @@ mod store_tests {
         dir.join("ledger.jsonl")
     }
     fn input(name: &str, text: &str, agent: &str) -> RememberInput {
-        RememberInput { text: text.into(), node_type: Some("fact".into()), name: Some(name.into()), agent_id: Some(agent.into()), ..Default::default() }
+        RememberInput {
+            text: text.into(),
+            node_type: Some("fact".into()),
+            name: Some(name.into()),
+            agent_id: Some(agent.into()),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -757,7 +864,10 @@ mod store_tests {
         let mut s2 = Store::new(led.clone(), "a/r".into());
         assert_eq!(s2.stats().entities, 3);
         assert!(s2.snapshot_path.exists());
-        assert!(s2.recall("zeta eta", 5, None).iter().any(|r| r.name == "k3"));
+        assert!(s2
+            .recall("zeta eta", 5, None)
+            .iter()
+            .any(|r| r.name == "k3"));
         let _ = std::fs::remove_dir_all(led.parent().unwrap());
     }
 
@@ -765,12 +875,26 @@ mod store_tests {
     fn supersede_invalidates_old_and_links() {
         let led = tmp_ledger();
         let mut s = Store::new(led.clone(), "a/r".into());
-        s.remember(&input("decision", "on route la voix vers devstral local", "a/r"));
-        s.remember(&input("decision", "on route la voix vers gpt-5.5 cloud", "a/r"));
+        s.remember(&input(
+            "decision",
+            "on route la voix vers devstral local",
+            "a/r",
+        ));
+        s.remember(&input(
+            "decision",
+            "on route la voix vers gpt-5.5 cloud",
+            "a/r",
+        ));
         let cur = s.recall("route voix", 5, None);
-        let top = cur.iter().find(|r| r.name == "decision").expect("current decision");
+        let top = cur
+            .iter()
+            .find(|r| r.name == "decision")
+            .expect("current decision");
         assert!(top.text.contains("gpt-5.5"));
-        assert!(top.relations.iter().any(|rel| rel.predicate == "supersedes"));
+        assert!(top
+            .relations
+            .iter()
+            .any(|rel| rel.predicate == "supersedes"));
         let old = s.get_superseded();
         assert_eq!(old.len(), 1);
         assert!(old[0].text.contains("devstral"));
@@ -783,8 +907,22 @@ mod store_tests {
         let led = tmp_ledger();
         let mut a = Store::new(led.clone(), "ministar/cb".into());
         let mut b = Store::new(led.clone(), "laptop/cb".into());
-        a.remember(&RememberInput { text: "le ledger append-only evite les pertes".into(), node_type: Some("fact".into()), name: Some("k".into()), agent_id: Some("ministar/cb".into()), confidence: Some(0.6), ..Default::default() });
-        b.remember(&RememberInput { text: "le ledger append-only evite les pertes".into(), node_type: Some("fact".into()), name: Some("k".into()), agent_id: Some("laptop/cb".into()), confidence: Some(0.6), ..Default::default() });
+        a.remember(&RememberInput {
+            text: "le ledger append-only evite les pertes".into(),
+            node_type: Some("fact".into()),
+            name: Some("k".into()),
+            agent_id: Some("ministar/cb".into()),
+            confidence: Some(0.6),
+            ..Default::default()
+        });
+        b.remember(&RememberInput {
+            text: "le ledger append-only evite les pertes".into(),
+            node_type: Some("fact".into()),
+            name: Some("k".into()),
+            agent_id: Some("laptop/cb".into()),
+            confidence: Some(0.6),
+            ..Default::default()
+        });
         let hits = b.recall("ledger pertes", 1, None);
         assert_eq!(hits[0].corroborations, 2);
         assert!(hits[0].confidence > 0.6);
@@ -793,7 +931,10 @@ mod store_tests {
 }
 
 fn snapshot_path_for(ledger: &Path) -> PathBuf {
-    let name = ledger.file_name().and_then(|n| n.to_str()).unwrap_or("ckg-ledger.jsonl");
+    let name = ledger
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("ckg-ledger.jsonl");
     ledger.with_file_name(format!("{}.snap", name))
 }
 

--- a/buddy-sense/src/main.rs
+++ b/buddy-sense/src/main.rs
@@ -29,7 +29,10 @@ fn audio_events_for(path: &str) -> Result<Vec<SensoryEvent>, String> {
     for ev in &mut events {
         if ev.kind.starts_with("speech") {
             if let Some(obj) = ev.payload.as_object_mut() {
-                obj.insert("wav".to_string(), serde_json::Value::String(path.to_string()));
+                obj.insert(
+                    "wav".to_string(),
+                    serde_json::Value::String(path.to_string()),
+                );
             }
         }
     }
@@ -45,14 +48,16 @@ fn compute_audio_events(path: &str) -> Result<Vec<SensoryEvent>, String> {
             if std::path::Path::new(&model).exists() {
                 // Fall through to the energy VAD on any neural error (bad rate,
                 // missing onnxruntime, decode failure) — never go deaf.
-                match senses::audio::read_wav_mono(path)
-                    .and_then(|(samples, rate)| senses::audio::neural::vad_events_neural(&samples, rate, &model))
-                {
+                match senses::audio::read_wav_mono(path).and_then(|(samples, rate)| {
+                    senses::audio::neural::vad_events_neural(&samples, rate, &model)
+                }) {
                     Ok(events) => {
                         eprintln!("[buddy-sense] audio: neural VAD (Silero)");
                         return Ok(events);
                     }
-                    Err(e) => eprintln!("[buddy-sense] neural VAD failed ({e}); falling back to energy VAD"),
+                    Err(e) => eprintln!(
+                        "[buddy-sense] neural VAD failed ({e}); falling back to energy VAD"
+                    ),
                 }
             }
         }
@@ -76,7 +81,8 @@ async fn main() {
         }
     }
 
-    let url = std::env::var("BUDDY_SENSE_BRIDGE_URL").unwrap_or_else(|_| "ws://127.0.0.1:8129".to_string());
+    let url = std::env::var("BUDDY_SENSE_BRIDGE_URL")
+        .unwrap_or_else(|_| "ws://127.0.0.1:8129".to_string());
     let wav = std::env::args().skip(1).find(|a| a.ends_with(".wav"));
 
     // Thalamus → consumers (broadcast). The per-organ sense channels are created below (one per
@@ -98,18 +104,27 @@ async fn main() {
     available.push(Organ::Ui);
     #[cfg(feature = "live-audio")]
     available.push(Organ::LiveAudio);
-    let organs = resolve_organs(&available, std::env::var("BUDDY_SENSE_ORGANS").ok().as_deref());
+    let organs = resolve_organs(
+        &available,
+        std::env::var("BUDDY_SENSE_ORGANS").ok().as_deref(),
+    );
     eprintln!(
         "[buddy-sense] organs live ({}): {}",
         organs.len(),
-        organs.iter().map(|o| o.as_str()).collect::<Vec<_>>().join(", ")
+        organs
+            .iter()
+            .map(|o| o.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     let organ_active = |o: Organ| organs.contains(&o);
 
     // Bridge to Code Buddy. A shared token (if set) authenticates our frames.
     {
         let rx = bcast_tx.subscribe();
-        let token = std::env::var("BUDDY_SENSE_TOKEN").ok().filter(|t| !t.is_empty());
+        let token = std::env::var("BUDDY_SENSE_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty());
         tokio::spawn(async move { bridge::run_bridge(url, token, rx).await });
     }
 
@@ -139,10 +154,20 @@ async fn main() {
     if organ_active(Organ::Screen) {
         let (tx, rx) = mpsc::channel::<SensoryEvent>(32);
         organ_rx.push(rx);
-        let screen_ms = std::env::var("BUDDY_SENSE_SCREEN_MS").ok().and_then(|s| s.parse::<u64>().ok()).unwrap_or(1000);
-        let screen_threshold = std::env::var("BUDDY_SENSE_SCREEN_THRESHOLD").ok().and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.02);
-        eprintln!("[buddy-sense] screen sense active ({screen_ms}ms, threshold {screen_threshold})");
-        tokio::spawn(async move { senses::screen::live::run(tx, screen_ms, screen_threshold).await });
+        let screen_ms = std::env::var("BUDDY_SENSE_SCREEN_MS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(1000);
+        let screen_threshold = std::env::var("BUDDY_SENSE_SCREEN_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.02);
+        eprintln!(
+            "[buddy-sense] screen sense active ({screen_ms}ms, threshold {screen_threshold})"
+        );
+        tokio::spawn(
+            async move { senses::screen::live::run(tx, screen_ms, screen_threshold).await },
+        );
     }
 
     // Camera sense — live webcam motion detection (the robot's eyes), opt-in build.
@@ -150,11 +175,22 @@ async fn main() {
     if organ_active(Organ::Vision) {
         let (tx, rx) = mpsc::channel::<SensoryEvent>(32);
         organ_rx.push(rx);
-        let device = std::env::var("BUDDY_SENSE_CAMERA").unwrap_or_else(|_| "/dev/video0".to_string());
-        let cam_ms = std::env::var("BUDDY_SENSE_CAMERA_MS").ok().and_then(|s| s.parse::<u64>().ok()).unwrap_or(1500);
-        let cam_threshold = std::env::var("BUDDY_SENSE_CAMERA_THRESHOLD").ok().and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.04);
-        eprintln!("[buddy-sense] camera sense active ({device}, {cam_ms}ms, threshold {cam_threshold})");
-        tokio::spawn(async move { senses::video::live::run(tx, device, cam_ms, cam_threshold).await });
+        let device =
+            std::env::var("BUDDY_SENSE_CAMERA").unwrap_or_else(|_| "/dev/video0".to_string());
+        let cam_ms = std::env::var("BUDDY_SENSE_CAMERA_MS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(1500);
+        let cam_threshold = std::env::var("BUDDY_SENSE_CAMERA_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.04);
+        eprintln!(
+            "[buddy-sense] camera sense active ({device}, {cam_ms}ms, threshold {cam_threshold})"
+        );
+        tokio::spawn(
+            async move { senses::video::live::run(tx, device, cam_ms, cam_threshold).await },
+        );
     }
 
     // UI sense — semantic accessibility events (active app / focus), opt-in build.
@@ -175,9 +211,16 @@ async fn main() {
     if organ_active(Organ::LiveAudio) {
         let (tx, rx) = mpsc::channel::<SensoryEvent>(32);
         organ_rx.push(rx);
-        let source = std::env::var("BUDDY_SENSE_MIC_SOURCE").unwrap_or_else(|_| "default".to_string());
-        let threshold = std::env::var("BUDDY_SENSE_MIC_THRESHOLD").ok().and_then(|s| s.parse::<f64>().ok()).unwrap_or(senses::live_audio::DEFAULT_MIC_THRESHOLD);
-        let endpoint_ms = std::env::var("BUDDY_SENSE_MIC_ENDPOINT_MS").ok().and_then(|s| s.parse::<u64>().ok()).unwrap_or(senses::live_audio::DEFAULT_MIC_ENDPOINT_MS);
+        let source =
+            std::env::var("BUDDY_SENSE_MIC_SOURCE").unwrap_or_else(|_| "default".to_string());
+        let threshold = std::env::var("BUDDY_SENSE_MIC_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(senses::live_audio::DEFAULT_MIC_THRESHOLD);
+        let endpoint_ms = std::env::var("BUDDY_SENSE_MIC_ENDPOINT_MS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(senses::live_audio::DEFAULT_MIC_ENDPOINT_MS);
         let adaptive = !matches!(
             std::env::var("BUDDY_SENSE_MIC_ADAPTIVE")
                 .unwrap_or_else(|_| "true".to_string())
@@ -217,7 +260,10 @@ async fn main() {
             let audio_tx = audio_batch_tx.expect("audio_batch_tx is Some when wav is Some");
             match audio_events_for(&path) {
                 Ok(events) => {
-                    eprintln!("[buddy-sense] audio: {} VAD event(s) from {path}", events.len());
+                    eprintln!(
+                        "[buddy-sense] audio: {} VAD event(s) from {path}",
+                        events.len()
+                    );
                     for ev in events {
                         if audio_tx.send(ev).await.is_err() {
                             break;


### PR DESCRIPTION
Hygiène des deux sidecars Rust (lot flotte luna, vérifié indépendamment) : `cargo fmt` sur `buddy-sense/src/main.rs` et 4 fichiers de `buddy-memory` ; `cargo clippy` était déjà à 0 ; `cargo test` inchangé (34 + 5) ; `cargo build --release` OK ; features optionnelles non activées ; aucun workflow Rust en CI (lot séparé si souhaité).

🤖 Generated with [Claude Code](https://claude.com/claude-code)