### PR TITLE
ci(windows): une relance par shard (fork tué hors-heap, 0 test rouge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,22 +84,23 @@ jobs:
     # what runs; Linux/macOS keep the single invocation.
     - name: Run tests (shard 1/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=1/6
+      # One retry: a fork can still be killed off-heap on windows-latest (0 red tests).
+      run: npm test -- --shard=1/6 || npm test -- --shard=1/6
     - name: Run tests (shard 2/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=2/6
+      run: npm test -- --shard=2/6 || npm test -- --shard=2/6
     - name: Run tests (shard 3/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=3/6
+      run: npm test -- --shard=3/6 || npm test -- --shard=3/6
     - name: Run tests (shard 4/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=4/6
+      run: npm test -- --shard=4/6 || npm test -- --shard=4/6
     - name: Run tests (shard 5/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=5/6
+      run: npm test -- --shard=5/6 || npm test -- --shard=5/6
     - name: Run tests (shard 6/6)
       if: runner.os == 'Windows'
-      run: npm test -- --shard=6/6
+      run: npm test -- --shard=6/6 || npm test -- --shard=6/6
 
     - name: Build project
       run: npm run build


### PR DESCRIPTION
Même avec 6 shards (#112), un fork Windows Node 20 meurt encore parfois (`Worker exited unexpectedly`, 0 test rouge — vu sur #108 après rebase). Chaque step shard Windows est relancé une fois (`npm test -- --shard=k/6 || npm test -- --shard=k/6`). Linux/macOS inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)