### PR TITLE
fix(memory,sensory): audit batch 2 — reste (découpe de #69)

### DIFF
--- a/buddy-sense/demo.sh
+++ b/buddy-sense/demo.sh
@@ -41,6 +41,7 @@ cat > /tmp/_bs_recv.mts <<EOF
 const { startSensoryBridge } = await import('$ROOT/src/sensory/sensory-bridge.js');
 const { getGlobalEventBus } = await import('$ROOT/src/events/event-bus.js');
 const b = startSensoryBridge({ port: $PORT });
+await b.ready;
 getGlobalEventBus().on('sensory:perception', (e) => {
   const m = e.metadata ?? {};
   console.log('  Code Buddy ◂ ' + m.modality + '/' + m.kind + '  ' + JSON.stringify(m.payload ?? {}));

--- a/buddy-sense/src/senses/video.rs
+++ b/buddy-sense/src/senses/video.rs
@@ -66,13 +66,16 @@ pub mod live {
     use super::{motion_score, MOTION_SALIENCE};
     use crate::event::{now_ms, Modality, SensoryEvent};
     use std::ffi::OsStr;
-    use std::io::Read;
+    use std::io::{self, Read};
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
+    use std::time::{Duration, SystemTime};
     use tokio::sync::mpsc;
 
     const W: usize = 64;
     const H: usize = 48;
+    const FRAME_KEEP: usize = 500;
+    const DEFAULT_FRAME_TTL_SECS: u64 = 7 * 24 * 60 * 60;
 
     fn ffmpeg_bin() -> String {
         std::env::var("BUDDY_SENSE_FFMPEG")
@@ -163,6 +166,78 @@ pub mod live {
             .unwrap_or(false)
     }
 
+    fn configured_frame_ttl(value: Option<&str>) -> Duration {
+        value
+            .and_then(|seconds| seconds.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_FRAME_TTL_SECS))
+    }
+
+    /// Remove expired camera keyframes and cap the survivors to the `keep` most
+    /// recently modified files. Files outside the `cam-*.jpg` namespace are
+    /// deliberately ignored, including ffmpeg's fixed `.buddy-sense-*-latest`
+    /// working image.
+    pub fn prune_frames(dir: &Path, keep: usize, ttl: Duration) -> io::Result<Vec<PathBuf>> {
+        prune_frames_at(dir, keep, ttl, SystemTime::now())
+    }
+
+    fn prune_frames_at(
+        dir: &Path,
+        keep: usize,
+        ttl: Duration,
+        now: SystemTime,
+    ) -> io::Result<Vec<PathBuf>> {
+        let mut frames = Vec::new();
+        for entry in std::fs::read_dir(dir)? {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if !name.starts_with("cam-") || !name.ends_with(".jpg") {
+                continue;
+            }
+            let modified = match entry.metadata().and_then(|metadata| metadata.modified()) {
+                Ok(modified) => modified,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            frames.push((modified, entry.path()));
+        }
+
+        // Newest first. The path provides deterministic ordering when a
+        // filesystem exposes coarse, equal modification timestamps.
+        frames.sort_by(|a, b| b.cmp(a));
+        let mut removed = Vec::new();
+        for (index, (modified, path)) in frames.into_iter().enumerate() {
+            let expired = now
+                .duration_since(modified)
+                .map(|age| age > ttl)
+                .unwrap_or(false);
+            if index < keep && !expired {
+                continue;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => removed.push(path),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(removed)
+    }
+
     /// Capture continuously at the configured cadence; emit `vision/motion`
     /// (+ a keyframe from the current stream) on rising motion. Hysteresis keeps
     /// a sustained scene change to one event rather than an event storm.
@@ -233,10 +308,24 @@ pub mod live {
                         let path = dir.join(format!("cam-{}.jpg", now_ms()));
                         let path_str = path.to_string_lossy().to_string();
                         let ok = retain_keyframe(&latest_frame, &path);
+                        if ok {
+                            let ttl_env = std::env::var("BUDDY_SENSE_FRAME_TTL").ok();
+                            let ttl = configured_frame_ttl(ttl_env.as_deref());
+                            if let Err(error) = prune_frames(dir, FRAME_KEEP, ttl) {
+                                eprintln!(
+                                    "[buddy-sense] live-vision: keyframe pruning failed ({error})"
+                                );
+                            }
+                        }
+                        let retained_path = if ok && path.is_file() {
+                            Some(path_str)
+                        } else {
+                            None
+                        };
                         let payload = serde_json::json!({
                             "score": score,
                             "camera": camera,
-                            "imagePath": if ok { Some(path_str) } else { None },
+                            "imagePath": retained_path,
                         });
                         let ev =
                             SensoryEvent::new(Modality::Vision, "motion", MOTION_SALIENCE, payload);
@@ -294,6 +383,74 @@ pub mod live {
                 &dir.join("never.jpg")
             ));
 
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+
+        fn write_frame_with_mtime(path: &Path, modified: SystemTime) {
+            let file = std::fs::File::create(path).unwrap();
+            file.set_times(std::fs::FileTimes::new().set_modified(modified))
+                .unwrap();
+        }
+
+        #[test]
+        fn configured_ttl_defaults_to_seven_days_and_accepts_seconds() {
+            assert_eq!(
+                configured_frame_ttl(None),
+                Duration::from_secs(7 * 24 * 60 * 60)
+            );
+            assert_eq!(configured_frame_ttl(Some("60")), Duration::from_secs(60));
+            assert_eq!(
+                configured_frame_ttl(Some("invalid")),
+                Duration::from_secs(7 * 24 * 60 * 60)
+            );
+        }
+
+        #[test]
+        fn prune_frames_removes_expired_camera_jpegs_only() {
+            let nonce = format!("{}-{}", std::process::id(), now_ms());
+            let dir = std::env::temp_dir().join(format!("buddy-sense-prune-ttl-{nonce}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+            let expired = dir.join("cam-expired.jpg");
+            let fresh = dir.join("cam-fresh.jpg");
+            let unrelated = dir.join("portrait.jpg");
+            write_frame_with_mtime(&expired, SystemTime::UNIX_EPOCH + Duration::from_secs(799));
+            write_frame_with_mtime(&fresh, SystemTime::UNIX_EPOCH + Duration::from_secs(900));
+            write_frame_with_mtime(
+                &unrelated,
+                SystemTime::UNIX_EPOCH + Duration::from_secs(100),
+            );
+
+            let removed = prune_frames_at(&dir, 500, Duration::from_secs(200), now).unwrap();
+
+            assert_eq!(removed, vec![expired.clone()]);
+            assert!(!expired.exists());
+            assert!(fresh.exists());
+            assert!(unrelated.exists());
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+
+        #[test]
+        fn prune_frames_keeps_only_the_newest_requested_count() {
+            let nonce = format!("{}-{}", std::process::id(), now_ms());
+            let dir = std::env::temp_dir().join(format!("buddy-sense-prune-count-{nonce}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+            let mut frames = Vec::new();
+            for second in 996..=1_000 {
+                let path = dir.join(format!("cam-{second}.jpg"));
+                write_frame_with_mtime(&path, SystemTime::UNIX_EPOCH + Duration::from_secs(second));
+                frames.push(path);
+            }
+
+            let removed = prune_frames_at(&dir, 2, Duration::from_secs(1_000), now).unwrap();
+
+            assert_eq!(removed.len(), 3);
+            assert!(!frames[0].exists());
+            assert!(!frames[1].exists());
+            assert!(!frames[2].exists());
+            assert!(frames[3].exists());
+            assert!(frames[4].exists());
             std::fs::remove_dir_all(dir).unwrap();
         }
 

--- a/buddy-sense/src/senses/video.rs
+++ b/buddy-sense/src/senses/video.rs
@@ -76,6 +76,76 @@ pub mod live {
     const H: usize = 48;
     const FRAME_KEEP: usize = 500;
     const DEFAULT_FRAME_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+    const DEFAULT_CAMERA_FAILURE_THRESHOLD: u32 = 20;
+    const DEFAULT_CAMERA_RETRY_MS: u64 = 500;
+    const CAMERA_ALIVE_SALIENCE: u8 = 10;
+    const CAMERA_UNAVAILABLE_SALIENCE: u8 = 180;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum CameraTransition {
+        Offline,
+        Online,
+    }
+
+    #[derive(Debug)]
+    struct CameraHealth {
+        consecutive_failures: u32,
+        failure_threshold: u32,
+        offline: bool,
+    }
+
+    impl CameraHealth {
+        fn new(failure_threshold: u32) -> Self {
+            Self {
+                consecutive_failures: 0,
+                failure_threshold: failure_threshold.max(1),
+                offline: false,
+            }
+        }
+
+        fn capture_failed(&mut self) -> Option<CameraTransition> {
+            self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+            if !self.offline && self.consecutive_failures >= self.failure_threshold {
+                self.offline = true;
+                Some(CameraTransition::Offline)
+            } else {
+                None
+            }
+        }
+
+        fn capture_succeeded(&mut self) -> Option<CameraTransition> {
+            self.consecutive_failures = 0;
+            if self.offline {
+                self.offline = false;
+                Some(CameraTransition::Online)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct CaptureRecoveryConfig {
+        failure_threshold: u32,
+        retry_delay: Duration,
+    }
+
+    fn configured_recovery(
+        failure_threshold: Option<&str>,
+        retry_ms: Option<&str>,
+    ) -> CaptureRecoveryConfig {
+        let failure_threshold = failure_threshold
+            .and_then(|value| value.parse::<u32>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_CAMERA_FAILURE_THRESHOLD);
+        let retry_ms = retry_ms
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_CAMERA_RETRY_MS);
+        CaptureRecoveryConfig {
+            failure_threshold,
+            retry_delay: Duration::from_millis(retry_ms),
+        }
+    }
 
     fn ffmpeg_bin() -> String {
         std::env::var("BUDDY_SENSE_FFMPEG")
@@ -249,10 +319,70 @@ pub mod live {
     ) {
         let dir = frame_dir();
         let program = ffmpeg_bin();
+        let failure_threshold = std::env::var("BUDDY_SENSE_CAMERA_FAILURE_THRESHOLD").ok();
+        let retry_ms = std::env::var("BUDDY_SENSE_CAMERA_RETRY_MS").ok();
+        let recovery = configured_recovery(failure_threshold.as_deref(), retry_ms.as_deref());
         let _ = tokio::task::spawn_blocking(move || {
-            capture_loop(tx, &device, interval_ms, threshold, &dir, program.as_ref())
+            capture_loop(
+                tx,
+                &device,
+                interval_ms,
+                threshold,
+                &dir,
+                program.as_ref(),
+                recovery,
+            )
         })
         .await;
+    }
+
+    fn emit_camera_transition(
+        tx: &mpsc::Sender<SensoryEvent>,
+        camera: &str,
+        health: &CameraHealth,
+        transition: CameraTransition,
+    ) -> bool {
+        let (kind, salience) = match transition {
+            CameraTransition::Offline => {
+                eprintln!(
+                    "[buddy-sense] live-vision: camera {camera} unavailable after {} consecutive capture failures",
+                    health.consecutive_failures
+                );
+                ("camera_unavailable", CAMERA_UNAVAILABLE_SALIENCE)
+            }
+            CameraTransition::Online => {
+                eprintln!("[buddy-sense] live-vision: camera {camera} alive");
+                ("camera_alive", CAMERA_ALIVE_SALIENCE)
+            }
+        };
+        let event = SensoryEvent::new(
+            Modality::Vision,
+            kind,
+            salience,
+            serde_json::json!({
+                "camera": camera,
+                "confidence": 1.0,
+                "consecutiveFailures": health.consecutive_failures,
+            }),
+        );
+        tx.blocking_send(event).is_ok()
+    }
+
+    fn note_capture_failure(
+        tx: &mpsc::Sender<SensoryEvent>,
+        camera: &str,
+        health: &mut CameraHealth,
+    ) -> bool {
+        match health.capture_failed() {
+            Some(transition) => emit_camera_transition(tx, camera, health, transition),
+            None => !tx.is_closed(),
+        }
+    }
+
+    fn wait_before_retry(delay: Duration) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
     }
 
     fn capture_loop(
@@ -262,87 +392,116 @@ pub mod live {
         threshold: f64,
         dir: &Path,
         program: &OsStr,
+        recovery: CaptureRecoveryConfig,
     ) {
         let camera = device.rsplit('/').next().unwrap_or("camera").to_string();
         let safe_camera = camera_name(device);
         let latest_frame = dir.join(format!(".buddy-sense-{safe_camera}-latest.jpg"));
-        // Never use a stale keyframe if capture fails before ffmpeg's first JPEG.
-        let _ = std::fs::remove_file(&latest_frame);
+        let mut health = CameraHealth::new(recovery.failure_threshold);
 
-        let mut child = match Command::new(program)
-            .args(ffmpeg_args(device, interval_ms, &latest_frame))
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .spawn()
-        {
-            Ok(child) => child,
-            Err(error) => {
-                eprintln!(
-                    "[buddy-sense] live-vision: ffmpeg spawn failed ({error}); is ffmpeg installed? sense disabled"
-                );
-                return;
-            }
-        };
-        let mut stdout = match child.stdout.take() {
-            Some(stdout) => stdout,
-            None => {
-                eprintln!("[buddy-sense] live-vision: no ffmpeg stdout; sense disabled");
-                let _ = child.kill();
-                let _ = child.wait();
-                return;
-            }
-        };
+        while !tx.is_closed() {
+            // Never use a stale keyframe if capture fails before ffmpeg's first JPEG.
+            let _ = std::fs::remove_file(&latest_frame);
+            let mut child = match Command::new(program)
+                .args(ffmpeg_args(device, interval_ms, &latest_frame))
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(_) => {
+                    if !note_capture_failure(&tx, &camera, &mut health) {
+                        break;
+                    }
+                    wait_before_retry(recovery.retry_delay);
+                    continue;
+                }
+            };
+            let mut stdout = match child.stdout.take() {
+                Some(stdout) => stdout,
+                None => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    if !note_capture_failure(&tx, &camera, &mut health) {
+                        break;
+                    }
+                    wait_before_retry(recovery.retry_delay);
+                    continue;
+                }
+            };
 
-        let mut prev: Option<Vec<u8>> = None;
-        let mut moving = false;
-        let mut frame = vec![0_u8; W * H];
-        loop {
-            if stdout.read_exact(&mut frame).is_err() {
+            let mut prev: Option<Vec<u8>> = None;
+            let mut moving = false;
+            let mut frame = vec![0_u8; W * H];
+            let mut receiver_open = true;
+            loop {
+                if stdout.read_exact(&mut frame).is_err() {
+                    break;
+                }
+                if let Some(transition) = health.capture_succeeded() {
+                    if !emit_camera_transition(&tx, &camera, &health, transition) {
+                        receiver_open = false;
+                        break;
+                    }
+                }
+                if let Some(p) = &prev {
+                    if p.len() == frame.len() {
+                        let score = motion_score(p, frame.as_slice());
+                        if !moving && score >= threshold {
+                            moving = true;
+                            let path = dir.join(format!("cam-{}.jpg", now_ms()));
+                            let path_str = path.to_string_lossy().to_string();
+                            let ok = retain_keyframe(&latest_frame, &path);
+                            if ok {
+                                let ttl_env = std::env::var("BUDDY_SENSE_FRAME_TTL").ok();
+                                let ttl = configured_frame_ttl(ttl_env.as_deref());
+                                if let Err(error) = prune_frames(dir, FRAME_KEEP, ttl) {
+                                    eprintln!(
+                                        "[buddy-sense] live-vision: keyframe pruning failed ({error})"
+                                    );
+                                }
+                            }
+                            let retained_path = if ok && path.is_file() {
+                                Some(path_str)
+                            } else {
+                                None
+                            };
+                            let payload = serde_json::json!({
+                                "score": score,
+                                "camera": camera,
+                                "imagePath": retained_path,
+                            });
+                            let event = SensoryEvent::new(
+                                Modality::Vision,
+                                "motion",
+                                MOTION_SALIENCE,
+                                payload,
+                            );
+                            if tx.blocking_send(event).is_err() {
+                                receiver_open = false;
+                                break;
+                            }
+                        } else if moving && score < threshold {
+                            moving = false;
+                        }
+                    } else {
+                        moving = false; // resolution change → re-baseline + re-arm
+                    }
+                }
+                prev = Some(frame.clone());
+            }
+
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&latest_frame);
+            if !receiver_open || tx.is_closed() {
                 break;
             }
-            if let Some(p) = &prev {
-                if p.len() == frame.len() {
-                    let score = motion_score(p, frame.as_slice());
-                    if !moving && score >= threshold {
-                        moving = true;
-                        let path = dir.join(format!("cam-{}.jpg", now_ms()));
-                        let path_str = path.to_string_lossy().to_string();
-                        let ok = retain_keyframe(&latest_frame, &path);
-                        if ok {
-                            let ttl_env = std::env::var("BUDDY_SENSE_FRAME_TTL").ok();
-                            let ttl = configured_frame_ttl(ttl_env.as_deref());
-                            if let Err(error) = prune_frames(dir, FRAME_KEEP, ttl) {
-                                eprintln!(
-                                    "[buddy-sense] live-vision: keyframe pruning failed ({error})"
-                                );
-                            }
-                        }
-                        let retained_path = if ok && path.is_file() {
-                            Some(path_str)
-                        } else {
-                            None
-                        };
-                        let payload = serde_json::json!({
-                            "score": score,
-                            "camera": camera,
-                            "imagePath": retained_path,
-                        });
-                        let ev =
-                            SensoryEvent::new(Modality::Vision, "motion", MOTION_SALIENCE, payload);
-                        if tx.blocking_send(ev).is_err() {
-                            break;
-                        }
-                    } else if moving && score < threshold {
-                        moving = false;
-                    }
-                } else {
-                    moving = false; // resolution change → re-baseline + re-arm
-                }
+            if !note_capture_failure(&tx, &camera, &mut health) {
+                break;
             }
-            prev = Some(frame.clone());
+            wait_before_retry(recovery.retry_delay);
         }
-        let _ = child.kill();
-        let _ = child.wait();
         let _ = std::fs::remove_file(latest_frame);
         eprintln!("[buddy-sense] live-vision: capture ended");
     }
@@ -454,6 +613,51 @@ pub mod live {
             std::fs::remove_dir_all(dir).unwrap();
         }
 
+        #[test]
+        fn camera_health_emits_each_offline_online_transition_once() {
+            let mut health = CameraHealth::new(3);
+            assert_eq!(health.capture_failed(), None);
+            assert_eq!(health.capture_failed(), None);
+            assert_eq!(health.capture_failed(), Some(CameraTransition::Offline));
+            assert_eq!(health.capture_failed(), None);
+            assert_eq!(health.capture_failed(), None);
+
+            assert_eq!(health.capture_succeeded(), Some(CameraTransition::Online));
+            assert_eq!(health.capture_succeeded(), None);
+            assert_eq!(health.capture_failed(), None);
+        }
+
+        #[test]
+        fn camera_recovery_defaults_to_about_ten_seconds_and_is_configurable() {
+            let defaults = configured_recovery(None, None);
+            assert_eq!(defaults.failure_threshold, 20);
+            assert_eq!(defaults.retry_delay, Duration::from_millis(500));
+
+            let custom = configured_recovery(Some("4"), Some("25"));
+            assert_eq!(custom.failure_threshold, 4);
+            assert_eq!(custom.retry_delay, Duration::from_millis(25));
+
+            let invalid = configured_recovery(Some("0"), Some("invalid"));
+            assert_eq!(invalid.failure_threshold, 20);
+            assert_eq!(invalid.retry_delay, Duration::from_millis(500));
+        }
+
+        #[cfg(unix)]
+        fn recv_with_timeout(rx: &mut mpsc::Receiver<SensoryEvent>) -> SensoryEvent {
+            let deadline = std::time::Instant::now() + Duration::from_secs(3);
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => return event,
+                    Err(mpsc::error::TryRecvError::Empty)
+                        if std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("camera event not received before timeout: {error}"),
+                }
+            }
+        }
+
         #[cfg(unix)]
         #[test]
         fn capture_loop_spawns_once_and_retains_a_keyframe_without_reopening_device() {
@@ -466,11 +670,7 @@ pub mod live {
             let spawn_log = dir.join("spawns.log");
             let latest = dir.join(".buddy-sense-video0-latest.jpg");
             let script = format!(
-                "#!/bin/sh\n\
-                 printf 'spawn\\n' >> '{}'\n\
-                 printf 'jpeg-from-the-persistent-process' > '{}'\n\
-                 dd if=/dev/zero bs={} count=1 2>/dev/null\n\
-                 dd if=/dev/zero bs={} count=1 2>/dev/null | tr '\\000' '\\377'\n",
+                "#!/bin/sh\nprintf 'spawn\\n' >> '{}'\nprintf 'jpeg-from-the-persistent-process' > '{}'\ndd if=/dev/zero bs={} count=1 2>/dev/null\ndd if=/dev/zero bs={} count=1 2>/dev/null | tr '\\000' '\\377'\nsleep 0.2\n",
                 spawn_log.display(),
                 latest.display(),
                 W * H,
@@ -482,11 +682,24 @@ pub mod live {
             std::fs::set_permissions(&program, permissions).unwrap();
 
             let (tx, mut rx) = mpsc::channel(1);
-            capture_loop(tx, "/dev/video0", 1_500, 0.1, &dir, program.as_os_str());
+            let capture_dir = dir.clone();
+            let capture_program = program.clone();
+            let handle = std::thread::spawn(move || {
+                capture_loop(
+                    tx,
+                    "/dev/video0",
+                    1_500,
+                    0.1,
+                    &capture_dir,
+                    capture_program.as_os_str(),
+                    CaptureRecoveryConfig {
+                        failure_threshold: 3,
+                        retry_delay: Duration::from_millis(1),
+                    },
+                );
+            });
 
-            let event = rx
-                .blocking_recv()
-                .expect("the changed raw frame should emit motion");
+            let event = recv_with_timeout(&mut rx);
             assert_eq!(event.kind, "motion");
             let image_path = event.payload["imagePath"]
                 .as_str()
@@ -495,8 +708,71 @@ pub mod live {
                 std::fs::read(image_path).unwrap(),
                 b"jpeg-from-the-persistent-process"
             );
+            drop(rx);
+            handle.join().unwrap();
             assert_eq!(std::fs::read_to_string(spawn_log).unwrap(), "spawn\n");
 
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn capture_loop_emits_unavailable_then_alive_across_reconnects() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let nonce = format!("{}-{}", std::process::id(), now_ms());
+            let dir = std::env::temp_dir().join(format!("buddy-sense-recovery-test-{nonce}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let program = dir.join("recovering-ffmpeg.sh");
+            let spawn_log = dir.join("spawns.log");
+            let script = format!(
+                "#!/bin/sh\nprintf 'spawn\\n' >> '{}'\nattempts=$(wc -l < '{}')\nif [ \"$attempts\" -lt 3 ]; then exit 1; fi\ndd if=/dev/zero bs={} count=1 2>/dev/null\nsleep 0.2\n",
+                spawn_log.display(),
+                spawn_log.display(),
+                W * H,
+            );
+            std::fs::write(&program, script).unwrap();
+            let mut permissions = std::fs::metadata(&program).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&program, permissions).unwrap();
+
+            let (tx, mut rx) = mpsc::channel(4);
+            let capture_dir = dir.clone();
+            let capture_program = program.clone();
+            let handle = std::thread::spawn(move || {
+                capture_loop(
+                    tx,
+                    "/dev/video0",
+                    1_500,
+                    0.1,
+                    &capture_dir,
+                    capture_program.as_os_str(),
+                    CaptureRecoveryConfig {
+                        failure_threshold: 2,
+                        retry_delay: Duration::from_millis(1),
+                    },
+                );
+            });
+
+            let unavailable = recv_with_timeout(&mut rx);
+            let alive = recv_with_timeout(&mut rx);
+            assert_eq!(unavailable.kind, "camera_unavailable");
+            assert_eq!(unavailable.salience, CAMERA_UNAVAILABLE_SALIENCE);
+            assert_eq!(unavailable.payload["camera"], "video0");
+            assert_eq!(unavailable.payload["confidence"], 1.0);
+            assert_eq!(unavailable.payload["consecutiveFailures"], 2);
+            assert_eq!(alive.kind, "camera_alive");
+            assert_eq!(alive.salience, CAMERA_ALIVE_SALIENCE);
+            assert_eq!(alive.payload["camera"], "video0");
+            assert_eq!(alive.payload["confidence"], 1.0);
+            assert_eq!(alive.payload["consecutiveFailures"], 0);
+
+            drop(rx);
+            handle.join().unwrap();
+            assert_eq!(
+                std::fs::read_to_string(spawn_log).unwrap(),
+                "spawn\nspawn\nspawn\n"
+            );
             std::fs::remove_dir_all(dir).unwrap();
         }
     }

--- a/src/fleet/capability-registry.ts
+++ b/src/fleet/capability-registry.ts
@@ -43,6 +43,8 @@ import type {
 /** Cached snapshot — rebuilt every refresh interval. */
 let cached: PeerCapability | null = null;
 let lastRefreshAt = 0;
+/** In-flight rebuild shared by concurrent callers after cache expiry. */
+let building: Promise<PeerCapability> | null = null;
 /** Refresh window: 5 minutes — enough to catch a manual Ollama restart. */
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const ANSI_ESCAPE_PATTERN = new RegExp(
@@ -68,9 +70,20 @@ export async function getLocalCapabilities(
     // would make the router's load term worse than useless.
     return { ...cached, activeRequests: getFleetLoad().activeRequests };
   }
-  cached = await buildCapabilitySnapshot();
-  lastRefreshAt = now;
-  return { ...cached, activeRequests: getFleetLoad().activeRequests };
+  if (!building) {
+    building = buildCapabilitySnapshot()
+      .then((snapshot) => {
+        cached = snapshot;
+        lastRefreshAt = Date.now();
+        return snapshot;
+      })
+      .finally(() => {
+        building = null;
+      });
+  }
+
+  const snapshot = await building;
+  return { ...snapshot, activeRequests: getFleetLoad().activeRequests };
 }
 
 /** Sync getter — returns last cached snapshot or empty stub. */

--- a/src/memory/buddy-memory-client.ts
+++ b/src/memory/buddy-memory-client.ts
@@ -171,9 +171,15 @@ export class BuddyMemoryClient {
 
   /** Stop the engine (test seam / shutdown). */
   close(): void {
+    const child = this.child;
     this.fail();
     try {
-      this.child?.kill();
+      if (child && !child.stdin.destroyed) child.stdin.end();
+    } catch {
+      /* ignore */
+    }
+    try {
+      child?.kill();
     } catch {
       /* ignore */
     }

--- a/src/memory/collective-knowledge-graph.ts
+++ b/src/memory/collective-knowledge-graph.ts
@@ -189,13 +189,14 @@ interface EmbeddingCacheEvent {
 const SCOPE = 'collective';
 
 function normalizeName(s: string): string {
-  return s
+  const normalized = s
     .toLowerCase()
     .normalize('NFD')
     .replace(/\p{M}+/gu, '')
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80);
+    .replace(/^-+|-+$/g, '');
+  if (normalized.length <= 80) return normalized;
+  return `${normalized.slice(0, 71)}-${contentHash('name', normalized).slice(0, 8)}`;
 }
 
 /** Code-Explorer id convention: `Type:scope:name`. */

--- a/src/memory/collective-knowledge-graph.ts
+++ b/src/memory/collective-knowledge-graph.ts
@@ -36,6 +36,7 @@ import {
   existsSync,
   mkdirSync,
   openSync,
+  readFileSync,
   readSync,
   statSync,
   writeFileSync,
@@ -49,6 +50,7 @@ import { getCodeBuddyHome } from '../utils/codebuddy-home.js';
 import { EmbeddingProvider } from '../embeddings/embedding-provider.js';
 import { BM25Index } from '../search/bm25.js';
 import { cosineSimilarityF32, hybridMmrRank, type HybridCandidate } from './hybrid-mmr.js';
+import { withTimeout } from '../utils/errors.js';
 import {
   canonicalObject,
   factMatchKey,
@@ -178,6 +180,12 @@ interface LedgerEvent {
   reason?: string;
 }
 
+interface EmbeddingCacheEvent {
+  hash: string;
+  model: string;
+  vec: number[];
+}
+
 const SCOPE = 'collective';
 
 function normalizeName(s: string): string {
@@ -230,6 +238,7 @@ export interface CkgEmbedder {
  */
 export class CollectiveKnowledgeGraph {
   private readonly ledgerPath: string;
+  private readonly embeddingCachePath: string;
   private readonly agentId: string;
   /** Currently-true nodes (validTo === null), keyed by logical id. */
   private readonly current = new Map<string, CkgEntity>();
@@ -245,6 +254,7 @@ export class CollectiveKnowledgeGraph {
   private ledgerInode: number | null = null;
   /** contentHash → embedding vector. Content-addressed, so it survives ledger reloads. */
   private readonly embCache = new Map<string, Float32Array>();
+  private embeddingCacheLoaded = false;
   private readonly embeddingModel: string;
   private embedder: CkgEmbedder | null = null;
   /** Rust engine client (lazy) — used only when CODEBUDDY_CKG_ENGINE=rust and the binary exists.
@@ -254,6 +264,7 @@ export class CollectiveKnowledgeGraph {
 
   constructor(options: CollectiveKnowledgeGraphOptions = {}) {
     this.ledgerPath = options.ledgerPath ?? join(getCodeBuddyHome(), 'collective', 'ckg-ledger.jsonl');
+    this.embeddingCachePath = `${this.ledgerPath}.emb.jsonl`;
     this.agentId = options.agentId ?? safeAgentId();
     this.embeddingModel = options.embeddingModel ?? CKG_EMBEDDING_MODEL;
     this.embedder = options.embedder ?? null;
@@ -399,16 +410,12 @@ export class CollectiveKnowledgeGraph {
       const self = this.current.get(stored.id);
       if (!self) return stored;
       const provider = this.getEmbedder();
-      const selfVec = (await provider.embed(`${self.name}. ${self.text}`)).embedding;
-      this.embCache.set(self.contentHash, selfVec);
+      this.loadEmbeddingCache();
+      const selfVec = await this.embedEntity(provider, self);
       const sims: Array<{ e: CkgEntity; sim: number }> = [];
       for (const e of this.current.values()) {
         if (e.id === self.id) continue;
-        let v = this.embCache.get(e.contentHash);
-        if (!v) {
-          v = (await provider.embed(`${e.name}. ${e.text}`)).embedding;
-          this.embCache.set(e.contentHash, v);
-        }
+        const v = await this.embedEntity(provider, e);
         sims.push({ e, sim: cosineSimilarityF32(selfVec, v) });
       }
       sims.sort((a, b) => b.sim - a.sim);
@@ -516,13 +523,12 @@ export class CollectiveKnowledgeGraph {
     if (candidates.length === 0) return [];
 
     const provider = this.getEmbedder();
+    this.loadEmbeddingCache();
     let qVec: Float32Array | null = null;
     try {
       qVec = (await provider.embed(query)).embedding;
       for (const e of candidates) {
-        if (!this.embCache.has(e.contentHash)) {
-          this.embCache.set(e.contentHash, (await provider.embed(`${e.name}. ${e.text}`)).embedding);
-        }
+        await this.embedEntity(provider, e);
       }
     } catch (err) {
       // Embeddings unavailable → degrade gracefully to keyword recall (still useful, $0, no crash).
@@ -573,8 +579,20 @@ export class CollectiveKnowledgeGraph {
 
   /** A `<collective_knowledge>` system block for prompt injection (token-budgeted).
    *  Uses hybrid (semantic+keyword) retrieval; degrades to keyword if embeddings are unavailable. */
-  async formatCollectiveContext(query: string, maxChars = 600): Promise<string> {
-    const hits = await this.recallHybrid(query, { limit: 8 });
+  async formatCollectiveContext(query: string, maxChars = 600, timeoutMs = 3_000): Promise<string> {
+    let hits: CkgRecallResult[];
+    try {
+      hits = await withTimeout(
+        this.recallHybrid(query, { limit: 8 }),
+        timeoutMs,
+        'Collective knowledge recall timed out',
+      );
+    } catch (err) {
+      logger.debug(
+        `[ckg] collective context skipped: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return '';
+    }
     if (hits.length === 0) return '';
     const lines: string[] = [];
     let used = 0;
@@ -873,6 +891,48 @@ export class CollectiveKnowledgeGraph {
 
   // -- internals ------------------------------------------------------------
 
+  /** Load vectors written by previous processes, accepting only this instance's model. */
+  private loadEmbeddingCache(): void {
+    if (this.embeddingCacheLoaded) return;
+    this.embeddingCacheLoaded = true;
+    if (!existsSync(this.embeddingCachePath)) return;
+    let content: string;
+    try {
+      content = readFileSync(this.embeddingCachePath, 'utf8');
+    } catch (err) {
+      logger.debug(`[ckg] embedding cache unavailable: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    for (const line of content.split('\n')) {
+      const event = parseEmbeddingCacheEvent(line);
+      if (!event || event.model !== this.embeddingModel || this.embCache.has(event.hash)) continue;
+      this.embCache.set(event.hash, Float32Array.from(event.vec));
+    }
+  }
+
+  private async embedEntity(provider: CkgEmbedder, entity: CkgEntity): Promise<Float32Array> {
+    const cached = this.embCache.get(entity.contentHash);
+    if (cached) return cached;
+    // The vector input depends only on the content-addressed hash (type + text), not the
+    // mutable display name, so persisted vectors remain valid across processes/reloads.
+    const vector = (await provider.embed(entity.text)).embedding;
+    this.embCache.set(entity.contentHash, vector);
+    this.persistEmbedding(entity.contentHash, vector);
+    return vector;
+  }
+
+  private persistEmbedding(hash: string, vector: Float32Array): void {
+    try {
+      const dir = dirname(this.embeddingCachePath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      const event: EmbeddingCacheEvent = { hash, model: this.embeddingModel, vec: Array.from(vector) };
+      appendFileSync(this.embeddingCachePath, `${JSON.stringify(event)}\n`, 'utf8');
+    } catch (err) {
+      // Persistence is an optimisation: semantic recall remains available in-memory.
+      logger.debug(`[ckg] embedding cache write skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   private append(event: LedgerEvent): void {
     const dir = dirname(this.ledgerPath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
@@ -1108,6 +1168,23 @@ export class CollectiveKnowledgeGraph {
 
 function clamp01(n: number): number {
   return Math.max(0, Math.min(1, Number.isFinite(n) ? n : 0.8));
+}
+
+function parseEmbeddingCacheEvent(line: string): EmbeddingCacheEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.hash !== 'string' || typeof candidate.model !== 'string') return null;
+  if (!Array.isArray(candidate.vec) || candidate.vec.length === 0) return null;
+  if (!candidate.vec.every((value) => typeof value === 'number' && Number.isFinite(value))) return null;
+  return { hash: candidate.hash, model: candidate.model, vec: [...candidate.vec] as number[] };
 }
 
 /** Recover the fact category from a fact node's match-key name. */

--- a/src/memory/persistent-memory.ts
+++ b/src/memory/persistent-memory.ts
@@ -847,7 +847,7 @@ export class PersistentMemoryManager extends EventEmitter {
       const tags = memory.tags?.length ? ` [${memory.tags.join(", ")}]` : "";
       return (
         `- **${memory.key}** (${memory.category}${tags}, accessed ${memory.accessCount}×, ` +
-        `age ${Math.round(candidate.ageDays)}d, retention ${candidate.retention.toFixed(3)}): ${memory.value}`
+        `age ${Math.round(candidate.ageDays)}d, retention ${candidate.retention.toFixed(3)}): ${escapeArchiveValue(memory.value)}`
       );
     });
 
@@ -968,7 +968,7 @@ export class PersistentMemoryManager extends EventEmitter {
         .filter(Boolean);
       entries.push({
         key: entryKey,
-        value,
+        value: unescapeArchiveValue(value),
         category,
         ...(tags?.length ? { tags } : {}),
         forgottenAt,
@@ -1372,6 +1372,20 @@ export class PersistentMemoryManager extends EventEmitter {
       total: this.projectMemories.size + this.userMemories.size,
     };
   }
+}
+
+const ARCHIVE_ESCAPED_VALUE_PREFIX = "@codebuddy-escaped-v1:";
+
+function escapeArchiveValue(value: string): string {
+  return ARCHIVE_ESCAPED_VALUE_PREFIX + value.replace(/\\/g, "\\\\").replace(/\r?\n/g, "\\n");
+}
+
+/** Decode backslash/newline escapes in one pass so a literal `\\n` stays literal. */
+function unescapeArchiveValue(value: string): string {
+  if (!value.startsWith(ARCHIVE_ESCAPED_VALUE_PREFIX)) return value;
+  return value
+    .slice(ARCHIVE_ESCAPED_VALUE_PREFIX.length)
+    .replace(/\\(\\|n)/g, (_match, escaped: string) => escaped === "n" ? "\n" : "\\");
 }
 
 // Default singleton instance (no bot scope) + per-bot instances.

--- a/src/sensory/reactions.ts
+++ b/src/sensory/reactions.ts
@@ -41,7 +41,9 @@ export function wireSensoryReactions(onPerception?: (p: Perception, evt: BaseEve
   const bus = getGlobalEventBus();
   const id = bus.on('sensory:perception', (evt: BaseEvent) => {
     const p = perceptionOf(evt);
-    logger.info(`[sensory] ${p.modality}/${p.kind} (salience ${p.salience ?? 0})`);
+    const message = `[sensory] ${p.modality}/${p.kind} (salience ${p.salience ?? 0})`;
+    if ((p.salience ?? 0) < 128) logger.debug(message);
+    else logger.info(message);
     getSensoryMemory().push(p); // short-term memory → consolidated by dreaming
     onPerception?.(p, evt);
   });

--- a/src/sensory/reactions.ts
+++ b/src/sensory/reactions.ts
@@ -22,6 +22,12 @@ export interface Perception {
   payload?: unknown;
 }
 
+/** Speech can initiate a real agent turn, so it must never be wired on an
+ * unauthenticated sensory bridge. Keep this invariant pure and easy to test. */
+export function shouldWireSpeechReaction(env: { speech?: string; token?: string }): boolean {
+  return env.speech === 'true' && Boolean(env.token);
+}
+
 export function perceptionOf(evt: BaseEvent): Perception {
   const meta = (evt.metadata as Perception | undefined) ?? {};
   return { ...meta, receivedAt: evt.timestamp };

--- a/src/sensory/sensory-bridge.ts
+++ b/src/sensory/sensory-bridge.ts
@@ -49,6 +49,8 @@ interface RawSensoryFrame {
  * shape (no control chars / newlines, ≤64 chars) so a crafted local frame can't
  * inject content downstream (e.g. into CODEBUDDY_MEMORY.md via dreaming). */
 const KNOWN_MODALITIES = new Set(['audio', 'vision', 'screen', 'vital', 'ui']);
+const MAX_WEBSOCKET_PAYLOAD_BYTES = 256 * 1024;
+const MAX_FRAME_BYTES = 64 * 1024;
 
 let bridgeHealth: SensoryBridgeHealth = { status: 'disabled', ready: false };
 
@@ -70,7 +72,7 @@ export function startSensoryBridge(options: SensoryBridgeOptions = {}): SensoryB
   const token = options.token ?? process.env.CODEBUDDY_SENSORY_TOKEN;
   const bus = getGlobalEventBus();
 
-  const wss = new WebSocketServer({ host, port });
+  const wss = new WebSocketServer({ host, port, maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES });
   bridgeHealth = { status: 'starting', ready: false, port };
 
   let readySettled = false;
@@ -117,11 +119,18 @@ export function startSensoryBridge(options: SensoryBridgeOptions = {}): SensoryB
       return;
     }
     logger.info('[sensory] daemon connected');
+    // `ws` emits a socket-level error before closing oversized messages with
+    // code 1009. Always consume it so malformed local input cannot crash Node.
+    ws.on('error', (err) => {
+      logger.warn(`[sensory] daemon socket error: ${err instanceof Error ? err.message : String(err)}`);
+    });
 
     ws.on('message', (data) => {
+      const raw = String(data);
+      if (Buffer.byteLength(raw, 'utf8') > MAX_FRAME_BYTES) return;
       let frame: RawSensoryFrame;
       try {
-        frame = JSON.parse(String(data)) as RawSensoryFrame;
+        frame = JSON.parse(raw) as RawSensoryFrame;
       } catch {
         return; // ignore malformed
       }

--- a/src/sensory/sensory-bridge.ts
+++ b/src/sensory/sensory-bridge.ts
@@ -23,8 +23,17 @@ export interface SensoryBridgeOptions {
 }
 
 export interface SensoryBridgeHandle {
-  port: number;
+  readonly port: number;
+  /** Resolves only after the socket is bound; rejects on bind failure. */
+  ready: Promise<void>;
   close(): Promise<void>;
+}
+
+export interface SensoryBridgeHealth {
+  status: 'disabled' | 'starting' | 'listening' | 'error' | 'closed';
+  ready: boolean;
+  port?: number;
+  error?: string;
 }
 
 interface RawSensoryFrame {
@@ -41,6 +50,13 @@ interface RawSensoryFrame {
  * inject content downstream (e.g. into CODEBUDDY_MEMORY.md via dreaming). */
 const KNOWN_MODALITIES = new Set(['audio', 'vision', 'screen', 'vital', 'ui']);
 
+let bridgeHealth: SensoryBridgeHealth = { status: 'disabled', ready: false };
+
+/** Lightweight process-local status consumed by the HTTP health endpoints. */
+export function getSensoryBridgeHealth(): SensoryBridgeHealth {
+  return { ...bridgeHealth };
+}
+
 function sanitizeKind(kind: string): string {
   // `/` is part of the daemon's canonical vocabulary (`memory/digest`,
   // `audio/transcript_final`). Keep it while still rejecting whitespace,
@@ -55,6 +71,36 @@ export function startSensoryBridge(options: SensoryBridgeOptions = {}): SensoryB
   const bus = getGlobalEventBus();
 
   const wss = new WebSocketServer({ host, port });
+  bridgeHealth = { status: 'starting', ready: false, port };
+
+  let readySettled = false;
+  const ready = new Promise<void>((resolve, reject) => {
+    wss.once('listening', () => {
+      readySettled = true;
+      const address = wss.address();
+      const boundPort = typeof address === 'object' && address ? address.port : port;
+      bridgeHealth = { status: 'listening', ready: true, port: boundPort };
+      logger.info(`[sensory] bridge listening on ws://${host}:${boundPort}`);
+      resolve();
+    });
+
+    wss.on('error', (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      const message = err instanceof Error ? err.message : String(err);
+      bridgeHealth = { status: 'error', ready: false, port, error: message };
+      if (code === 'EADDRINUSE') {
+        logger.error(
+          `[sensory] bridge cannot bind ws://${host}:${port}: port already in use; sensory input is unavailable`,
+        );
+      } else {
+        logger.error(`[sensory] bridge error on ws://${host}:${port}: ${message}`);
+      }
+      if (!readySettled) {
+        readySettled = true;
+        reject(err);
+      }
+    });
+  });
 
   wss.on('connection', (ws, req) => {
     // Reject cross-origin (CSWSH): the Rust daemon sends NO Origin header; a
@@ -104,11 +150,18 @@ export function startSensoryBridge(options: SensoryBridgeOptions = {}): SensoryB
     });
   });
 
-  wss.on('error', (err) => logger.warn(`[sensory] bridge error: ${err instanceof Error ? err.message : String(err)}`));
-  logger.info(`[sensory] bridge listening on ws://${host}:${port}`);
-
   return {
-    port,
-    close: () => new Promise<void>((resolve) => wss.close(() => resolve())),
+    get port() {
+      const address = wss.address();
+      return typeof address === 'object' && address ? address.port : port;
+    },
+    ready,
+    close: () =>
+      new Promise<void>((resolve) => {
+        wss.close(() => {
+          bridgeHealth = { status: 'closed', ready: false, port };
+          resolve();
+        });
+      }),
   };
 }

--- a/src/sensory/sensory-rules-engine.ts
+++ b/src/sensory/sensory-rules-engine.ts
@@ -11,7 +11,7 @@
  */
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { readFile, writeFile, appendFile, mkdir, stat } from 'node:fs/promises';
+import { readFile, writeFile, appendFile, mkdir, stat, rename, rm } from 'node:fs/promises';
 import { getGlobalEventBus } from '../events/event-bus.js';
 import { logger } from '../utils/logger.js';
 import type { BaseEvent } from '../events/types.js';
@@ -40,6 +40,24 @@ function rulesPath(): string {
 }
 function auditPath(): string {
   return process.env.CODEBUDDY_RULE_RUNS_FILE || join(homedir(), '.codebuddy', 'companion', 'rule-runs.jsonl');
+}
+
+const RULE_RUNS_MAX_BYTES = 512 * 1024;
+
+/** Append one rule audit entry while keeping the sidecar bounded to one backup. */
+export async function appendRuleRun(run: RuleRun, path = auditPath()): Promise<void> {
+  await mkdir(join(path, '..'), { recursive: true });
+  let size = 0;
+  try {
+    size = (await stat(path)).size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  if (size > RULE_RUNS_MAX_BYTES) {
+    await rm(`${path}.1`, { force: true });
+    await rename(path, `${path}.1`);
+  }
+  await appendFile(path, `${JSON.stringify(run)}\n`, 'utf8');
 }
 
 export async function loadSensoryRules(path = rulesPath()): Promise<SensoryRule[]> {
@@ -271,12 +289,14 @@ export function wireSensoryRules(
         const res = await execute(rule.action, ctx).catch((e) => ({ ok: false, detail: String(e) }));
         logger.info(`[rules] ${rule.id} (${rule.action.type}) → ${res.ok ? 'ok' : 'FAIL'}${res.detail ? `: ${res.detail.slice(0, 80)}` : ''}`);
         try {
-          const ap = auditPath();
-          await mkdir(join(ap, '..'), { recursive: true });
-          await appendFile(
-            ap,
-            JSON.stringify({ ts: t, rule: rule.id, action: rule.action.type, kind: p.kind, ok: res.ok, detail: res.detail }) + '\n',
-          );
+          await appendRuleRun({
+            ts: t,
+            rule: rule.id,
+            action: rule.action.type,
+            kind: p.kind,
+            ok: res.ok,
+            detail: res.detail,
+          });
         } catch {
           /* best-effort audit */
         }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1283,7 +1283,7 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
         sensoryWired = true; // wire once per process (a 2nd start would double listeners + re-bind the port)
         try {
           const { startSensoryBridge } = await import('../sensory/sensory-bridge.js');
-          const { wireSensoryReactions } = await import('../sensory/reactions.js');
+          const { shouldWireSpeechReaction, wireSensoryReactions } = await import('../sensory/reactions.js');
           const { getHeartbeatScheduler } = await import('../sensory/heartbeat-scheduler.js');
           const sensoryBridgeHandle = startSensoryBridge();
           const unwireReactions = wireSensoryReactions();
@@ -1383,7 +1383,12 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
           }
           // Speech reaction (opt-in) — speech_end → STT → 'hearing' percept (+ onHeard hook).
           // With CODEBUDDY_SENSORY_SPEAK=true the loop closes: STT → think (local $0) → speak (Piper).
-          if (process.env.CODEBUDDY_SENSORY_SPEECH === 'true') {
+          if (
+            shouldWireSpeechReaction({
+              speech: process.env.CODEBUDDY_SENSORY_SPEECH,
+              token: sensoryToken,
+            })
+          ) {
             const { wireSpeechReaction } = await import('../sensory/speech-reaction.js');
             if (process.env.CODEBUDDY_SENSORY_SPEAK === 'true') {
               const {
@@ -1789,6 +1794,10 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
               sensoryTeardown.push(wireSpeechReaction());
               logger.info('Sensory speech reaction: Enabled (speech_end → STT → percept)');
             }
+          } else if (process.env.CODEBUDDY_SENSORY_SPEECH === 'true') {
+            logger.warn(
+              'Sensory speech reaction NOT enabled: set CODEBUDDY_SENSORY_TOKEN (speech can trigger an agent turn).',
+            );
           }
           // Privacy: camera/screen descriptions land in percepts.jsonl — warn if not encrypted at rest.
           if (

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1286,6 +1286,8 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
           const { shouldWireSpeechReaction, wireSensoryReactions } = await import('../sensory/reactions.js');
           const { getHeartbeatScheduler } = await import('../sensory/heartbeat-scheduler.js');
           const sensoryBridgeHandle = startSensoryBridge();
+          sensoryTeardown.push(() => sensoryBridgeHandle.close());
+          await sensoryBridgeHandle.ready;
           const unwireReactions = wireSensoryReactions();
           const { wireSensoryWorkspace } = await import('../cognition/sensory-workspace.js');
           const embodiedCognition = wireSensoryWorkspace({
@@ -1297,7 +1299,6 @@ export async function startServer(userConfig: Partial<ServerConfig> = {}): Promi
             embodiedCognition.workspace,
           );
           sensoryTeardown.push(
-            () => sensoryBridgeHandle.close(),
             unwireReactions,
             () => embodiedCognition.close(),
           );

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -143,6 +143,7 @@ interface HealthCheckResponse {
     database: 'ok' | 'error';
     api: 'ok' | 'error';
     memory: 'ok' | 'error';
+    sensoryBridge?: 'ok' | 'error';
   };
   memory: {
     heapUsedMB: number;
@@ -203,11 +204,15 @@ function getApiHeartbeatStatus(): 'ok' | 'stale' | 'unknown' {
 router.get(
   '/',
   asyncHandler(async (_req: Request, res: Response) => {
-    const checks = {
+    const checks: HealthCheckResponse['checks'] = {
       database: checkDatabase(),
       api: checkApi(),
       memory: checkMemory(),
     };
+    if (process.env.CODEBUDDY_SENSORY === 'true') {
+      const { getSensoryBridgeHealth } = await import('../../sensory/sensory-bridge.js');
+      checks.sensoryBridge = getSensoryBridgeHealth().ready ? 'ok' : 'error';
+    }
 
     const checksOk = Object.values(checks).filter((c) => c === 'ok').length;
     const totalChecks = Object.values(checks).length;
@@ -289,6 +294,18 @@ router.get(
         : `Memory pressure (${Math.round(memUsage.heapUsed / 1024 / 1024)}MB exceeds threshold)`,
     };
 
+    if (process.env.CODEBUDDY_SENSORY === 'true') {
+      const { getSensoryBridgeHealth } = await import('../../sensory/sensory-bridge.js');
+      const health = getSensoryBridgeHealth();
+      checks.sensoryBridge = {
+        ready: health.ready,
+        message:
+          health.status === 'error'
+            ? `Sensory bridge failed: ${health.error ?? 'unknown error'}`
+            : `Sensory bridge ${health.status}`,
+      };
+    }
+
     if (provider?.provider === 'grok') {
       const apiStart = Date.now();
       try {
@@ -320,7 +337,11 @@ router.get(
     }
 
     const allPassing = Object.values(checks).every((c) => c.ready);
-    const criticalPassing = checks.provider.ready && checks.database.ready && checks.memory.ready;
+    const criticalPassing =
+      checks.provider.ready &&
+      checks.database.ready &&
+      checks.memory.ready &&
+      (checks.sensoryBridge?.ready ?? true);
 
     const response = {
       ready: criticalPassing,

--- a/tests/fleet/capability-registry.test.ts
+++ b/tests/fleet/capability-registry.test.ts
@@ -461,6 +461,27 @@ describe('capability-registry — Hermes role tags', () => {
 });
 
 describe('capability-registry — caching', () => {
+  it('deduplicates concurrent snapshot builds', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('econn');
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const snapshots = await Promise.all(
+      Array.from({ length: 5 }, () => getLocalCapabilities()),
+    );
+
+    const probedUrls = fetchSpy.mock.calls.map(([url]) => String(url));
+    expect(probedUrls.length).toBeGreaterThan(0);
+    expect(new Set(probedUrls).size).toBe(probedUrls.length);
+    expect(snapshots).toHaveLength(5);
+    expect(
+      snapshots.every(
+        (snapshot) => snapshot.machineLabel === snapshots[0]!.machineLabel,
+      ),
+    ).toBe(true);
+  });
+
   it('caches the snapshot — second call does not re-probe', async () => {
     process.env.ANTHROPIC_API_KEY = 'k';
     const fetchSpy = vi.fn(async () => {

--- a/tests/memory/archive-restore.test.ts
+++ b/tests/memory/archive-restore.test.ts
@@ -86,6 +86,21 @@ describe('archive restore (recoverable forgetting)', () => {
     expect(fresh.get('revive-me')?.value).toBe('value worth keeping');
   });
 
+  it('round-trips a multiline value through forget, archive listing, and restore', async () => {
+    const value = 'first line\nsecond line with literal \\n marker\nthird line';
+    await forget('multiline', value);
+
+    const archived = await manager.listArchived('project');
+    expect(archived).toHaveLength(1);
+    expect(archived[0]!.value).toBe(value);
+
+    const restored = await manager.restoreFromArchive('multiline', 'project');
+    expect(restored?.result.status).toBe('stored');
+    expect(restored?.restored.value).toBe(value);
+    expect(manager.get('multiline')?.value).toBe(value);
+    expect(await manager.listArchived('project')).toHaveLength(0);
+  });
+
   it('returns null for a key that was never archived', async () => {
     expect(await manager.restoreFromArchive('never-forgotten')).toBeNull();
   });

--- a/tests/memory/buddy-memory-engine.test.ts
+++ b/tests/memory/buddy-memory-engine.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import {
   CollectiveKnowledgeGraph,
   resetCollectiveKnowledgeGraph,
 } from '../../src/memory/collective-knowledge-graph.js';
+import { BuddyMemoryClient } from '../../src/memory/buddy-memory-client.js';
 
 // The Rust engine MVP (Phase 1): keyword recall over the shared JSONL ledger via a sidecar.
 // Skips cleanly where the binary isn't built.
@@ -91,4 +92,60 @@ describe('CKG Rust engine (CODEBUDDY_CKG_ENGINE=rust)', () => {
     const hits = await b.recallHybrid('journal pertes concurrentes', { limit: 1 });
     expect(hits[0]?.corroborations).toBe(2);
   }, 30000);
+
+  it.skipIf(process.platform === 'win32')('close terminates the spawned sidecar process', async () => {
+    const fakeBin = join(dir, 'fake-buddy-memory.cjs');
+    const pidFile = join(dir, 'sidecar.pid');
+    writeFileSync(
+      fakeBin,
+      "#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.env.BUDDY_MEMORY_TEST_PID_FILE, String(process.pid));\nprocess.stdin.resume();\n",
+      'utf8',
+    );
+    chmodSync(fakeBin, 0o755);
+    const previousBin = process.env.CODEBUDDY_BUDDY_MEMORY_BIN;
+    const previousPidFile = process.env.BUDDY_MEMORY_TEST_PID_FILE;
+    process.env.CODEBUDDY_BUDDY_MEMORY_BIN = fakeBin;
+    process.env.BUDDY_MEMORY_TEST_PID_FILE = pidFile;
+    let pid: number | null = null;
+    let client: BuddyMemoryClient | null = null;
+    try {
+      client = new BuddyMemoryClient({ ledgerPath, agentId: 'test/agent' });
+      expect(client.available()).toBe(true);
+      await waitUntil(() => existsSync(pidFile));
+      pid = Number(readFileSync(pidFile, 'utf8'));
+      expect(Number.isInteger(pid)).toBe(true);
+      expect(isProcessAlive(pid)).toBe(true);
+
+      client.close();
+      await waitUntil(() => !isProcessAlive(pid!));
+      expect(isProcessAlive(pid)).toBe(false);
+    } finally {
+      client?.close();
+      if (pid !== null && isProcessAlive(pid)) {
+        try { process.kill(pid, 'SIGKILL'); } catch { /* already exited */ }
+      }
+      if (previousBin === undefined) delete process.env.CODEBUDDY_BUDDY_MEMORY_BIN;
+      else process.env.CODEBUDDY_BUDDY_MEMORY_BIN = previousBin;
+      if (previousPidFile === undefined) delete process.env.BUDDY_MEMORY_TEST_PID_FILE;
+      else process.env.BUDDY_MEMORY_TEST_PID_FILE = previousPidFile;
+    }
+  });
 });
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for sidecar process state');
+}

--- a/tests/memory/ckg-hybrid-mmr.test.ts
+++ b/tests/memory/ckg-hybrid-mmr.test.ts
@@ -61,6 +61,50 @@ async function seededGraph(): Promise<CollectiveKnowledgeGraph> {
 }
 
 describe('CKG recallHybrid — BM25 + RRF + MMR', () => {
+  it('persists corpus vectors so a new instance only embeds the query', async () => {
+    const ledgerPath = path.join(dir, 'ckg-ledger.jsonl');
+    const firstEmbed = vi.fn(async () => ({ embedding: Float32Array.from([1, 0, 0]) }));
+    const first = new CollectiveKnowledgeGraph({
+      ledgerPath,
+      agentId: 'first/agent',
+      embeddingModel: 'test/cache-model',
+      embedder: { embed: firstEmbed },
+    });
+    first.remember({ name: 'sqlite', text: 'sqlite concurrent writes require WAL' });
+    first.remember({ name: 'timeout', text: 'busy timeout prevents lock failures' });
+    await first.recallHybrid('database reliability');
+
+    expect(firstEmbed).toHaveBeenCalledTimes(3);
+    const cachePath = `${ledgerPath}.emb.jsonl`;
+    expect(fs.existsSync(cachePath)).toBe(true);
+    expect(fs.readFileSync(cachePath, 'utf8').trim().split('\n')).toHaveLength(2);
+
+    const secondEmbed = vi.fn(async () => ({ embedding: Float32Array.from([1, 0, 0]) }));
+    const second = new CollectiveKnowledgeGraph({
+      ledgerPath,
+      agentId: 'second/agent',
+      embeddingModel: 'test/cache-model',
+      embedder: { embed: secondEmbed },
+    });
+    await second.recallHybrid('database reliability');
+    expect(secondEmbed).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds collective-context recall when the embedder hangs', async () => {
+    const hanging: CkgEmbedder = {
+      embed: () => new Promise<{ embedding: Float32Array }>(() => undefined),
+    };
+    const ckg = new CollectiveKnowledgeGraph({
+      ledgerPath: path.join(dir, 'ckg-ledger.jsonl'),
+      agentId: 'test/agent',
+      embedder: hanging,
+    });
+    ckg.remember({ text: 'sqlite exige WAL' });
+    const startedAt = Date.now();
+    await expect(ckg.formatCollectiveContext('sqlite', 600, 20)).resolves.toBe('');
+    expect(Date.now() - startedAt).toBeLessThan(500);
+  });
+
   it('λ=1 (naive top-k) returns the near-duplicate cluster; default λ covers distinct facts', async () => {
     const ckg = await seededGraph();
     const query = 'sqlite écritures concurrentes process';

--- a/tests/memory/collective-knowledge-graph.test.ts
+++ b/tests/memory/collective-knowledge-graph.test.ts
@@ -161,6 +161,25 @@ describe('CollectiveKnowledgeGraph (Phase 0)', () => {
     expect(onlyLessons[0]!.type).toBe('lesson');
   });
 
+  it('keeps long names with the same 80-character prefix as distinct entities', () => {
+    const ckg = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'host/repo' });
+    const sharedPrefix = 'A'.repeat(90);
+    const first = ckg.remember({
+      name: `${sharedPrefix} first publication`,
+      text: 'first long-title discovery',
+      type: 'discovery',
+    });
+    const second = ckg.remember({
+      name: `${sharedPrefix} second publication`,
+      text: 'second long-title discovery',
+      type: 'discovery',
+    });
+
+    expect(first!.id).not.toBe(second!.id);
+    expect(ckg.listEntities({ type: 'discovery' })).toHaveLength(2);
+    expect(ckg.getSuperseded()).toHaveLength(0);
+  });
+
   it('empty text is ignored (never-throws)', () => {
     const ckg = new CollectiveKnowledgeGraph({ ledgerPath, agentId: 'host/repo' });
     expect(ckg.remember({ text: '   ' })).toBeNull();

--- a/tests/sensory/reactions.test.ts
+++ b/tests/sensory/reactions.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { shouldWireSpeechReaction } from '../../src/sensory/reactions.js';
+
+describe('shouldWireSpeechReaction — the speech security invariant', () => {
+  it('requires both the opt-in and a non-empty shared token', () => {
+    expect(shouldWireSpeechReaction({ speech: 'true', token: 'secret' })).toBe(true);
+    expect(shouldWireSpeechReaction({ speech: 'true', token: undefined })).toBe(false);
+    expect(shouldWireSpeechReaction({ speech: 'true', token: '' })).toBe(false);
+    expect(shouldWireSpeechReaction({ speech: 'false', token: 'secret' })).toBe(false);
+    expect(shouldWireSpeechReaction({ token: 'secret' })).toBe(false);
+  });
+});

--- a/tests/sensory/reactions.test.ts
+++ b/tests/sensory/reactions.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { shouldWireSpeechReaction } from '../../src/sensory/reactions.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getGlobalEventBus } from '../../src/events/event-bus.js';
+import { logger } from '../../src/utils/logger.js';
+import { getSensoryMemory } from '../../src/sensory/sensory-memory.js';
+import { shouldWireSpeechReaction, wireSensoryReactions } from '../../src/sensory/reactions.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  getSensoryMemory().drain();
+});
 
 describe('shouldWireSpeechReaction — the speech security invariant', () => {
   it('requires both the opt-in and a non-empty shared token', () => {
@@ -8,5 +16,30 @@ describe('shouldWireSpeechReaction — the speech security invariant', () => {
     expect(shouldWireSpeechReaction({ speech: 'true', token: '' })).toBe(false);
     expect(shouldWireSpeechReaction({ speech: 'false', token: 'secret' })).toBe(false);
     expect(shouldWireSpeechReaction({ token: 'secret' })).toBe(false);
+  });
+});
+
+describe('wireSensoryReactions logging', () => {
+  it('keeps low-salience heartbeat noise at debug and salient events at info', () => {
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    const unwire = wireSensoryReactions();
+    const bus = getGlobalEventBus();
+    try {
+      bus.emit('sensory:perception', {
+        source: 'test',
+        metadata: { modality: 'vital', kind: 'heartbeat', salience: 12 },
+      });
+      expect(debug).toHaveBeenCalledWith('[sensory] vital/heartbeat (salience 12)');
+      expect(info).not.toHaveBeenCalled();
+
+      bus.emit('sensory:perception', {
+        source: 'test',
+        metadata: { modality: 'vision', kind: 'motion', salience: 180 },
+      });
+      expect(info).toHaveBeenCalledWith('[sensory] vision/motion (salience 180)');
+    } finally {
+      unwire();
+    }
   });
 });

--- a/tests/sensory/sensory-bridge.test.ts
+++ b/tests/sensory/sensory-bridge.test.ts
@@ -147,4 +147,51 @@ describe('sensory bridge → event bus → reaction', () => {
       await first.close();
     }
   });
+
+  it('drops an application frame larger than 64 KiB before parsing or emitting it', async () => {
+    const bridge = startSensoryBridge({ port: 18235 });
+    await bridge.ready;
+    const received: Perception[] = [];
+    const unwire = wireSensoryReactions((p) => received.push(p));
+    const ws = await open(18235);
+    try {
+      ws.send(
+        JSON.stringify({
+          modality: 'vision',
+          kind: 'oversized',
+          payload: { blob: 'x'.repeat(70 * 1024) },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(received).toHaveLength(0);
+    } finally {
+      ws.close();
+      unwire();
+      await bridge.close();
+    }
+  });
+
+  it('closes transport payloads larger than 256 KiB without crashing or emitting', async () => {
+    const bridge = startSensoryBridge({ port: 18236 });
+    await bridge.ready;
+    const received: Perception[] = [];
+    const unwire = wireSensoryReactions((p) => received.push(p));
+    const ws = await open(18236);
+    try {
+      const closed = new Promise<number>((resolve) => ws.once('close', (code) => resolve(code)));
+      ws.send(
+        JSON.stringify({
+          modality: 'vision',
+          kind: 'transport_oversized',
+          payload: { blob: 'x'.repeat(300 * 1024) },
+        }),
+      );
+      expect(await closed).toBe(1009);
+      expect(received).toHaveLength(0);
+    } finally {
+      ws.close();
+      unwire();
+      await bridge.close();
+    }
+  });
 });

--- a/tests/sensory/sensory-bridge.test.ts
+++ b/tests/sensory/sensory-bridge.test.ts
@@ -15,6 +15,7 @@ async function open(port: number): Promise<WebSocket> {
 describe('sensory bridge → event bus → reaction', () => {
   it('a daemon frame reaches the bus and fires the reaction', async () => {
     const bridge = startSensoryBridge({ port: 18231 });
+    await bridge.ready;
     const received: Perception[] = [];
     const unwire = wireSensoryReactions((p) => received.push(p));
     try {
@@ -41,6 +42,7 @@ describe('sensory bridge → event bus → reaction', () => {
 
   it('ignores malformed, token-mismatched, and modality-less frames', async () => {
     const bridge = startSensoryBridge({ port: 18232, token: 'secret' });
+    await bridge.ready;
     const received: Perception[] = [];
     const unwire = wireSensoryReactions((p) => received.push(p));
     try {
@@ -59,6 +61,7 @@ describe('sensory bridge → event bus → reaction', () => {
 
   it('rejects cross-origin connections (CSWSH defence)', async () => {
     const bridge = startSensoryBridge({ port: 18233 });
+    await bridge.ready;
     const received: Perception[] = [];
     const unwire = wireSensoryReactions((p) => received.push(p));
     try {
@@ -84,6 +87,7 @@ describe('sensory bridge → event bus → reaction', () => {
 
   it('clamps out-of-range salience and drops a negative ts_ms (UI frame)', async () => {
     const bridge = startSensoryBridge({ port: 18234 });
+    await bridge.ready;
     const received: Perception[] = [];
     const unwire = wireSensoryReactions((p) => received.push(p));
     try {
@@ -109,6 +113,7 @@ describe('sensory bridge → event bus → reaction', () => {
 
   it('preserves slash-separated canonical event kinds from the Rust daemon', async () => {
     const bridge = startSensoryBridge({ port: 18235 });
+    await bridge.ready;
     const received: Perception[] = [];
     const unwire = wireSensoryReactions((p) => received.push(p));
     try {
@@ -126,6 +131,20 @@ describe('sensory bridge → event bus → reaction', () => {
     } finally {
       unwire();
       await bridge.close();
+    }
+  });
+
+  it('rejects ready and reports unhealthy when the port is already in use', async () => {
+    const first = startSensoryBridge({ port: 0 });
+    await first.ready;
+    const second = startSensoryBridge({ port: first.port });
+    try {
+      await expect(second.ready).rejects.toMatchObject({ code: 'EADDRINUSE' });
+      const { getSensoryBridgeHealth } = await import('../../src/sensory/sensory-bridge.js');
+      expect(getSensoryBridgeHealth()).toMatchObject({ status: 'error', ready: false });
+    } finally {
+      await second.close();
+      await first.close();
     }
   });
 });

--- a/tests/sensory/sensory-rules-admin.test.ts
+++ b/tests/sensory/sensory-rules-admin.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { rm, appendFile, mkdir } from 'node:fs/promises';
+import { rm, appendFile, mkdir, readFile, stat } from 'node:fs/promises';
 import {
   validateRule,
   upsertSensoryRule,
@@ -9,6 +9,7 @@ import {
   toggleSensoryRule,
   removeSensoryRule,
   readRuleRuns,
+  appendRuleRun,
   type SensoryRule,
 } from '../../src/sensory/sensory-rules-engine.js';
 
@@ -87,5 +88,16 @@ describe('sensory-rules admin — readRuleRuns (observe)', () => {
     // tolerate junk lines
     await appendFile(f, 'not json\n');
     expect((await readRuleRuns(10)).length).toBe(2);
+  });
+
+  it('rotates a large rule-runs sidecar before appending', async () => {
+    await mkdir(dir, { recursive: true });
+    const file = process.env.CODEBUDDY_RULE_RUNS_FILE!;
+    await appendFile(file, 'x'.repeat(512 * 1024 + 1));
+
+    await appendRuleRun({ ts: 3, rule: 'rotated', action: 'alert', ok: true });
+
+    expect((await stat(`${file}.1`)).size).toBeGreaterThan(512 * 1024);
+    expect(JSON.parse((await readFile(file, 'utf8')).trim())).toMatchObject({ rule: 'rotated', ok: true });
   });
 });


### PR DESCRIPTION
Découpe finale de la vieille PR #69 après #106 (lot flotte sol, rebasée et vérifiée indépendamment) — 11 commits, un par fix :

- memory : embeddings CKG persistants + recall borné (timeout) ; arrêt du sidecar `buddy-memory` à la fermeture ; mémoires oubliées multilignes préservées ; noms d'entités CKG longs désambiguïsés.
- fleet : dédup des sondes de capacités.
- sensory : token requis pour les réactions speech ; bridge fail-closed sur erreur de bind ; payloads de trames bornés ; rétention disque bornée ; transitions de disponibilité caméra Rust signalées ; bruit de logs peu saillants réduit.
- Déjà sur main (non refaits) : ledger incrémental, redaction CKG, capture caméra persistante ; `agent-executor`/sandbox exclus.

Vérifications : `tsc --noEmit` 0 ; vitest `tests/memory tests/sensory` 58 fichiers / 613 tests (602 → 613) ; fleet/server 62/62 ; `cargo fmt --check` OK, `cargo test` 34/34 (+ `live-vision` 43/43 côté sol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)