### PR TITLE
test: durcir 2 flakys (code_exec session cwd, ocr-tool binaires)

### DIFF
--- a/src/tools/ocr-tool.ts
+++ b/src/tools/ocr-tool.ts
@@ -1,9 +1,18 @@
 import { UnifiedVfsRouter } from '../services/vfs/unified-vfs-router.js';
 import path from 'path';
-import { spawn, execSync } from 'child_process';
+import { spawn as defaultSpawn, execSync as defaultExecSync } from 'child_process';
 import { ToolResult, getErrorMessage } from '../types/index.js';
 import { fileURLToPath } from 'url';
 import { logger } from '../utils/logger.js';
+
+type TesseractJsLoader = () => Promise<{
+  createWorker: (language?: string) => Promise<{
+    recognize: (imagePath: string) => Promise<{
+      data: { text?: string; confidence?: number; words?: unknown[] };
+    }>;
+    terminate: () => Promise<void>;
+  }>;
+}>;
 
 export interface OCRResult {
   text: string;
@@ -44,6 +53,21 @@ export interface OCRToolOptions {
    * `import('child_process')` escapes the static mock) and would race them.
    */
   platform?: NodeJS.Platform;
+  /**
+   * Injected `spawn`. Tests pass a fake so the Tesseract CLI path never
+   * depends on a host `tesseract` binary being present or absent.
+   */
+  spawn?: typeof defaultSpawn;
+  /**
+   * Injected `execSync`. Same reason: `tesseract --version` / `which convert`
+   * must not silently consult PATH.
+   */
+  execSync?: typeof defaultExecSync;
+  /**
+   * Override the dynamic `import('tesseract.js')`. Tests supply a rejecting
+   * stub so engine 2 fails on a microtask instead of loading WASM.
+   */
+  loadTesseractJs?: TesseractJsLoader;
 }
 
 export class OCRTool {
@@ -52,9 +76,16 @@ export class OCRTool {
   private tesseractAvailable: boolean | null = null;
   private vfs = UnifiedVfsRouter.Instance;
   private readonly platform: NodeJS.Platform;
+  private readonly spawnImpl: typeof defaultSpawn;
+  private readonly execSyncImpl: typeof defaultExecSync;
+  private readonly loadTesseractJs: TesseractJsLoader;
 
   constructor(options: OCRToolOptions = {}) {
     this.platform = options.platform ?? process.platform;
+    this.spawnImpl = options.spawn ?? defaultSpawn;
+    this.execSyncImpl = options.execSync ?? defaultExecSync;
+    this.loadTesseractJs = options.loadTesseractJs
+      ?? (async () => import('tesseract.js') as unknown as Awaited<ReturnType<TesseractJsLoader>>);
   }
 
   /**
@@ -139,7 +170,7 @@ export class OCRTool {
     }
 
     try {
-      execSync('tesseract --version', { stdio: 'ignore' });
+      this.execSyncImpl('tesseract --version', { stdio: 'ignore' });
       this.tesseractAvailable = true;
     } catch {
       this.tesseractAvailable = false;
@@ -179,7 +210,7 @@ export class OCRTool {
       // Request TSV output for confidence scores
       args.push('-c', 'tessedit_create_tsv=1');
 
-      const tesseract = spawn('tesseract', args);
+      const tesseract = this.spawnImpl('tesseract', args);
 
       let stdout = '';
       let stderr = '';
@@ -362,7 +393,7 @@ export class OCRTool {
         };
       }
 
-      const output = execSync('tesseract --list-langs', { encoding: 'utf8' });
+      const output = this.execSyncImpl('tesseract --list-langs', { encoding: 'utf8' });
       const lines = output.split('\n').slice(1).filter(l => l.trim());
 
       return {
@@ -424,7 +455,7 @@ export class OCRTool {
   ): Promise<ToolResult> {
     // For region extraction, we need ImageMagick to crop first
     try {
-      execSync('which convert', { stdio: 'ignore' });
+      this.execSyncImpl('which convert', { stdio: 'ignore' });
     } catch {
       return {
         success: false,
@@ -445,7 +476,7 @@ export class OCRTool {
 
     try {
       // Crop the region using ImageMagick
-      execSync(
+      this.execSyncImpl(
         `convert "${resolvedPath}" -crop ${region.width}x${region.height}+${region.x}+${region.y} "${tempPath}"`
       );
 
@@ -536,7 +567,7 @@ export class OCRTool {
   private async runTesseractJS(imagePath: string, options: OCROptions): Promise<ToolResult> {
     const startTime = Date.now();
     try {
-      const { createWorker } = await import('tesseract.js');
+      const { createWorker } = await this.loadTesseractJs();
       const worker = await createWorker(options.language || 'eng');
       
       const { data } = await worker.recognize(imagePath);
@@ -554,7 +585,7 @@ export class OCRTool {
       }));
 
       const result: OCRResult = {
-        text: data.text,
+        text: data.text ?? '',
         confidence: data.confidence,
         language: options.language || 'eng',
         blocks,

--- a/tests/agent/tool-handler-code-exec-session.test.ts
+++ b/tests/agent/tool-handler-code-exec-session.test.ts
@@ -1,18 +1,46 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ToolHandler } from '../../src/agent/tool-handler.js';
+import { resetPermissionModeManager } from '../../src/security/permission-modes.js';
+import { resetTrustFolderManager } from '../../src/security/trust-folders.js';
 import { ConfirmationService } from '../../src/utils/confirmation-service.js';
 import {
   approveSandboxUnavailableEscalations,
   clearSandboxEscalationBridge,
 } from '../helpers/sandbox-escalation-bridge.js';
 import { canonical, canonicalShellPath } from '../helpers/shell-path.js';
+import { makeTmpDir, removeTmpDir } from '../helpers/tmp.js';
 import { clearAllCodeExecSessions } from '../../src/tools/code-exec-tool.js';
-import { getFormalToolRegistry } from '../../src/tools/registry/index.js';
+import { getFormalToolRegistry, resetBashInstance } from '../../src/tools/registry/index.js';
 import type { ITool, IToolExecutionContext } from '../../src/tools/registry/types.js';
+
+const REPO_ROOT = fs.realpathSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..'),
+);
+
+const HOST_ENV_KEYS = ['HOME', 'USERPROFILE', 'TMPDIR', 'TEMP', 'TMP'] as const;
+
+const hostEnvSnapshot: Record<(typeof HOST_ENV_KEYS)[number], string | undefined> = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TMPDIR: process.env.TMPDIR,
+  TEMP: process.env.TEMP,
+  TMP: process.env.TMP,
+};
+
+function restoreHostProcess(): void {
+  if (process.cwd() !== REPO_ROOT) {
+    process.chdir(REPO_ROOT);
+  }
+  for (const key of HOST_ENV_KEYS) {
+    const previous = hostEnvSnapshot[key];
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+}
 
 const PROBE_TOOL = 'code_exec_recovery_scope_probe';
 
@@ -44,12 +72,29 @@ describe('ToolHandler code_exec logical-session isolation', () => {
   const observedScopes: string[] = [];
 
   beforeEach(() => {
+    // Previous files in the same vitest fork can leave process.cwd(), HOME,
+    // the bash singleton cwd, or trust enforcement behind. Restore first so
+    // this file's session dirs are not created under a mutated host state.
+    restoreHostProcess();
+    resetBashInstance();
+    resetTrustFolderManager();
+    resetPermissionModeManager();
     clearAllCodeExecSessions();
     observedScopes.splice(0);
     // The bash `pwd` below runs through the real ConfirmationService; hosts
     // without a sandbox backend (Windows CI) escalate it to an exact grant.
     approveSandboxUnavailableEscalations(ConfirmationService.getInstance());
-    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-exec-session-'));
+    // Repo-local tmp (gitignored): Linux bubblewrap mounts a tmpfs over `/tmp`,
+    // so a cwd under os.tmpdir() disappears inside the sandbox. git rev-parse
+    // from this path still finds the workspace, so the bind stays visible.
+    workDir = makeTmpDir('code-exec-session-', path.join(REPO_ROOT, 'tmp'));
+    const isolatedHome = path.join(workDir, 'home');
+    fs.mkdirSync(isolatedHome, { recursive: true });
+    process.env.HOME = isolatedHome;
+    process.env.USERPROFILE = isolatedHome;
+    process.env.TMPDIR = workDir;
+    process.env.TEMP = workDir;
+    process.env.TMP = workDir;
     handler = new ToolHandler({
       checkpointManager: {
         checkpointBeforeCreate: vi.fn(),
@@ -97,8 +142,12 @@ describe('ToolHandler code_exec logical-session isolation', () => {
   afterEach(() => {
     getFormalToolRegistry().unregister(PROBE_TOOL);
     clearAllCodeExecSessions();
+    resetBashInstance();
+    resetTrustFolderManager();
+    resetPermissionModeManager();
     clearSandboxEscalationBridge(ConfirmationService.getInstance());
-    fs.rmSync(workDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    restoreHostProcess();
+    removeTmpDir(workDir);
   });
 
   it('propagates executionExtra to tools called from code_exec', async () => {
@@ -138,16 +187,14 @@ describe('ToolHandler code_exec logical-session isolation', () => {
   });
 
   it('owns cd state locally and restores it without changing the host process cwd', async () => {
-    const sessionA = fs.mkdtempSync(path.join(workDir, 'session-a-'));
-    const sessionB = fs.mkdtempSync(path.join(workDir, 'session-b-'));
     const hostCwd = process.cwd();
-    // `cd` stores the canonical (realpath) cwd; a restored value comes from that
-    // same store, so restore canonical paths too (os.tmpdir() is a symlink on macOS).
-    const realSessionA = fs.realpathSync(sessionA);
-    const realSessionB = fs.realpathSync(sessionB);
+    // `cd` stores the canonical (realpath) cwd; makeTmpDir already realpaths so
+    // restore/compare use the same spelling (os.tmpdir() is a symlink on macOS).
+    const realSessionA = makeTmpDir('session-a-', workDir);
+    const realSessionB = makeTmpDir('session-b-', workDir);
 
     handler.setRecoverySessionId('logical-session-a');
-    const changed = await handler.executeTool(bashCall('cd-a', `cd ${sessionA}`));
+    const changed = await handler.executeTool(bashCall('cd-a', `cd ${realSessionA}`));
     expect(changed.success).toBe(true);
     expect(handler.getWorkingDirectory()).toBe(realSessionA);
     expect(process.cwd()).toBe(hostCwd);

--- a/tests/helpers/tmp.ts
+++ b/tests/helpers/tmp.ts
@@ -9,8 +9,25 @@
  * logged so a real leak stays visible.
  */
 import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 export const TMP_RM_OPTIONS = { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } as const;
+
+/**
+ * Unique temp directory with the canonical (realpath) spelling.
+ *
+ * `os.tmpdir()` is a symlink on macOS (`/var` → `/private/var`). Session cwd
+ * stores that realpath, so tests must create and compare the same path.
+ * Prefer a caller-supplied `baseDir` (e.g. the repo `tmp/` folder) when the
+ * directory will be used as a bash cwd: Linux bubblewrap mounts a tmpfs on
+ * `/tmp` and would hide a workspace created under `os.tmpdir()`.
+ */
+export function makeTmpDir(prefix: string, baseDir: string = os.tmpdir()): string {
+  fs.mkdirSync(baseDir, { recursive: true });
+  const created = fs.mkdtempSync(path.join(baseDir, prefix));
+  return fs.realpathSync.native(created);
+}
 
 export function removeTmpDir(target: string | undefined | null): void {
   if (!target) return;

--- a/tests/tools/ocr-tool.test.ts
+++ b/tests/tools/ocr-tool.test.ts
@@ -1,6 +1,7 @@
+import { spawn as defaultSpawn, execSync as defaultExecSync } from 'child_process';
+import { EventEmitter } from 'events';
 import { OCRTool } from '../../src/tools/ocr-tool.js';
 import { UnifiedVfsRouter } from '../../src/services/vfs/unified-vfs-router.js';
-import { EventEmitter } from 'events';
 
 // Define mocks inside the factory
 jest.mock('../../src/services/vfs/unified-vfs-router.js', () => ({
@@ -15,30 +16,38 @@ jest.mock('../../src/services/vfs/unified-vfs-router.js', () => ({
   }
 }));
 
-// Mock child_process (static `spawn`/`execSync` imports). The Windows-native
-// OCR engine (engine 1 of the cascade) does a DYNAMIC `await import('child_process')`
-// that this mock does not reliably intercept — on a Windows host it shelled out
-// to a real PowerShell OCR (up to 15 s) and raced the `setImmediate`-timed
-// emissions below. The tool is therefore constructed with an explicit
-// non-Windows platform so the cascade starts at engine 2 on every host.
+// Hermetic CLI/WASM stubs injected via OCRToolOptions. A module-level
+// `jest.mock('child_process')` is incomplete (no `exec`/`execFile`, and the
+// Jest-compat transform rewrites the factory to `async () =>`) so macOS CI
+// could still shell out to a real `tesseract` / `/usr/bin/convert` (CUPS, not
+// ImageMagick) and race the cascade. Injected fakes do not consult PATH.
 const mockSpawn = jest.fn();
 const mockExecSync = jest.fn();
-jest.mock('child_process', () => ({
-  spawn: (...args: any[]) => mockSpawn(...args),
-  execSync: (...args: any[]) => mockExecSync(...args)
-}));
+const rejectTesseractJs = async () => {
+  throw new Error('tesseract.js disabled in test');
+};
 
-// The OCR cascade tries Windows-native OCR (engine 1) and Tesseract.js WASM
-// (engine 2) BEFORE the Tesseract CLI path these tests exercise. Stub
-// tesseract.js so engine 2 fails on a microtask (rather than doing real WASM
-// macrotask IO, which would both download models and race the test's
-// `setImmediate`-timed event emissions). With this in place the cascade falls
-// through deterministically to the mocked Tesseract CLI path.
-jest.mock('tesseract.js', () => ({
-  createWorker: jest.fn(async () => {
-    throw new Error('tesseract.js disabled in test');
-  })
-}));
+const HOST_OCR_ENV = {
+  GROK_API_KEY: process.env.GROK_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+};
+
+function restoreOcrEnv(): void {
+  for (const key of Object.keys(HOST_OCR_ENV) as Array<keyof typeof HOST_OCR_ENV>) {
+    const previous = HOST_OCR_ENV[key];
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+}
+
+function createTool(): OCRTool {
+  return new OCRTool({
+    platform: 'linux',
+    spawn: mockSpawn as unknown as typeof defaultSpawn,
+    execSync: mockExecSync as unknown as typeof defaultExecSync,
+    loadTesseractJs: rejectTesseractJs,
+  });
+}
 
 describe('OCRTool', () => {
   let tool: OCRTool;
@@ -52,11 +61,16 @@ describe('OCRTool', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    tool = new OCRTool({ platform: 'linux' });
-    (tool as any).tesseractAvailable = null;
-    
+    restoreOcrEnv();
+    tool = createTool();
+    (tool as { tesseractAvailable: boolean | null }).tesseractAvailable = null;
+
     // Default execSync to return empty string instead of buffer to avoid split errors
     mockExecSync.mockReturnValue('');
+  });
+
+  afterEach(() => {
+    restoreOcrEnv();
   });
 
   const mockProcess = () => {
@@ -129,7 +143,7 @@ describe('OCRTool', () => {
 
       const promise = tool.extractText('test.png');
 
-      await new Promise(resolve => setImmediate(resolve));
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
 
       proc.stderr.emit('data', Buffer.from('Error'));
       proc.emit('close', 1);
@@ -255,7 +269,7 @@ describe('OCRTool', () => {
 
       const promise = tool.extractRegion('test.png', { x: 0, y: 0, width: 100, height: 100 });
 
-      await new Promise(resolve => setImmediate(resolve));
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
 
       const tsv = `level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext
 5\t1\t1\t1\t1\t1\t10\t10\t50\t20\t95\tRegionText`;


### PR DESCRIPTION
## Contenu
Corrige la **cause** de 2 flakes vus en CI (0 changement de comportement produit) :

1. **`tool-handler-code-exec-session`** (`owns cd state locally…`, Ubuntu Node 22) — le cwd de session était créé sous `os.tmpdir()` (`/tmp`). Le sandbox Linux `bwrap` monte ensuite un tmpfs sur `/tmp`, donc `bash pwd` dans le cwd restauré échoue quand le sandbox est disponible et passe quand il ne l’est pas. Le test crée désormais un répertoire **realpath** sous le `tmp/` gitignoré du dépôt (`tests/helpers/tmp.ts` `makeTmpDir`), restaure `process.cwd()` / `HOME`/`TMPDIR` en `afterEach`, et réinitialise les singletons bash / trust / `code_exec`.
2. **`ocr-tool`** (`batchOCR` / `extractRegion`, macOS Node 20) — `jest.mock('child_process')` est incomplet (transform Jest-compat → factory `async`, pas d’`exec`/`execFile`) : le cascade pouvait encore shell-out vers un vrai `tesseract` ou `/usr/bin/convert` (CUPS, pas ImageMagick) et courir contre un `setImmediate`. `OCRTool` accepte désormais `spawn` / `execSync` / `loadTesseractJs` injectés (défauts = binaires réels). Les tests sont hermétiques ; plus de dépendance silencieuse à PATH. `vi.waitFor(spawn)` avant d’émettre sur le faux process.

## Vérification
- `tests/agent/tool-handler-code-exec-session.test.ts` : 5 passages verts (3 tests) — Vitest 4.1.9 n’a pas `--repeat-each`, boucle `vitest run`.
- `tests/tools/ocr-tool.test.ts` : 5× vert avec `PATH=/usr/bin:/bin` + `HOME` isolé (10 tests) ; 1× vert avec `PATH=/bin` (tesseract/convert absents).
- `npx tsc --noEmit` : 0 erreur
- `npx eslint` sur les 4 fichiers : 0 erreur

Ne pas merger.