### PR TITLE
perf(cli): démarrage à froid — dépendances UI différées (premier rendu plus tôt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ once it reaches `1.0.0`.
 
 ### Added
 
+- **cli:** splash « Starting Code Buddy… » pendant le chargement du graphe agent (premier cadre TUI plus tôt). Désactivable pour l'automatisation : `CODEBUDDY_NO_LOADING_SCREEN=1` ou `--no-loading-screen`.
 - **cli:** add `buddy cost` (aggregated token & cost dashboard), `buddy changelog` (release notes from Conventional Commits), and `buddy import` (rules & MCP server migration from Cursor/Cline/Copilot/Claude Code) (#104).
 - **cli:** add `buddy explain [path]` — one-shot repository explanation report (Markdown or self-contained HTML, `--depth quick|deep`), extracted from PR #70 (#107)
 - **ui:** read-only LSP navigation tools (`lsp_definition`, `lsp_references`, `lsp_hover`, `lsp_symbols`, `lsp_diagnostics`) and ephemeral `@file` mentions with bounded project-root resolution (#103).

--- a/docs/perf/_bench-st3c.mjs
+++ b/docs/perf/_bench-st3c.mjs
@@ -164,7 +164,7 @@ function summarize(name, s) {
     : `${name}: (no samples)`;
 }
 
-function collect(label) {
+function collect() {
   return {
     firstPaintApp: [],
     uiRenderApp: [],
@@ -233,7 +233,7 @@ async function main() {
       console.error(`  phases=${JSON.stringify(sample.phases)}`);
     }
   } else {
-    const buckets = Object.fromEntries(TARGETS.map((t) => [t.label, collect(t.label)]));
+    const buckets = Object.fromEntries(TARGETS.map((t) => [t.label, collect()]));
     console.error(`[tui] interleaved n=${TUI_RUNS} targets=${TARGETS.map((t) => t.label).join(',')}`);
     for (let i = 0; i < TUI_RUNS; i++) {
       for (const t of TARGETS) {

--- a/docs/perf/_bench-st3c.mjs
+++ b/docs/perf/_bench-st3c.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Cold-start bench for ST3c. Not part of the product.
+ *
+ * Usage:
+ *   node docs/perf/_bench-st3c.mjs probe
+ *   node docs/perf/_bench-st3c.mjs tui
+ *   node docs/perf/_bench-st3c.mjs tui --runs 12
+ *
+ * Compares origin/main (frozen dist-main-bench) vs serial / prefetch / light
+ * (compiled dist/index.js + CODEBUDDY_COLD_START_VARIANT). Unset default of
+ * dist/ is `light` (ST3c winner). TUI runs are interleaved so the four trees
+ * share the same thermal regime.
+ */
+import { spawn } from 'node:child_process';
+import { writeFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const mode = process.argv[2] || 'tui';
+const runsArg = process.argv.indexOf('--runs');
+const TUI_RUNS = runsArg >= 0 ? Number(process.argv[runsArg + 1]) : 12;
+const TUI_TIMEOUT_MS = 8000;
+const node = process.execPath;
+
+const TARGETS = [
+  {
+    label: 'main',
+    dist: resolve('dist-main-bench/index.js'),
+    env: {},
+  },
+  {
+    label: 'serial',
+    dist: resolve('dist/index.js'),
+    env: { CODEBUDDY_COLD_START_VARIANT: 'serial' },
+  },
+  {
+    label: 'prefetch',
+    dist: resolve('dist/index.js'),
+    env: { CODEBUDDY_COLD_START_VARIANT: 'prefetch' },
+  },
+  {
+    label: 'light',
+    dist: resolve('dist/index.js'),
+    env: { CODEBUDDY_COLD_START_VARIANT: 'light' },
+  },
+];
+
+function stats(samples) {
+  const s = [...samples].sort((a, b) => a - b);
+  const n = s.length;
+  if (n === 0) return null;
+  const mean = s.reduce((a, b) => a + b, 0) / n;
+  const variance = s.reduce((a, b) => a + (b - mean) ** 2, 0) / n;
+  const pct = (p) => {
+    const i = (n - 1) * p;
+    const lo = Math.floor(i);
+    const hi = Math.ceil(i);
+    if (lo === hi) return s[lo];
+    return s[lo] + (s[hi] - s[lo]) * (i - lo);
+  };
+  return {
+    n,
+    min: s[0],
+    p10: pct(0.1),
+    median: pct(0.5),
+    p90: pct(0.9),
+    max: s[n - 1],
+    mean,
+    stddev: Math.sqrt(variance),
+  };
+}
+
+function fmt(ms) {
+  return `${ms.toFixed(2)}`;
+}
+
+function parsePhases(text) {
+  const phases = {};
+  const re = /(?:INFO|WARN|ERROR)\s+(.+?):\s+(\d+)ms/g;
+  let m;
+  while ((m = re.exec(text))) {
+    phases[m[1].trim()] = Number(m[2]);
+  }
+  const totals = [...text.matchAll(/Total time:\s+(\d+)ms/g)];
+  if (totals.length) phases.__total = Number(totals[totals.length - 1][1]);
+  return phases;
+}
+
+function cleanEnv(extra = {}) {
+  const env = { ...process.env, ...extra, NO_COLOR: '1' };
+  delete env.FORCE_COLOR;
+  return env;
+}
+
+function measureTuiOnce(dist, extraEnv = {}) {
+  return new Promise((resolveOnce) => {
+    const t0 = process.hrtime.bigint();
+    const wall = {
+      firstPaintAppMs: null,
+      firstPaintWallMs: null,
+      assistantLineWallMs: null,
+      bannerWallMs: null,
+      agentReadyAppMs: null,
+      uiRenderAppMs: null,
+      splashRenderDoneAppMs: null,
+      renderersAwaitStartAppMs: null,
+    };
+    const child = spawn(
+      'script',
+      [
+        '-qec',
+        `${node} ${JSON.stringify(dist)} --no-alt-screen --ephemeral`,
+        '/dev/null',
+      ],
+      {
+        env: cleanEnv({
+          PERF_TIMING: 'true',
+          CODEBUDDY_PROVIDER: 'chatgpt',
+          ...extraEnv,
+        }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    let out = '';
+    const onData = (buf) => {
+      const chunk = buf.toString('utf8');
+      out += chunk;
+      const now = Number(process.hrtime.bigint() - t0) / 1e6;
+      if (wall.firstPaintWallMs == null && /ui-first-render:\s+\d+ms/.test(out)) {
+        wall.firstPaintWallMs = now;
+      }
+      if (wall.assistantLineWallMs == null && /Starting Code Buddy Conversational Assistant/.test(out)) {
+        wall.assistantLineWallMs = now;
+      }
+      if (wall.bannerWallMs == null && /██████╗ █████╗ ██████╗ ███████╗/.test(out)) {
+        wall.bannerWallMs = now;
+      }
+      if (wall.bannerWallMs != null && wall.assistantLineWallMs != null) {
+        child.kill('SIGTERM');
+      }
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    const killer = setTimeout(() => {
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 400);
+    }, TUI_TIMEOUT_MS);
+    child.on('close', () => {
+      clearTimeout(killer);
+      const phases = parsePhases(out);
+      wall.firstPaintAppMs = phases['ui-first-render'] ?? null;
+      wall.agentReadyAppMs = phases['agent-ready-render'] ?? null;
+      wall.uiRenderAppMs = phases['ui-render'] ?? null;
+      wall.splashRenderDoneAppMs = phases['splash-render-done'] ?? null;
+      wall.renderersAwaitStartAppMs = phases['renderers-await-start'] ?? null;
+      resolveOnce({ phases, wall, sawBanner: wall.bannerWallMs != null, outTail: out.slice(-2500) });
+    });
+  });
+}
+
+function summarize(name, s) {
+  return s
+    ? `${name}: n=${s.n} median=${fmt(s.median)} mean=${fmt(s.mean)} p10=${fmt(s.p10)} p90=${fmt(s.p90)} min=${fmt(s.min)} max=${fmt(s.max)} sd=${fmt(s.stddev)}`
+    : `${name}: (no samples)`;
+}
+
+function collect(label) {
+  return {
+    firstPaintApp: [],
+    uiRenderApp: [],
+    agentReadyApp: [],
+    firstPaintWall: [],
+    assistantLineWall: [],
+    bannerWall: [],
+    splashRenderDoneApp: [],
+    renderersAwaitStartApp: [],
+    raw: [],
+  };
+}
+
+function pushSample(bucket, sample) {
+  bucket.raw.push({ phases: sample.phases, wall: sample.wall, sawBanner: sample.sawBanner });
+  const { phases, wall } = sample;
+  if (typeof wall.firstPaintAppMs === 'number') bucket.firstPaintApp.push(wall.firstPaintAppMs);
+  if (typeof wall.uiRenderAppMs === 'number') bucket.uiRenderApp.push(wall.uiRenderAppMs);
+  if (typeof wall.agentReadyAppMs === 'number') bucket.agentReadyApp.push(wall.agentReadyAppMs);
+  if (typeof wall.firstPaintWallMs === 'number') bucket.firstPaintWall.push(wall.firstPaintWallMs);
+  if (typeof wall.assistantLineWallMs === 'number') bucket.assistantLineWall.push(wall.assistantLineWallMs);
+  if (typeof wall.bannerWallMs === 'number') bucket.bannerWall.push(wall.bannerWallMs);
+  if (typeof wall.splashRenderDoneAppMs === 'number') bucket.splashRenderDoneApp.push(wall.splashRenderDoneAppMs);
+  if (typeof wall.renderersAwaitStartAppMs === 'number') bucket.renderersAwaitStartApp.push(wall.renderersAwaitStartAppMs);
+  void phases;
+}
+
+function bucketStats(bucket) {
+  return {
+    firstPaintApp: stats(bucket.firstPaintApp),
+    uiRenderApp: stats(bucket.uiRenderApp),
+    agentReadyApp: stats(bucket.agentReadyApp),
+    firstPaintWall: stats(bucket.firstPaintWall),
+    assistantLineWall: stats(bucket.assistantLineWall),
+    bannerWall: stats(bucket.bannerWall),
+    splashRenderDoneApp: stats(bucket.splashRenderDoneApp),
+    renderersAwaitStartApp: stats(bucket.renderersAwaitStartApp),
+    raw: bucket.raw,
+  };
+}
+
+async function main() {
+  for (const t of TARGETS) {
+    if (!existsSync(t.dist)) {
+      console.error(`missing dist: ${t.dist}`);
+      process.exit(1);
+    }
+  }
+
+  const report = {
+    mode,
+    node: process.version,
+    startedAt: new Date().toISOString(),
+    runs: mode === 'probe' ? 1 : TUI_RUNS,
+    targets: TARGETS.map((t) => ({ label: t.label, dist: t.dist, env: t.env })),
+  };
+
+  if (mode === 'probe') {
+    for (const t of TARGETS) {
+      console.error(`[probe] ${t.label}`);
+      const sample = await measureTuiOnce(t.dist, t.env);
+      report[t.label] = sample;
+      console.error(
+        `  appFirst=${sample.wall.firstPaintAppMs ?? '-'} appUiRender=${sample.wall.uiRenderAppMs ?? '-'} appAgentReady=${sample.wall.agentReadyAppMs ?? '-'} wallFirst=${sample.wall.firstPaintWallMs?.toFixed(0) ?? '-'} wallBanner=${sample.wall.bannerWallMs?.toFixed(0) ?? '-'} wallAssist=${sample.wall.assistantLineWallMs?.toFixed(0) ?? '-'}`,
+      );
+      console.error(`  phases=${JSON.stringify(sample.phases)}`);
+    }
+  } else {
+    const buckets = Object.fromEntries(TARGETS.map((t) => [t.label, collect(t.label)]));
+    console.error(`[tui] interleaved n=${TUI_RUNS} targets=${TARGETS.map((t) => t.label).join(',')}`);
+    for (let i = 0; i < TUI_RUNS; i++) {
+      for (const t of TARGETS) {
+        const sample = await measureTuiOnce(t.dist, t.env);
+        pushSample(buckets[t.label], sample);
+        console.error(
+          `  ${t.label} ${i + 1}/${TUI_RUNS} appFirst=${sample.wall.firstPaintAppMs ?? '-'} appUiRender=${sample.wall.uiRenderAppMs ?? '-'} wallFirst=${sample.wall.firstPaintWallMs?.toFixed(0) ?? '-'} wallBanner=${sample.wall.bannerWallMs?.toFixed(0) ?? '-'} keys=${Object.keys(sample.phases).join(',')}`,
+        );
+      }
+    }
+    for (const t of TARGETS) {
+      report[t.label] = bucketStats(buckets[t.label]);
+    }
+  }
+
+  const outPath = resolve(`docs/perf/_bench-st3c-${mode}.json`);
+  writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.error(`wrote ${outPath}`);
+
+  if (mode !== 'probe') {
+    for (const t of TARGETS) {
+      const s = report[t.label];
+      console.error(`\n=== ${t.label} ===`);
+      console.error(summarize('TUI app ui-first-render', s.firstPaintApp));
+      console.error(summarize('TUI app ui-render (agent-ready)', s.uiRenderApp));
+      console.error(summarize('TUI app agent-ready-render', s.agentReadyApp));
+      console.error(summarize('TUI wall to ui-first-render line', s.firstPaintWall));
+      console.error(summarize('TUI wall to assistant line', s.assistantLineWall));
+      console.error(summarize('TUI wall to ASCII banner', s.bannerWall));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/perf/cold-start-2026-08-23.md
+++ b/docs/perf/cold-start-2026-08-23.md
@@ -1,0 +1,66 @@
+# Démarrage à froid — 2026-08-23
+
+## Résultat
+
+Mesure sur Linux 6.17, AMD Ryzen AI 9 HX 470, Node `v24.14.1`, avec le
+worktree compilé par `npm run build`. `hyperfine` n’étant pas installé, chaque
+valeur est la médiane de 10 processus indépendants, mesurée avec
+`process.hrtime.bigint()`.
+
+| Parcours | Avant (ms) | Après (ms) | Évolution | Cible |
+|---|---:|---:|---:|---:|
+| `node dist/index.js --version` | 96,81 | 102,07 | 0,95× (bruit de mesure) | < 150 — OK |
+| `node dist/index.js --help` | 88,70 | 138,25 | 0,64× (bruit de mesure) | < 400 — OK |
+| `buddy try`, providerless → message | 162,86 | 146,51 | 1,11× | message immédiat — OK |
+| TUI, marqueur `ui-first-render` | 838 | 494 | **1,70× / −41 %** | < 1 200 — OK |
+
+Les deux chemins CLI courts ne passent pas par le bootstrap interactif modifié
+et restent largement sous leur seuil. Leur variation avant/après est donc du
+bruit de lancement de processus, pas un gain revendiqué.
+
+## Méthode
+
+1. `npm run build` a été exécuté avant chaque série. Aucun `npm install`.
+2. Version et aide ont été lancées 10 fois avec `spawnSync(process.execPath,
+   ['dist/index.js', ...])`, sortie ignorée, puis triées pour prendre la 6e
+   valeur.
+3. Le TUI a été lancé dans un pseudo-terminal avec :
+
+   ```bash
+   timeout -k 0.2s 2s script -qec \
+     'PERF_TIMING=true CODEBUDDY_PROVIDER=chatgpt node dist/index.js --no-alt-screen --ephemeral' \
+     /dev/null
+   ```
+
+   La mesure est le champ `ui-first-render` de `PERF_TIMING=true`. La référence
+   utilisait le marqueur historique `ui-render`. `--ephemeral` évite la
+   persistance de session ; le processus est arrêté après capture du premier
+   rendu.
+4. Une authentification ChatGPT existe sur cette machine. Pour tester le cas
+   `buddy try` sans provider sans toucher au fichier d’authentification, la
+   série utilise un preload Node éphémère qui redirige uniquement
+   `os` dans `codex-oauth` vers `/codebuddy-no-home`, plus
+   `OLLAMA_HOST=http://127.0.0.1:1`. La commande exacte reste
+   `node dist/index.js try`, retourne le code 2 et affiche `No free provider is
+   ready for the demo.` ; aucun fichier n’est créé par ce parcours.
+
+## Profil et changement
+
+Le profil de référence `PERF_TIMING=true` montrait deux bloqueurs avant le
+premier rendu : l’import du barrel des renderers (`lazy:renderers`, environ
+913 ms) et l’import du graphe `CodeBuddyAgent` (environ 815 ms). Le graphe de
+l’agent inclut notamment le registre complet des outils et ses dépendances.
+
+Le correctif :
+
+- `src/renderers/startup.ts` ne charge d’abord que `RenderManager` ; les six
+  renderers spécialisés sont importés dynamiquement et enregistrés en
+  arrière-plan. Le barrel public `src/renderers/index.ts` reste inchangé.
+- `ChatHistory` et `StructuredOutput` importent directement le manager et les
+  types légers, sans réveiller le barrel spécialisé pendant le premier paint.
+- Le CLI affiche un shell TUI minimal, puis fait `rerender` avec l’agent après
+  son import dynamique. Le rendu complet, les options, le message initial et
+  les tâches d’arrière-plan conservent leur chemin existant.
+
+Le premier rendu final observé est donc inférieur à 1,2 s, tandis que l’agent
+continue son initialisation derrière ce premier écran.

--- a/docs/perf/cold-start-2026-08-23.md
+++ b/docs/perf/cold-start-2026-08-23.md
@@ -125,6 +125,28 @@ Cible first-paint < 1 200 ms : OK (528 ms).
    dans `script -qec` (PTY pour `isTTY`). `--ephemeral` évite la
    persistance de session. Arrêt à la bannière.
 
+## Écran « Starting Code Buddy… »
+
+Sur HEAD, le premier cadre TUI est un splash cyan :
+
+```
+Starting Code Buddy...
+Loading the coding assistant.
+```
+
+Il s’affiche **avant** que `CodeBuddyAgent` (registre d’outils, providers)
+soit importé. L’UI complète (bannière ASCII, prompt) arrive au
+`rerender` *time-to-agent-ready*.
+
+Pour l’automatisation (CI, scripts qui scrapent le PTY et ne doivent pas
+voir un écran transitoire) :
+
+- variable : `CODEBUDDY_NO_LOADING_SCREEN=1` (aliases : `true` / `yes` / `on`)
+- option : `buddy --no-loading-screen`
+
+Dans ce mode le splash n’est pas peint : le premier cadre est l’UI
+agent, comme sur `origin/main`.
+
 ## Profil et changement
 
 Le profil `PERF_TIMING=true` sur `origin/main` montre encore le graphe

--- a/docs/perf/cold-start-2026-08-23.md
+++ b/docs/perf/cold-start-2026-08-23.md
@@ -1,66 +1,160 @@
 # Démarrage à froid — 2026-08-23
 
-## Résultat
+Rebenchmark ST3b (juge : ne pas opposer *time-to-first-paint* à
+*time-to-agent-ready*). Mesure sur Linux 6.17, AMD Ryzen AI 9 HX 470,
+Node `v24.14.1`. `hyperfine` n’est **pas** installé (`command -v hyperfine`
+vide) : les CLI courts sont 50 processus `spawnSync` + 3 warm-up ;
+le TUI est 12 runs dans un PTY (`script -qec`).
 
-Mesure sur Linux 6.17, AMD Ryzen AI 9 HX 470, Node `v24.14.1`, avec le
-worktree compilé par `npm run build`. `hyperfine` n’étant pas installé, chaque
-valeur est la médiane de 10 processus indépendants, mesurée avec
-`process.hrtime.bigint()`.
+Les deux arbres compilés comparés :
 
-| Parcours | Avant (ms) | Après (ms) | Évolution | Cible |
-|---|---:|---:|---:|---:|
-| `node dist/index.js --version` | 96,81 | 102,07 | 0,95× (bruit de mesure) | < 150 — OK |
-| `node dist/index.js --help` | 88,70 | 138,25 | 0,64× (bruit de mesure) | < 400 — OK |
-| `buddy try`, providerless → message | 162,86 | 146,51 | 1,11× | message immédiat — OK |
-| TUI, marqueur `ui-first-render` | 838 | 494 | **1,70× / −41 %** | < 1 200 — OK |
+- `origin/main` = `aaa4224c` (`feat(models): entrée de registre qwen3.8-27b…`)
+- `HEAD` = `a59d04ea` (`perf(cli): defer cold-start UI dependencies`)
 
-Les deux chemins CLI courts ne passent pas par le bootstrap interactif modifié
-et restent largement sous leur seuil. Leur variation avant/après est donc du
-bruit de lancement de processus, pas un gain revendiqué.
+`npx tsc --pretty false` avant chaque série. Aucun `npm install`.
+
+## Deux métriques distinctes
+
+| Nom | Quoi | Marqueur `origin/main` | Marqueur `HEAD` |
+|---|---|---|---|
+| **time-to-first-paint** | Premier cadre TUI visible | Il n’y a pas d’écran intermédiaire : le premier cadre **est** l’UI agent (`ui-render`) | Écran « Starting Code Buddy… » (`ui-first-render`) |
+| **time-to-agent-ready** | Agent construit + UI complète (bannière ASCII) | `ui-render` (dump `PERF_TIMING` juste avant `render()`) | Wall-clock jusqu’à la bannière. `agent-ready-render` est enregistré mais **n’était pas dumpé** par `logStartupMetrics()` (appelé trop tôt) |
+
+Comparer `HEAD ui-first-render` à `main ui-render` (le « −41 % » de la
+première rédaction) mélange les deux. Les tableaux ci-dessous les
+séparent.
+
+## CLI courts — 50 runs `spawnSync`
+
+`node dist/index.js --version` et `--help` ne passent **pas** par le
+bootstrap interactif modifié (`lazyImport.renderers` reste lazy). `-p`
+charge l’agent complet (chemin headless) : ce n’est pas un CLI court.
+
+### Série séquentielle (HEAD puis `origin/main`, machine pas au même régime)
+
+| Parcours | origin/main médiane (ms) | HEAD médiane (ms) | Δ médiane | p10 / p90 HEAD | Cible |
+|---|---:|---:|---:|---|---:|
+| `--version` | 61,04 | 82,18 | +35 % | 68,09 / 137,25 | < 150 — OK |
+| `--help` | 64,54 | 81,44 | +26 % | 71,65 / 127,17 | < 400 — OK |
+| `-p "dis bonjour"` (API `127.0.0.1:1`, fail-fast) | 3038,96 | 3201,41 | +5 % | 3004,92 / 3950,62 | n/a (agent + 1 tour) |
+
+Cette série **ne tranche pas** `--help` : HEAD a tourné juste après des
+probes TUI (sd `--help` 34 ms vs 11 ms sur main ; max HEAD 267 ms).
+
+### Confirmation entrelacée (même session, `dist` figés, 50 paires main/HEAD)
+
+Les deux `dist/index.js` ne diffèrent que de 357 octets (151 167 →
+151 524). Pour chaque run : un spawn `origin/main`, un spawn `HEAD`,
+ordre inversé à chaque paire.
+
+| Parcours | origin/main médiane (ms) | HEAD médiane (ms) | Δ médiane | p10 main / HEAD |
+|---|---:|---:|---:|---|
+| `--version` | 55,13 | 56,79 | **+3,0 % (+1,67 ms)** | 47,09 / 47,25 |
+| `--help` | 64,71 | 61,16 | **−5,5 % (−3,55 ms)** | 50,95 / 51,42 |
+
+`--version` : n=50 main mean=56,75 sd=9,72 ; HEAD mean=58,87 sd=10,60.
+`--help` : n=50 main mean=64,76 sd=11,59 ; HEAD mean=62,67 sd=9,73.
+
+### Tranche `--help` : bruit, pas une régression
+
+Le +56 % de la première rédaction (88,70 → 138,25 ms, **n=10**) n’est
+pas reproductible. Sur n=50 entrelacé, les planchers p10 sont identiques
+à 0,5 ms près et HEAD est même légèrement plus rapide en médiane. Le
+chemin `--help` n’importe pas `startup.ts` ni `ChatInterface`. Cause
+du chiffre initial : variance de lancement + n trop petit, pas
+`lazyImport`.
+
+`-p "dis bonjour"` n’est pas un gain revendiqué (+5 % séquentiel, sd
+HEAD 450 ms) : le tour headless charge `CodeBuddyAgent` + prompt système.
+
+## TUI — first-paint ≠ agent-ready
+
+12 runs, PTY, `PERF_TIMING=true CODEBUDDY_PROVIDER=chatgpt node dist/index.js --no-alt-screen --ephemeral`,
+arrêt dès la bannière ASCII (timeout 8 s). Série HEAD puis main.
+
+### Time-to-first-paint
+
+| Côté | Définition | n | médiane (ms) | p10 / p90 | min / max |
+|---|---|---:|---:|---|---|
+| origin/main | Premier cadre = UI agent (`ui-render` app) | 12 | **770,5** | 738 / 851 | 734 / 919 |
+| HEAD | Écran « Starting Code Buddy… » (`ui-first-render` app) | 12 | **528,5** | 456 / 572 | 431 / 786 |
+| HEAD | Idem, wall-clock jusqu’à la ligne `ui-first-render` | 12 | 617,6 | 521 / 649 | 485 / 875 |
+
+Sur le **premier cadre visible**, HEAD est plus tôt : 528 vs 770 ms
+app-reported (−31 %). C’est le seul gain de perçue. Ce n’est **pas**
+un agent prêt.
+
+### Time-to-agent-ready
+
+| Côté | Définition | n | médiane (ms) | p10 / p90 | min / max |
+|---|---|---:|---:|---|---|
+| origin/main | `ui-render` (app) | 12 | **770,5** | 738 / 851 | 734 / 919 |
+| origin/main | Wall-clock jusqu’à la bannière ASCII | 12 | **859,9** | 824 / 939 | 816 / 1018 |
+| HEAD | Wall-clock jusqu’à « Starting Code Buddy Conversational Assistant » | 12 | 925,4 | 832 / 1076 | 764 / 1271 |
+| HEAD | Wall-clock jusqu’à la bannière ASCII (UI agent) | 12 | **947,4** | 852 / 1117 | 786 / 1302 |
+
+À métrique égale (bannière ASCII), HEAD est **légèrement plus lent**
+(+10 %, 947 vs 860 ms). Attendu : un `render()` d’écran de chargement
+s’intercale avant l’import de l’agent, puis un `rerender`. L’agent n’est
+pas initialisé plus vite ; l’utilisateur voit un cadre plus tôt.
+
+Le −41 % (494 vs 838 ms) de la première rédaction opposait HEAD
+`ui-first-render` à main `ui-render`. Chiffres ST3b, mêmes métriques :
+first-paint **−31 %** ; agent-ready **+10 %**.
+
+Cible first-paint < 1 200 ms : OK (528 ms).
 
 ## Méthode
 
-1. `npm run build` a été exécuté avant chaque série. Aucun `npm install`.
-2. Version et aide ont été lancées 10 fois avec `spawnSync(process.execPath,
-   ['dist/index.js', ...])`, sortie ignorée, puis triées pour prendre la 6e
-   valeur.
-3. Le TUI a été lancé dans un pseudo-terminal avec :
+1. `npx tsc --pretty false` (exit 0) avant chaque arbre. Pas de `npm install`.
+2. CLI : `spawnSync(process.execPath, ['dist/index.js', …])`,
+   `process.hrtime.bigint()`, 3 warm-up + 50 runs. `FORCE_COLOR` retiré
+   (sinon warning Node à chaque spawn). Confirmation `--help`/`--version` :
+   `dist-main-bench/` vs `dist-head-bench/`, 50 paires entrelacées.
+3. `-p "dis bonjour"` : `GROK_BASE_URL=http://127.0.0.1:1`,
+   `CODEBUDDY_PROVIDER=grok`, `GROK_API_KEY=bench-st3b` — le process
+   charge l’agent puis échoue en `Connection error` (aucun appel réseau
+   payant). 50 runs séquentiels.
+4. TUI :
 
    ```bash
-   timeout -k 0.2s 2s script -qec \
-     'PERF_TIMING=true CODEBUDDY_PROVIDER=chatgpt node dist/index.js --no-alt-screen --ephemeral' \
-     /dev/null
+   PERF_TIMING=true CODEBUDDY_PROVIDER=chatgpt \
+     node dist/index.js --no-alt-screen --ephemeral
    ```
 
-   La mesure est le champ `ui-first-render` de `PERF_TIMING=true`. La référence
-   utilisait le marqueur historique `ui-render`. `--ephemeral` évite la
-   persistance de session ; le processus est arrêté après capture du premier
-   rendu.
-4. Une authentification ChatGPT existe sur cette machine. Pour tester le cas
-   `buddy try` sans provider sans toucher au fichier d’authentification, la
-   série utilise un preload Node éphémère qui redirige uniquement
-   `os` dans `codex-oauth` vers `/codebuddy-no-home`, plus
-   `OLLAMA_HOST=http://127.0.0.1:1`. La commande exacte reste
-   `node dist/index.js try`, retourne le code 2 et affiche `No free provider is
-   ready for the demo.` ; aucun fichier n’est créé par ce parcours.
+   dans `script -qec` (PTY pour `isTTY`). `--ephemeral` évite la
+   persistance de session. Arrêt à la bannière.
 
 ## Profil et changement
 
-Le profil de référence `PERF_TIMING=true` montrait deux bloqueurs avant le
-premier rendu : l’import du barrel des renderers (`lazy:renderers`, environ
-913 ms) et l’import du graphe `CodeBuddyAgent` (environ 815 ms). Le graphe de
-l’agent inclut notamment le registre complet des outils et ses dépendances.
+Le profil `PERF_TIMING=true` sur `origin/main` montre encore le graphe
+`CodeBuddyAgent` (≈ 360–530 ms) **avant** le premier `render()`. Sur
+HEAD, `ui-load-start` / `lazy:ChatInterface` précèdent `ui-first-render` ;
+l’agent se charge derrière l’écran de démarrage.
 
 Le correctif :
 
-- `src/renderers/startup.ts` ne charge d’abord que `RenderManager` ; les six
-  renderers spécialisés sont importés dynamiquement et enregistrés en
-  arrière-plan. Le barrel public `src/renderers/index.ts` reste inchangé.
-- `ChatHistory` et `StructuredOutput` importent directement le manager et les
-  types légers, sans réveiller le barrel spécialisé pendant le premier paint.
-- Le CLI affiche un shell TUI minimal, puis fait `rerender` avec l’agent après
-  son import dynamique. Le rendu complet, les options, le message initial et
-  les tâches d’arrière-plan conservent leur chemin existant.
+- `src/renderers/startup.ts` ne charge d’abord que `RenderManager` ; les
+  six renderers spécialisés sont importés dynamiquement et enregistrés
+  en arrière-plan. Le barrel public `src/renderers/index.ts` reste
+  inchangé.
+- `ChatHistory` et `StructuredOutput` importent directement le manager
+  et les types légers, sans réveiller le barrel pendant le premier paint.
+- Le CLI affiche un shell TUI minimal, puis `rerender` avec l’agent
+  après son import dynamique.
 
-Le premier rendu final observé est donc inférieur à 1,2 s, tandis que l’agent
-continue son initialisation derrière ce premier écran.
+## Preuves brutes (sorties)
+
+`command -v hyperfine` : vide.
+
+`--help` entrelacé (extrait) :
+
+```
+PARCOURS --help
+  origin/main  n=50 median=64.71 mean=64.76 p10=50.95 p90=73.67 min=45.80 max=104.84 sd=11.59
+  HEAD         n=50 median=61.16 mean=62.67 p10=51.42 p90=72.82 min=42.60 max=91.64 sd=9.73
+  delta median HEAD/main = -5.5%  (-3.55 ms)
+```
+
+TUI HEAD `ui-first-render` médiane 528,5 ms ; TUI main `ui-render`
+médiane 770,5 ms ; bannière ASCII 947,4 vs 859,9 ms.

--- a/docs/perf/cold-start-st3c-analyse.md
+++ b/docs/perf/cold-start-st3c-analyse.md
@@ -1,0 +1,260 @@
+# ST3c — Où partent les 88 ms ? (agent-ready HEAD vs main)
+
+Analyse + prototype sur `perf/cold-start-st3c`, à partir de
+`perf/cold-start-2026-08-23` (`dcd729cd`). **Pas de merge, pas de push,
+PR #142 non modifiée.**
+
+Objectif : **agent-ready ≤ main** tout en gardant un premier cadre tôt.
+ST3b (série HEAD puis main, n=12 PTY) : first-paint 770 → 528 ms (−31 %),
+mais agent-ready **bannière ASCII 860 → 947 ms (+10 %, +87 ms)**.
+
+## Verdict
+
+**Garder le splash, le rendre léger (`light`). Ne pas préfetcher le graphe
+agent avant le premier cadre. Ne pas abandonner le splash.**
+
+| Question | Réponse mesurée |
+|---|---|
+| Les +87 ms ST3b sont-ils du travail réel ? | **Surtout non.** Série HEAD-puis-main (HEAD plus froid). En **entrelacé**, `serial` (HEAD) est **plus rapide** que main à la bannière (871 vs 921 ms). |
+| `await renderersReady` bloque-t-il ? | **Non. 0 ms / 12 runs** sur serial, prefetch et light. |
+| Double montage Ink ? | **Non.** Un `render()` + `rerender()` (même instance). Coût splash Ink = **10 ms** médiane. |
+| Prefetch agent **avant** le splash ? | **Rejeté.** L’évaluation ESM est sur le thread principal : React/Ink/ChatInterface sont affamés. First-paint **725 ms** (pire que HEAD 465 ms). |
+| Variante `light` | **Gagnante.** Splash = `StartupScreen` (React+Ink seulement). First-paint **270 ms**. Agent-ready **801 ms app / 884 ms bannière** ≤ main (832 / 921). |
+
+Le défaut runtime (sans env) est désormais `light`.
+`CODEBUDDY_COLD_START_VARIANT=serial` reproduit HEAD PR #142 ;
+`=prefetch` est l’essai rejeté.
+
+## Méthode
+
+Même protocole que ST3b (`docs/perf/_bench-st3b.mjs`), étendu :
+
+```bash
+npx tsc --pretty false          # exit 0
+node docs/perf/_bench-st3c.mjs probe
+node docs/perf/_bench-st3c.mjs tui --runs 12
+```
+
+- n=12 PTY (`script -qec`), `PERF_TIMING=true CODEBUDDY_PROVIDER=chatgpt`,
+  `--no-alt-screen --ephemeral`, timeout 8 s, arrêt à la bannière ASCII.
+- **Entrelacement** à chaque run : main → serial → prefetch → light
+  (même régime thermique, contrairement à ST3b « HEAD puis main »).
+- `main` = `dist-main-bench/` figé ST3b = `aaa4224c` (pas le `origin/main`
+  actuel `71b566ef`).
+- serial / prefetch / light = `dist/index.js` + `CODEBUDDY_COLD_START_VARIANT`.
+- Node `v24.14.1`. `hyperfine` toujours absent. Pas de `npm install`.
+
+Brut : `docs/perf/_bench-st3c-tui.json` (non commité, régénérable).
+
+## Chronologie HEAD (`serial`) — un run médian
+
+Run le plus proche de first-paint 464,5 ms (app 463, agent-ready 776) :
+
+```
+  189  renderers-mod-done
+  192  ui-load-start
+  463  lazy:ChatInterface (199ms)     ← premier cadre attend CE module
+  463  ui-first-render                ← splash ChatInterface { loading:true }
+  473  splash-render-done             ← Ink = 10 ms
+  725  lazy:CodeBuddyAgent (251ms)    ← démarre APRÈS le splash
+  747  agent-create-done
+  776  renderers-await (0ms)
+  776  ui-render / agent-ready-render
+```
+
+Wall : `ui-first-render` ligne 534 ms, bannière ASCII 847 ms.
+
+Ce que HEAD **sérialise** alors qu’on pourrait recouvrir :
+
+1. **Import `ChatInterface` (199–223 ms) sur le chemin du premier cadre**,
+   pour peindre deux lignes de texte. Le module tire ThemeProvider,
+   ToastProvider, hooks, historique, TTS, ConfirmationService, etc.
+   L’early-return `loading && <StartupScreen />` est *runtime* : les
+   imports ont déjà eu lieu.
+2. **`CodeBuddyAgent` ne démarre qu’après** `render()` + dump PERF
+   (`logStartupMetrics` au splash). 251 ms d’import agent *en plus*
+   des 199 ms ChatInterface.
+3. **Pas de second `render()` Ink** — `rerender()` sur la même instance.
+4. **`await renderersReady` ne coûte rien** (les 6 renderers spécialisés
+   ont fini pendant ChatInterface).
+
+Le graphe agent n’est **pas** plus lent que sur main. Sur main, l’agent
+est importé *en premier* (386 ms à froid) puis ChatInterface est *bon marché*
+(59 ms, graphe chaud). HEAD inverse l’ordre : ChatInterface froid (199 ms)
+puis agent tiède (251 ms). Total imports comparable ; le splash s’intercale
+(10 ms Ink + dump).
+
+## Pourquoi prefetch avant paint échoue
+
+Run proche de first-paint 725 ms :
+
+```
+  181  prefetch-start                 ← agent + ChatInterface lancés
+  412  renderers-mod-done             ← +231 ms : renderers affamé
+  671  lazy:react (257ms)             ← React seul est déjà > 250 ms
+  678  lazy:CodeBuddyAgent (497ms)
+  716  lazy:ChatInterface (378ms)
+  716  ui-first-render                ← splash aussi tard que ChatInterface
+  769  ui-render
+```
+
+Node évalue les modules ESM **sur le thread principal**. `import()` sans
+`await` n’est pas du recouvrement CPU : ça *vole* le temps de React/Ink.
+First-paint passe de 465 → 725 ms ; agent-ready reste ~783 ms (pas de gain).
+
+Un essai intermédiaire « light + prefetch agent pendant React » a donné
+first-paint **850 ms** (`lazy:ink (307ms)` pendant l’agent). Même leçon.
+
+## Variante `light` (gagnante)
+
+Run proche de first-paint 270,5 ms (app 264, agent-ready 816) :
+
+```
+  189  renderers-mod-done / variant:light
+  192  ui-load-start
+  264  ui-first-render                ← StartupScreen, PAS ChatInterface
+  273  splash-render-done / prefetch-after-splash
+  741  lazy:CodeBuddyAgent (468ms)    ← à froid, après le splash
+  770  agent-create-done
+  799  lazy:ChatInterface (371ms)     ← en parallèle de l’agent
+  816  chat-import-join-done (0 ms d’attente)
+  816  renderers-await (0ms)
+  816  ui-render
+```
+
+Wall : first-paint 342 ms, bannière 905 ms.
+
+React+Ink non contestés : `ui-load-start` 192 → first-paint 264 = **72 ms**
+(souvent < 50 ms, donc absents du dump `lazy:*`). HEAD payait 199 ms
+ChatInterface pour le même écran.
+
+L’agent est plus froid (468 vs 251 ms) parce que ChatInterface n’a pas
+préchauffé le graphe. ChatInterface tourne **pendant** l’agent : le join
+après le constructeur est 0 ms. Net : agent-ready ≈ serial ≈ mieux que main.
+
+## Tableau n=12 entrelacé
+
+Médiane (p10 / p90). First-paint main = `ui-render` (pas de splash).
+Agent-ready = `ui-render` app / bannière ASCII wall (métrique ST3b).
+
+### Time-to-first-paint
+
+| Côté | Définition | médiane (ms) | p10 / p90 | min / max |
+|---|---|---:|---|---|
+| main | UI agent (`ui-render` app) | **831,5** | 751 / 984 | 747 / 1088 |
+| serial (HEAD) | splash ChatInterface (`ui-first-render`) | **464,5** | 435 / 541 | 433 / 569 |
+| prefetch | splash ChatInterface, imports lancés trop tôt | **725,0** | 688 / 858 | 674 / 865 |
+| **light** | splash `StartupScreen` | **270,5** | 249 / 382 | 238 / 398 |
+
+Wall jusqu’à la ligne `ui-first-render` : serial 544 ms, light **342 ms**,
+prefetch 812 ms. Main n’a pas cette ligne.
+
+### Time-to-agent-ready
+
+| Côté | Définition | médiane (ms) | p10 / p90 | min / max |
+|---|---|---:|---|---|
+| main | `ui-render` app | **831,5** | 751 / 984 | 747 / 1088 |
+| serial | `ui-render` app | **785,5** | 739 / 890 | 733 / 893 |
+| prefetch | `ui-render` app | **782,5** | 741 / 914 | 723 / 915 |
+| **light** | `ui-render` app | **801,0** | 735 / 932 | 727 / 982 |
+| main | bannière ASCII wall | **921,4** | 828 / 1119 | 810 / 1174 |
+| serial | bannière ASCII wall | **871,2** | 808 / 990 | 806 / 1002 |
+| prefetch | bannière ASCII wall | **865,9** | 821 / 991 | 801 / 998 |
+| **light** | bannière ASCII wall | **883,6** | 804 / 1034 | 796 / 1109 |
+
+Cible : agent-ready ≤ main. **serial, prefetch et light y sont** (app et
+bannière). prefetch sacrifie le first-paint. light le **améliore**
+(270 vs 465 HEAD vs 832 main) sans casser agent-ready.
+
+Δ bannière light vs main : **−38 ms (−4 %)**. Δ first-paint light vs main :
+**−561 ms (−67 %)**. Δ first-paint light vs serial : **−194 ms (−42 %)**.
+
+## Les +87 ms de ST3b
+
+ST3b (séquentiel HEAD puis main) :
+
+| | HEAD | main | Δ |
+|---|---:|---:|---:|
+| first-paint app | 528,5 | 770,5 | −31 % |
+| bannière wall | 947,4 | 859,9 | **+10 %** |
+
+ST3c (entrelacé, même machine, même PTY) :
+
+| | serial (= HEAD) | main | Δ |
+|---|---:|---:|---:|
+| first-paint app | 464,5 | 831,5 | −44 % |
+| bannière wall | 871,2 | 921,4 | **−5 %** |
+
+La régression agent-ready ST3b **ne se reproduit pas** à protocole égal.
+Cause : HEAD tournait sur une machine plus froide ; main bénéficiait du
+cache OS / thermique. Les ~10 ms Ink + dump PERF au splash existent mais
+sont noyés dans le bruit (sd bannière main 110 ms, serial 71 ms).
+
+Les « 88 ms » après le splash sur HEAD **serial** sont le **chargement
+légitime de `CodeBuddyAgent`** (≈ 250 ms), pas un second montage Ink ni
+`await renderersReady`. Main fait ce travail *avant* le premier pixel.
+
+## Recommandation pour PR #142
+
+1. **Ne pas abandonner le splash.** First-paint 270–465 ms vs 832 ms sur
+   main est le seul gain perçu. Agent-ready n’est plus une régression dès
+   qu’on mesure équitablement.
+2. **Remplacer le splash `ChatInterface { loading: true }` par
+   `StartupScreen` seul** (variante `light`, défaut de cette branche).
+   Ne pas importer ChatInterface avant le premier cadre.
+3. **Ne pas lancer `CodeBuddyAgent` / `ChatInterface` avant ce cadre.**
+   Prefetch = first-paint 725 ms, gain agent-ready nul.
+4. Après le splash : lancer agent + ChatInterface **sans les attendre
+   l’un l’autre** ; joindre ChatInterface après le constructeur.
+5. Garder `await renderersReady` (sémantique : registre complet au
+   `rerender`) — coût mesuré 0 ms.
+6. Garder `--no-loading-screen` / `CODEBUDDY_NO_LOADING_SCREEN` (CI).
+
+Cette branche implémente (2)+(4) par défaut. PR #142 (`perf/cold-start-2026-08-23`)
+n’est **pas** mise à jour : à cherry-picker après revue.
+
+## Preuves (sorties)
+
+`npx tsc --pretty false` : exit 0.
+
+Probe (1 run / cible, ordre main→…→light — **ne pas** en tirer de
+médianes, seulement la forme des phases) : first-paint light 246 ms /
+serial 509 / prefetch 821 ; `renderers-await: 0`.
+
+Résumé n=12 entrelacé (sortie de `_bench-st3c.mjs tui`) :
+
+```
+=== main ===
+TUI app ui-render (agent-ready): n=12 median=831.50 p10=751.40 p90=983.60
+TUI wall to ASCII banner:        n=12 median=921.44 p10=827.87 p90=1119.36
+
+=== serial ===
+TUI app ui-first-render:         n=12 median=464.50 p10=434.60 p90=541.40
+TUI app ui-render (agent-ready): n=12 median=785.50 p10=738.50 p90=890.40
+TUI wall to ASCII banner:        n=12 median=871.18 p10=808.46 p90=990.06
+
+=== prefetch ===
+TUI app ui-first-render:         n=12 median=725.00 p10=688.30 p90=858.20
+TUI app ui-render (agent-ready): n=12 median=782.50 p10=741.10 p90=913.70
+TUI wall to ASCII banner:        n=12 median=865.87 p10=821.40 p90=991.48
+
+=== light ===
+TUI app ui-first-render:         n=12 median=270.50 p10=248.80 p90=382.40
+TUI app ui-render (agent-ready): n=12 median=801.00 p10=735.10 p90=931.60
+TUI wall to ASCII banner:        n=12 median=883.56 p10=803.70 p90=1033.81
+```
+
+Splash Ink (`splash-render-done − ui-first-render`) : médiane 10 ms
+(serial, 12× 9–11 ms) / 9 ms (light).
+
+Tests : `tests/ui/loading-screen.test.ts` + `tests/renderers/startup.test.ts`
+— 7/7 pass.
+
+## Reste ouvert
+
+- Pas de n=50 CLI `--help`/`--version` ici (ST3b a déjà tranché : bruit,
+  pas `lazyImport`).
+- `origin/main` a avancé (`#139` mcp serve) depuis le `dist-main-bench`
+  `aaa4224c` ; rejouer contre HEAD main si on rattache la PR.
+- `CODEBUDDY_COLD_START_VARIANT` est un échappatoire d’analyse : à retirer
+  au squash dans #142 si `light` est retenu.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   NO_PROVIDER_GUIDANCE,
   recoverFirstRunWithChatGpt,
 } from './cli/first-run.js';
+import { isLoadingScreenDisabled } from './ui/loading-screen.js';
 
 // Read version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -1431,6 +1432,10 @@ program
     "skip session persistence (do not save session to disk)"
   )
   .option(
+    "--no-loading-screen",
+    "skip the Starting Code Buddy… splash (also CODEBUDDY_NO_LOADING_SCREEN=1)"
+  )
+  .option(
     "--system-prompt-override <text>",
     "replace the entire system prompt with this text"
   )
@@ -1966,6 +1971,12 @@ program
       // Paint a lightweight shell before importing the agent graph. The agent
       // imports the complete tool dispatch surface and provider runtime; none
       // of that is needed to show the first useful frame of the TUI.
+      // Automation can skip the splash: CODEBUDDY_NO_LOADING_SCREEN=1 or
+      // --no-loading-screen (Commander stores that as loadingScreen === false).
+      const skipLoadingScreen = isLoadingScreenDisabled(
+        process.env,
+        options.loadingScreen === false,
+      );
       recordStartupPhase('ui-load-start');
       const React = await lazyImport.React();
       const { render } = await lazyImport.ink();
@@ -1976,13 +1987,17 @@ program
         inkOptions.patchConsole = false;
       }
 
-      recordStartupPhase('ui-first-render');
-      const firstPaintAt = Date.now();
-      const startupRender = render(
-        React.createElement(ChatInterface, { loading: true }),
-        inkOptions,
-      );
-      logStartupMetrics();
+      let firstPaintAt = STARTUP_TIME;
+      let startupRender: ReturnType<typeof render> | undefined;
+      if (!skipLoadingScreen) {
+        recordStartupPhase('ui-first-render');
+        firstPaintAt = Date.now();
+        startupRender = render(
+          React.createElement(ChatInterface, { loading: true }),
+          inkOptions,
+        );
+        logStartupMetrics();
+      }
 
       // Interactive mode: load the full agent graph after the first frame.
       const CodeBuddyAgent = await lazyImport.CodeBuddyAgent();
@@ -2184,6 +2199,10 @@ program
         : message;
 
       const totalStartupMs = Date.now() - STARTUP_TIME;
+      if (!startupRender) {
+        recordStartupPhase('ui-first-render');
+        firstPaintAt = Date.now();
+      }
       const sinceFirstPaintMs = Date.now() - firstPaintAt;
       if (totalStartupMs > 5000) {
         logger.warn(`Slow startup detected: ${totalStartupMs}ms. Run with PERF_TIMING=true for phase breakdown.`);
@@ -2201,13 +2220,19 @@ program
       // Historical alias: longitudinal PERF_TIMING series used `ui-render`
       // for time-to-agent-ready (the full ChatInterface, not the loading shell).
       recordStartupPhase('ui-render');
+      logStartupMetrics();
       try {
         await renderersReady;
       } catch {
         cli.warn('Specialized renderers failed to load; structured output (tests, weather, diffs, tables) will use generic text.');
       }
       const renderersDegraded = areSpecializedRenderersDegraded();
-      startupRender.rerender(React.createElement(ChatInterface, { agent, initialMessage, renderersDegraded }));
+      const readyUi = React.createElement(ChatInterface, { agent, initialMessage, renderersDegraded });
+      if (startupRender) {
+        startupRender.rerender(readyUi);
+      } else {
+        render(readyUi, inkOptions);
+      }
 
       // Initialize plugin system in background (non-blocking)
       setImmediate(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2192,6 +2192,9 @@ program
       agent.enableBackgroundReview();
 
       recordStartupPhase('agent-ready-render');
+      // Historical alias: longitudinal PERF_TIMING series used `ui-render`
+      // for time-to-agent-ready (the full ChatInterface, not the loading shell).
+      recordStartupPhase('ui-render');
       await renderersReady;
       startupRender.rerender(React.createElement(ChatInterface, { agent, initialMessage }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,33 @@ function logStartupMetrics(): void {
   cli.info('===========================\n');
 }
 
+type ColdStartVariant = 'serial' | 'prefetch' | 'light';
+
+/**
+ * ST3c cold-start experiment (perf/cold-start-st3c).
+ *
+ * - `serial`: PR #142 HEAD — await ChatInterface, paint splash, THEN
+ *   import CodeBuddyAgent. First paint is early; agent-ready is serialized.
+ * - `prefetch`: start CodeBuddyAgent + ChatInterface imports before the splash
+ *   without awaiting the agent; splash is still ChatInterface `{ loading: true }`.
+ * - `light`: first Ink tree is the tiny StartupScreen (React+Ink only). No
+ *   agent/ChatInterface prefetch before that frame — kicking those imports
+ *   off early starves Ink on the main thread (probe: first-paint 850 ms).
+ *   After the splash, the agent import starts and ChatInterface joins
+ *   once construction is done (warm graph).
+ *
+ * Override with CODEBUDDY_COLD_START_VARIANT. Unset is `light` (ST3c winner:
+ * early StartupScreen, heavy imports after first paint). `serial` reproduces
+ * PR #142 HEAD; `prefetch` is the rejected overlap-before-paint attempt.
+ */
+function resolveColdStartVariant(
+  env: NodeJS.ProcessEnv = process.env,
+): ColdStartVariant {
+  const raw = env.CODEBUDDY_COLD_START_VARIANT?.trim().toLowerCase();
+  if (raw === 'prefetch' || raw === 'light' || raw === 'serial') return raw;
+  return 'light';
+}
+
 recordStartupPhase('imports-start');
 
 recordStartupPhase('imports-done');
@@ -1955,18 +1982,35 @@ program
         return;
       }
 
-      // Initialize rendering system (lazy load)
+      // Initialize rendering system (lazy load). Prefetch variants kick off the
+      // heavy agent / ChatInterface graphs BEFORE this await so they overlap
+      // the renderer module + first Ink frame instead of starting after it.
+      const coldStartVariant = resolveColdStartVariant();
+      recordStartupPhase(`variant:${coldStartVariant}`);
+      // `prefetch` starts both heavy graphs immediately (rejected: starves
+      // React/Ink, first-paint ~725 ms). `light` does not prefetch here.
+      let agentImportP: ReturnType<typeof lazyImport.CodeBuddyAgent> | undefined;
+      let chatImportP: ReturnType<typeof lazyImport.ChatInterface> | undefined;
+      if (coldStartVariant === 'prefetch') {
+        recordStartupPhase('prefetch-start');
+        agentImportP = lazyImport.CodeBuddyAgent();
+        chatImportP = lazyImport.ChatInterface();
+      }
+
       const {
         initializeRenderers,
         configureRenderContext,
         areSpecializedRenderersDegraded,
       } = await lazyImport.renderers();
+      recordStartupPhase('renderers-mod-done');
       const renderersReady = initializeRenderers();
       configureRenderContext({
         plain: options.plain,
         noColor: options.color === false,
         noEmoji: options.emoji === false,
       });
+      // `light` deliberately does not prefetch the agent here: CodeBuddyAgent's
+      // module evaluation is main-thread work and delays `await ink()`.
 
       // Paint a lightweight shell before importing the agent graph. The agent
       // imports the complete tool dispatch surface and provider runtime; none
@@ -1980,7 +2024,15 @@ program
       recordStartupPhase('ui-load-start');
       const React = await lazyImport.React();
       const { render } = await lazyImport.ink();
-      const ChatInterface = await lazyImport.ChatInterface();
+      type ChatInterfaceComponent = Awaited<
+        ReturnType<typeof lazyImport.ChatInterface>
+      >;
+      let ChatInterface: ChatInterfaceComponent | undefined;
+      // `light` must not wait for ChatInterface before the first frame —
+      // that module is the 200–340 ms tax ST3b paid for a 2-line splash.
+      if (coldStartVariant !== 'light') {
+        ChatInterface = await (chatImportP ?? lazyImport.ChatInterface());
+      }
       const inkOptions: Record<string, unknown> = { exitOnCtrlC: true };
       if (options.altScreen === false) {
         // --no-alt-screen disables Ink's alternate screen buffer
@@ -1992,15 +2044,35 @@ program
       if (!skipLoadingScreen) {
         recordStartupPhase('ui-first-render');
         firstPaintAt = Date.now();
-        startupRender = render(
-          React.createElement(ChatInterface, { loading: true }),
-          inkOptions,
-        );
+        if (coldStartVariant === 'light') {
+          const { StartupScreen } = await import(
+            './ui/components/StartupScreen.js'
+          );
+          startupRender = render(
+            React.createElement(StartupScreen),
+            inkOptions,
+          );
+        } else if (ChatInterface) {
+          startupRender = render(
+            React.createElement(ChatInterface, { loading: true }),
+            inkOptions,
+          );
+        }
+        recordStartupPhase('splash-render-done');
         logStartupMetrics();
       }
 
-      // Interactive mode: load the full agent graph after the first frame.
-      const CodeBuddyAgent = await lazyImport.CodeBuddyAgent();
+      // Light: heavy graphs are safe to start now — the splash is already
+      // painted. Agent + ChatInterface overlap each other, not the first frame.
+      if (coldStartVariant === 'light') {
+        recordStartupPhase('prefetch-after-splash');
+        agentImportP = agentImportP ?? lazyImport.CodeBuddyAgent();
+        chatImportP = chatImportP ?? lazyImport.ChatInterface();
+      }
+
+      // Interactive mode: load the full agent graph. Prefetch variants have
+      // already started this import; serial starts it only now (HEAD).
+      const CodeBuddyAgent = await (agentImportP ?? lazyImport.CodeBuddyAgent());
       let systemPromptId = options.systemPrompt;  // New: external prompt support
       let customAgentConfig = null;
 
@@ -2216,16 +2288,31 @@ program
       // trigger a review (recursion + cost safety).
       agent.enableBackgroundReview();
 
-      recordStartupPhase('agent-ready-render');
-      // Historical alias: longitudinal PERF_TIMING series used `ui-render`
-      // for time-to-agent-ready (the full ChatInterface, not the loading shell).
-      recordStartupPhase('ui-render');
-      logStartupMetrics();
+      // Light variant: ChatInterface was loading during agent construction.
+      if (!ChatInterface) {
+        recordStartupPhase('chat-import-join-start');
+        ChatInterface = await (chatImportP ?? lazyImport.ChatInterface());
+        recordStartupPhase('chat-import-join-done');
+      }
+
+      const renderersAwaitStart = PERF_TIMING ? Date.now() : 0;
+      recordStartupPhase('renderers-await-start');
       try {
         await renderersReady;
       } catch {
         cli.warn('Specialized renderers failed to load; structured output (tests, weather, diffs, tables) will use generic text.');
       }
+      const renderersAwaitMs = PERF_TIMING ? Date.now() - renderersAwaitStart : 0;
+      if (PERF_TIMING) {
+        recordStartupPhase(`renderers-await (${renderersAwaitMs}ms)`);
+        cli.info(`  renderers-await: ${renderersAwaitMs}ms`);
+      }
+
+      recordStartupPhase('agent-ready-render');
+      // Historical alias: longitudinal PERF_TIMING series used `ui-render`
+      // for time-to-agent-ready (the full ChatInterface, not the loading shell).
+      recordStartupPhase('ui-render');
+      logStartupMetrics();
       const renderersDegraded = areSpecializedRenderersDegraded();
       const readyUi = React.createElement(ChatInterface, { agent, initialMessage, renderersDegraded });
       if (startupRender) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ const lazyImport = {
   initProject: () => lazyLoad('initProject', () => import("./utils/init-project.js")),
   securityModes: () => lazyLoad('securityModes', () => import("./security/security-modes.js")),
   contextLoader: () => lazyLoad('contextLoader', () => import("./context/context-loader.js")),
-  renderers: () => lazyLoad('renderers', () => import("./renderers/index.js")),
+  renderers: () => lazyLoad('renderers', () => import("./renderers/startup.js")),
   performance: () => lazyLoad('performance', () => import("./performance/index.js")),
   pluginManager: () => lazyLoad('pluginManager', () => import("./plugins/plugin-manager.js")),
   lazyLoader: () => lazyLoad('lazyLoader', () => import("./performance/lazy-loader.js")),
@@ -1952,14 +1952,34 @@ program
 
       // Initialize rendering system (lazy load)
       const { initializeRenderers, configureRenderContext } = await lazyImport.renderers();
-      initializeRenderers();
+      const renderersReady = initializeRenderers();
       configureRenderContext({
         plain: options.plain,
         noColor: options.color === false,
         noEmoji: options.emoji === false,
       });
 
-      // Interactive mode: launch UI (lazy load heavy modules)
+      // Paint a lightweight shell before importing the agent graph. The agent
+      // imports the complete tool dispatch surface and provider runtime; none
+      // of that is needed to show the first useful frame of the TUI.
+      recordStartupPhase('ui-load-start');
+      const React = await lazyImport.React();
+      const { render } = await lazyImport.ink();
+      const ChatInterface = await lazyImport.ChatInterface();
+      const inkOptions: Record<string, unknown> = { exitOnCtrlC: true };
+      if (options.altScreen === false) {
+        // --no-alt-screen disables Ink's alternate screen buffer
+        inkOptions.patchConsole = false;
+      }
+
+      recordStartupPhase('ui-first-render');
+      const startupRender = render(
+        React.createElement(ChatInterface, { loading: true }),
+        inkOptions,
+      );
+      logStartupMetrics();
+
+      // Interactive mode: load the full agent graph after the first frame.
       const CodeBuddyAgent = await lazyImport.CodeBuddyAgent();
       let systemPromptId = options.systemPrompt;  // New: external prompt support
       let customAgentConfig = null;
@@ -2158,28 +2178,11 @@ program
         ? message.join(" ")
         : message;
 
-      // Lazy load React and Ink for UI
-      recordStartupPhase('ui-load-start');
-      const React = await lazyImport.React();
-      const { render } = await lazyImport.ink();
-      const ChatInterface = await lazyImport.ChatInterface();
-
-      // Log startup metrics before UI render
-      recordStartupPhase('ui-render');
-      logStartupMetrics();
-
       const totalStartupMs = Date.now() - STARTUP_TIME;
       if (totalStartupMs > 5000) {
         logger.warn(`Slow startup detected: ${totalStartupMs}ms. Run with PERF_TIMING=true for phase breakdown.`);
       } else {
-        logger.debug(`Startup completed in ${totalStartupMs}ms`);
-      }
-
-      // Configure Ink render options
-      const inkOptions: Record<string, unknown> = { exitOnCtrlC: true };
-      if (options.altScreen === false) {
-        // --no-alt-screen disables Ink's alternate screen buffer
-        inkOptions.patchConsole = false;
+        logger.debug(`Agent ready in ${totalStartupMs}ms after the first TUI frame`);
       }
 
       // Opt the interactive session into the Hermes-style post-session background
@@ -2188,7 +2191,9 @@ program
       // trigger a review (recursion + cost safety).
       agent.enableBackgroundReview();
 
-      render(React.createElement(ChatInterface, { agent, initialMessage }), inkOptions);
+      recordStartupPhase('agent-ready-render');
+      await renderersReady;
+      startupRender.rerender(React.createElement(ChatInterface, { agent, initialMessage }));
 
       // Initialize plugin system in background (non-blocking)
       setImmediate(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1973,6 +1973,7 @@ program
       }
 
       recordStartupPhase('ui-first-render');
+      const firstPaintAt = Date.now();
       const startupRender = render(
         React.createElement(ChatInterface, { loading: true }),
         inkOptions,
@@ -2179,10 +2180,11 @@ program
         : message;
 
       const totalStartupMs = Date.now() - STARTUP_TIME;
+      const sinceFirstPaintMs = Date.now() - firstPaintAt;
       if (totalStartupMs > 5000) {
         logger.warn(`Slow startup detected: ${totalStartupMs}ms. Run with PERF_TIMING=true for phase breakdown.`);
       } else {
-        logger.debug(`Agent ready in ${totalStartupMs}ms after the first TUI frame`);
+        logger.debug(`Agent ready in ${sinceFirstPaintMs}ms after the first TUI frame`);
       }
 
       // Opt the interactive session into the Hermes-style post-session background

--- a/src/index.ts
+++ b/src/index.ts
@@ -1951,7 +1951,11 @@ program
       }
 
       // Initialize rendering system (lazy load)
-      const { initializeRenderers, configureRenderContext } = await lazyImport.renderers();
+      const {
+        initializeRenderers,
+        configureRenderContext,
+        areSpecializedRenderersDegraded,
+      } = await lazyImport.renderers();
       const renderersReady = initializeRenderers();
       configureRenderContext({
         plain: options.plain,
@@ -2197,8 +2201,13 @@ program
       // Historical alias: longitudinal PERF_TIMING series used `ui-render`
       // for time-to-agent-ready (the full ChatInterface, not the loading shell).
       recordStartupPhase('ui-render');
-      await renderersReady;
-      startupRender.rerender(React.createElement(ChatInterface, { agent, initialMessage }));
+      try {
+        await renderersReady;
+      } catch {
+        cli.warn('Specialized renderers failed to load; structured output (tests, weather, diffs, tables) will use generic text.');
+      }
+      const renderersDegraded = areSpecializedRenderersDegraded();
+      startupRender.rerender(React.createElement(ChatInterface, { agent, initialMessage, renderersDegraded }));
 
       // Initialize plugin system in background (non-blocking)
       setImmediate(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2299,8 +2299,9 @@ program
       recordStartupPhase('renderers-await-start');
       try {
         await renderersReady;
-      } catch {
-        cli.warn('Specialized renderers failed to load; structured output (tests, weather, diffs, tables) will use generic text.');
+      } catch (renderersError) {
+        const detail = renderersError instanceof Error ? renderersError.message : String(renderersError);
+        cli.warn(`Specialized renderers failed to load (${detail}); structured output (tests, weather, diffs, tables) will use generic text.`);
       }
       const renderersAwaitMs = PERF_TIMING ? Date.now() - renderersAwaitStart : 0;
       if (PERF_TIMING) {

--- a/src/renderers/startup.ts
+++ b/src/renderers/startup.ts
@@ -10,39 +10,102 @@ import {
   configureRenderContext,
   getRenderManager,
 } from './render-manager.js';
+import type { Renderer } from './types.js';
 import { logger } from '../utils/logger.js';
 
-let specializedRenderersReady: Promise<void> | undefined;
+export type SpecializedRendererBundle = {
+  testResultsRenderer: Renderer;
+  weatherRenderer: Renderer;
+  codeStructureRenderer: Renderer;
+  diffRenderer: Renderer;
+  tableRenderer: Renderer;
+  treeRenderer: Renderer;
+};
 
-/**
- * Start loading the specialized renderers without blocking the first TUI
- * paint. Network/LLM work cannot begin before these imports settle, so a
- * structured response still observes the same renderer registry in normal
- * operation; only the initial shell is allowed to paint first.
- */
-export function initializeRenderers(): Promise<void> {
-  if (specializedRenderersReady) return specializedRenderersReady;
+export type SpecializedRendererLoader = () => Promise<SpecializedRendererBundle>;
 
-  specializedRenderersReady = Promise.all([
+const defaultLoadSpecializedRenderers: SpecializedRendererLoader = async () => {
+  const [testResults, weather, codeStructure, diff, table, tree] = await Promise.all([
     import('./test-results-renderer.js'),
     import('./weather-renderer.js'),
     import('./code-structure-renderer.js'),
     import('./diff-renderer.js'),
     import('./table-renderer.js'),
     import('./tree-renderer.js'),
-  ]).then(([testResults, weather, codeStructure, diff, table, tree]) => {
-    const manager = getRenderManager();
-    manager.register(testResults.testResultsRenderer);
-    manager.register(weather.weatherRenderer);
-    manager.register(codeStructure.codeStructureRenderer);
-    manager.register(diff.diffRenderer);
-    manager.register(table.tableRenderer);
-    manager.register(tree.treeRenderer);
-  }).catch((error: unknown) => {
-    logger.warn('Specialized renderer bootstrap failed; generic rendering remains available', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  ]);
+  return {
+    testResultsRenderer: testResults.testResultsRenderer,
+    weatherRenderer: weather.weatherRenderer,
+    codeStructureRenderer: codeStructure.codeStructureRenderer,
+    diffRenderer: diff.diffRenderer,
+    tableRenderer: table.tableRenderer,
+    treeRenderer: tree.treeRenderer,
+  };
+};
+
+let loadSpecializedRenderers: SpecializedRendererLoader = defaultLoadSpecializedRenderers;
+let specializedRenderersReady: Promise<void> | undefined;
+let renderersDegraded = false;
+let renderersDegradedError: string | undefined;
+
+export function areSpecializedRenderersDegraded(): boolean {
+  return renderersDegraded;
+}
+
+export function getSpecializedRenderersDegradedError(): string | undefined {
+  return renderersDegradedError;
+}
+
+export function setSpecializedRendererLoaderForTests(
+  loader?: SpecializedRendererLoader,
+): void {
+  loadSpecializedRenderers = loader ?? defaultLoadSpecializedRenderers;
+}
+
+export function resetSpecializedRendererBootstrapForTests(): void {
+  specializedRenderersReady = undefined;
+  renderersDegraded = false;
+  renderersDegradedError = undefined;
+  loadSpecializedRenderers = defaultLoadSpecializedRenderers;
+}
+
+function markRenderersDegraded(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  renderersDegraded = true;
+  renderersDegradedError = message;
+  logger.warn('Specialized renderer bootstrap failed; generic rendering remains available', {
+    error: message,
+    renderersDegraded: true,
   });
+  return error instanceof Error ? error : new Error(message);
+}
+
+/**
+ * Start loading the specialized renderers without blocking the first TUI
+ * paint. Network/LLM work cannot begin before these imports settle, so a
+ * structured response still observes the same renderer registry in normal
+ * operation; only the initial shell is allowed to paint first.
+ *
+ * On failure the returned promise **rejects** after exposing
+ * `areSpecializedRenderersDegraded()`. Callers must catch if they want a
+ * degraded TUI rather than aborting the rerender.
+ */
+export function initializeRenderers(): Promise<void> {
+  if (specializedRenderersReady) return specializedRenderersReady;
+
+  specializedRenderersReady = loadSpecializedRenderers()
+    .then((bundle) => {
+      const manager = getRenderManager();
+      manager.register(bundle.testResultsRenderer);
+      manager.register(bundle.weatherRenderer);
+      manager.register(bundle.codeStructureRenderer);
+      manager.register(bundle.diffRenderer);
+      manager.register(bundle.tableRenderer);
+      manager.register(bundle.treeRenderer);
+    })
+    .catch((error: unknown) => {
+      throw markRenderersDegraded(error);
+    });
 
   return specializedRenderersReady;
 }

--- a/src/renderers/startup.ts
+++ b/src/renderers/startup.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimal renderer bootstrap for the interactive CLI.
+ *
+ * The full renderer barrel intentionally remains available for consumers that
+ * need every renderer. The CLI only needs the manager and its context during
+ * the first paint, so specialized renderers are registered asynchronously.
+ */
+
+import {
+  configureRenderContext,
+  getRenderManager,
+} from './render-manager.js';
+import { logger } from '../utils/logger.js';
+
+let specializedRenderersReady: Promise<void> | undefined;
+
+/**
+ * Start loading the specialized renderers without blocking the first TUI
+ * paint. Network/LLM work cannot begin before these imports settle, so a
+ * structured response still observes the same renderer registry in normal
+ * operation; only the initial shell is allowed to paint first.
+ */
+export function initializeRenderers(): Promise<void> {
+  if (specializedRenderersReady) return specializedRenderersReady;
+
+  specializedRenderersReady = Promise.all([
+    import('./test-results-renderer.js'),
+    import('./weather-renderer.js'),
+    import('./code-structure-renderer.js'),
+    import('./diff-renderer.js'),
+    import('./table-renderer.js'),
+    import('./tree-renderer.js'),
+  ]).then(([testResults, weather, codeStructure, diff, table, tree]) => {
+    const manager = getRenderManager();
+    manager.register(testResults.testResultsRenderer);
+    manager.register(weather.weatherRenderer);
+    manager.register(codeStructure.codeStructureRenderer);
+    manager.register(diff.diffRenderer);
+    manager.register(table.tableRenderer);
+    manager.register(tree.treeRenderer);
+  }).catch((error: unknown) => {
+    logger.warn('Specialized renderer bootstrap failed; generic rendering remains available', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  return specializedRenderersReady;
+}
+
+export { configureRenderContext, getRenderManager };

--- a/src/ui/components/ChatHistory.tsx
+++ b/src/ui/components/ChatHistory.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { Box, Text, Static } from "ink";
-import { ChatEntry } from "../../agent/codebuddy-agent.js";
+import type { ChatEntry } from "../../agent/codebuddy-agent.js";
 import { DiffRenderer } from "./DiffRenderer.js";
 import { MarkdownRenderer } from "../utils/markdown-renderer.js";
 import { useTheme } from "../context/theme-context.js";
 import { ThemeColors, AvatarConfig } from "../../themes/theme.js";
-import { getRenderManager, isTestResultsData, isWeatherData, isCodeStructureData } from "../../renderers/index.js";
+import { getRenderManager } from "../../renderers/render-manager.js";
+import { isTestResultsData, isWeatherData, isCodeStructureData } from "../../renderers/types.js";
 import { ErrorBoundary } from "./ErrorBoundary.js";
 import { Divider } from "./EnhancedSpinners.js";
 import { ReasoningBlock } from "./ReasoningBlock.js";

--- a/src/ui/components/ChatInterface.tsx
+++ b/src/ui/components/ChatInterface.tsx
@@ -29,6 +29,7 @@ import {
   useAccessibilitySettings,
   useKeyboardShortcuts,
 } from "../utils/accessibility.js";
+import { StartupScreen } from "./StartupScreen.js";
 
 interface ChatInterfaceProps {
   agent?: CodeBuddyAgent;
@@ -37,15 +38,6 @@ interface ChatInterfaceProps {
   loading?: boolean;
   /** Specialized renderers failed to register; structured output is generic. */
   renderersDegraded?: boolean;
-}
-
-function StartupScreen() {
-  return (
-    <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Text color="cyan">Starting Code Buddy...</Text>
-      <Text color="gray" dimColor>Loading the coding assistant.</Text>
-    </Box>
-  );
 }
 
 // Main chat component that handles input when agent is available

--- a/src/ui/components/ChatInterface.tsx
+++ b/src/ui/components/ChatInterface.tsx
@@ -35,6 +35,8 @@ interface ChatInterfaceProps {
   initialMessage?: string;
   /** Render the lightweight shell while the agent graph is loading. */
   loading?: boolean;
+  /** Specialized renderers failed to register; structured output is generic. */
+  renderersDegraded?: boolean;
 }
 
 function StartupScreen() {
@@ -664,6 +666,7 @@ function ChatInterfaceInner({
   agent,
   initialMessage,
   loading,
+  renderersDegraded,
 }: ChatInterfaceProps) {
   const [currentAgent, setCurrentAgent] = useState<CodeBuddyAgent | null>(
     agent || null
@@ -684,10 +687,19 @@ function ChatInterfaceInner({
   }
 
   return (
-    <ChatInterfaceWithAgent
-      agent={activeAgent}
-      initialMessage={initialMessage}
-    />
+    <Box flexDirection="column">
+      {renderersDegraded && (
+        <Box paddingX={2} paddingTop={1}>
+          <Text color="yellow">
+            Specialized renderers failed to load; structured output falls back to generic text.
+          </Text>
+        </Box>
+      )}
+      <ChatInterfaceWithAgent
+        agent={activeAgent}
+        initialMessage={initialMessage}
+      />
+    </Box>
   );
 }
 
@@ -696,11 +708,17 @@ export default function ChatInterface({
   agent,
   initialMessage,
   loading,
+  renderersDegraded,
 }: ChatInterfaceProps) {
   return (
     <ThemeProvider>
       <ToastProvider>
-        <ChatInterfaceInner agent={agent} initialMessage={initialMessage} loading={loading} />
+        <ChatInterfaceInner
+          agent={agent}
+          initialMessage={initialMessage}
+          loading={loading}
+          renderersDegraded={renderersDegraded}
+        />
       </ToastProvider>
     </ThemeProvider>
   );

--- a/src/ui/components/ChatInterface.tsx
+++ b/src/ui/components/ChatInterface.tsx
@@ -33,6 +33,17 @@ import {
 interface ChatInterfaceProps {
   agent?: CodeBuddyAgent;
   initialMessage?: string;
+  /** Render the lightweight shell while the agent graph is loading. */
+  loading?: boolean;
+}
+
+function StartupScreen() {
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1}>
+      <Text color="cyan">Starting Code Buddy...</Text>
+      <Text color="gray" dimColor>Loading the coding assistant.</Text>
+    </Box>
+  );
 }
 
 // Main chat component that handles input when agent is available
@@ -652,22 +663,29 @@ function ChatInterfaceWithAgent({
 function ChatInterfaceInner({
   agent,
   initialMessage,
+  loading,
 }: ChatInterfaceProps) {
   const [currentAgent, setCurrentAgent] = useState<CodeBuddyAgent | null>(
     agent || null
   );
 
+  const activeAgent = agent || currentAgent;
+
   const handleApiKeySet = (newAgent: CodeBuddyAgent) => {
     setCurrentAgent(newAgent);
   };
 
-  if (!currentAgent) {
+  if (loading && !activeAgent) {
+    return <StartupScreen />;
+  }
+
+  if (!activeAgent) {
     return <ApiKeyInput onApiKeySet={handleApiKeySet} />;
   }
 
   return (
     <ChatInterfaceWithAgent
-      agent={currentAgent}
+      agent={activeAgent}
       initialMessage={initialMessage}
     />
   );
@@ -677,11 +695,12 @@ function ChatInterfaceInner({
 export default function ChatInterface({
   agent,
   initialMessage,
+  loading,
 }: ChatInterfaceProps) {
   return (
     <ThemeProvider>
       <ToastProvider>
-        <ChatInterfaceInner agent={agent} initialMessage={initialMessage} />
+        <ChatInterfaceInner agent={agent} initialMessage={initialMessage} loading={loading} />
       </ToastProvider>
     </ThemeProvider>
   );

--- a/src/ui/components/StartupScreen.tsx
+++ b/src/ui/components/StartupScreen.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { LOADING_SCREEN_TITLE } from '../loading-screen.js';
+
+export function StartupScreen() {
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1}>
+      <Text color="cyan">{LOADING_SCREEN_TITLE}</Text>
+      <Text color="gray" dimColor>Loading the coding assistant.</Text>
+    </Box>
+  );
+}

--- a/src/ui/components/StructuredOutput.tsx
+++ b/src/ui/components/StructuredOutput.tsx
@@ -7,7 +7,8 @@
 
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
-import { getRenderManager, RenderContext } from '../../renderers/index.js';
+import { getRenderManager } from '../../renderers/render-manager.js';
+import type { RenderContext } from '../../renderers/types.js';
 import { useTheme } from '../context/theme-context.js';
 import type { WeatherCondition } from '../../renderers/types.js';
 

--- a/src/ui/loading-screen.ts
+++ b/src/ui/loading-screen.ts
@@ -1,0 +1,20 @@
+/**
+ * Interactive CLI splash shown while the agent graph loads.
+ *
+ * Automation (CI, scripts scraping the TTY) can skip it with
+ * `CODEBUDDY_NO_LOADING_SCREEN=1` or `--no-loading-screen`.
+ */
+
+export const LOADING_SCREEN_TITLE = 'Starting Code Buddy...';
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+export function isLoadingScreenDisabled(
+  env: NodeJS.ProcessEnv = process.env,
+  cliFlag = false,
+): boolean {
+  if (cliFlag) return true;
+  const raw = env.CODEBUDDY_NO_LOADING_SCREEN;
+  if (raw == null || raw === '') return false;
+  return TRUTHY.has(raw.trim().toLowerCase());
+}

--- a/tests/renderers/startup.test.ts
+++ b/tests/renderers/startup.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Specialized renderer bootstrap — failure must be visible, not swallowed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import type { Renderer } from '../../src/renderers/types.js';
+import {
+  initializeRenderers,
+  areSpecializedRenderersDegraded,
+  getSpecializedRenderersDegradedError,
+  resetSpecializedRendererBootstrapForTests,
+  setSpecializedRendererLoaderForTests,
+} from '../../src/renderers/startup.js';
+import { getRenderManager, resetRenderManager } from '../../src/renderers/render-manager.js';
+import { logger } from '../../src/utils/logger.js';
+
+function dummyRenderer(id: string): Renderer {
+  return {
+    id,
+    name: id,
+    priority: 0,
+    canRender: (_data: unknown): _data is unknown => false,
+    render: () => '',
+  };
+}
+
+function dummyBundle() {
+  return {
+    testResultsRenderer: dummyRenderer('test-results'),
+    weatherRenderer: dummyRenderer('weather'),
+    codeStructureRenderer: dummyRenderer('code-structure'),
+    diffRenderer: dummyRenderer('diff'),
+    tableRenderer: dummyRenderer('table'),
+    treeRenderer: dummyRenderer('tree'),
+  };
+}
+
+describe('initializeRenderers', () => {
+  beforeEach(() => {
+    resetRenderManager();
+    resetSpecializedRendererBootstrapForTests();
+    vi.mocked(logger.warn).mockClear();
+  });
+
+  afterEach(() => {
+    resetSpecializedRendererBootstrapForTests();
+    resetRenderManager();
+  });
+
+  it('registers specialized renderers and stays healthy on success', async () => {
+    setSpecializedRendererLoaderForTests(async () => dummyBundle());
+    await initializeRenderers();
+    expect(areSpecializedRenderersDegraded()).toBe(false);
+    expect(getSpecializedRenderersDegradedError()).toBeUndefined();
+    const ids = getRenderManager().getRenderers().map((r) => r.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'test-results',
+        'weather',
+        'code-structure',
+        'diff',
+        'table',
+        'tree',
+      ]),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects, flags degraded state, and warns when loading fails', async () => {
+    setSpecializedRendererLoaderForTests(async () => {
+      throw new Error('boom-import');
+    });
+
+    await expect(initializeRenderers()).rejects.toThrow('boom-import');
+
+    expect(areSpecializedRenderersDegraded()).toBe(true);
+    expect(getSpecializedRenderersDegradedError()).toBe('boom-import');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Specialized renderer bootstrap failed; generic rendering remains available',
+      expect.objectContaining({
+        error: 'boom-import',
+        renderersDegraded: true,
+      }),
+    );
+    expect(getRenderManager().getRenderers()).toHaveLength(0);
+  });
+
+  it('does not swallow a later initializeRenderers() call after a failed bootstrap', async () => {
+    setSpecializedRendererLoaderForTests(async () => {
+      throw new Error('still-broken');
+    });
+    await expect(initializeRenderers()).rejects.toThrow('still-broken');
+    await expect(initializeRenderers()).rejects.toThrow('still-broken');
+    expect(areSpecializedRenderersDegraded()).toBe(true);
+  });
+});

--- a/tests/ui/loading-screen.test.ts
+++ b/tests/ui/loading-screen.test.ts
@@ -1,0 +1,72 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('ink', () => ({
+  Text: ({ children }: { children?: React.ReactNode }) => children,
+  Box: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+import {
+  isLoadingScreenDisabled,
+  LOADING_SCREEN_TITLE,
+} from '../../src/ui/loading-screen.js';
+import { StartupScreen } from '../../src/ui/components/StartupScreen.js';
+
+describe('isLoadingScreenDisabled', () => {
+  const env = (value?: string): NodeJS.ProcessEnv => {
+    const next: NodeJS.ProcessEnv = {};
+    if (value !== undefined) next.CODEBUDDY_NO_LOADING_SCREEN = value;
+    return next;
+  };
+
+  it('is enabled by default (splash shown)', () => {
+    expect(isLoadingScreenDisabled(env())).toBe(false);
+    expect(isLoadingScreenDisabled(env(''))).toBe(false);
+    expect(isLoadingScreenDisabled(env('0'))).toBe(false);
+    expect(isLoadingScreenDisabled(env('false'))).toBe(false);
+  });
+
+  it('is disabled by CODEBUDDY_NO_LOADING_SCREEN=1 (and aliases)', () => {
+    expect(isLoadingScreenDisabled(env('1'))).toBe(true);
+    expect(isLoadingScreenDisabled(env('true'))).toBe(true);
+    expect(isLoadingScreenDisabled(env('YES'))).toBe(true);
+    expect(isLoadingScreenDisabled(env(' on '))).toBe(true);
+  });
+
+  it('is disabled by --no-loading-screen even without the env var', () => {
+    expect(isLoadingScreenDisabled(env(), true)).toBe(true);
+    expect(isLoadingScreenDisabled(env('0'), true)).toBe(true);
+  });
+});
+
+describe('StartupScreen', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the documented Starting Code Buddy splash copy', () => {
+    const element = StartupScreen();
+    const text = collectText(element);
+    expect(text).toContain(LOADING_SCREEN_TITLE);
+    expect(text).toContain('Loading the coding assistant.');
+  });
+});
+
+function collectText(node: unknown, depth = 0): string {
+  if (depth > 20 || node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map((child) => collectText(child, depth + 1)).join('');
+  if (React.isValidElement(node)) {
+    const { props, type } = node as React.ReactElement<{ children?: unknown }>;
+    if (typeof type === 'function') {
+      try {
+        const rendered = (type as (p: unknown) => unknown)(props);
+        return collectText(rendered, depth + 1);
+      } catch {
+        return collectText(props?.children, depth + 1);
+      }
+    }
+    return collectText(props?.children, depth + 1);
+  }
+  return '';
+}


### PR DESCRIPTION
Mission ST3 (luna, 15:25), rebasée sur `main`. **Draft** : la revue adversariale indépendante (Nemotron 3 Ultra, $0) rend GO-AVEC-RÉSERVES avec 3 points majeurs à traiter avant merge :
1. le « −41 % » compare *time-to-first-paint* (`ui-first-render`, 494 ms) à l'ancien *time-to-agent-ready* (`ui-render`, 838 ms) — métriques différentes ;
2. régression `--help` 88,7 → 138,3 ms (+56 %) qualifiée de bruit sans preuve (10 runs) ;
3. nouvel écran « Starting Code Buddy… » non documenté (changelog, option, impact automatisation).
Mineurs : `initializeRenderers()` avale les erreurs (renderers dégradés silencieux) ; log « after the first TUI frame » mesuré depuis `STARTUP_TIME` ; marqueur historique `ui-render` supprimé (continuité des séries perf).

Une mission de suite (ST3b) traite ces points sur cette branche ; verdict complet : `lots-2026-08-23-soir/JUGE-ST3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Réserves levées (ST3b)

Mesure honnête, Linux 6.17 / Ryzen AI 9 HX 470 / Node v24.14.1. `hyperfine` absent → 50× `spawnSync` (CLI) + 12 PTY (TUI). Arbres : `origin/main` `aaa4224c` vs `HEAD` de cette branche. Détail : `docs/perf/cold-start-2026-08-23.md`.

| Métrique | origin/main | HEAD | Lecture |
|---|---:|---:|---|
| **time-to-first-paint** (app, médiane n=12) | 770,5 ms (`ui-render` = premier cadre) | 528,5 ms (`ui-first-render` = splash) | **−31 %** premier cadre visible — ce n’est pas un agent prêt |
| **time-to-agent-ready** (wall, bannière ASCII, n=12) | 859,9 ms | 947,4 ms | **+10 %** — l’agent n’est pas plus vite ; un `render()` s’intercale |
| `--help` 50 paires **entrelacées** | 64,71 ms | 61,16 ms | **−5,5 %** — le +56 % (n=10) était du **bruit** (p10 50,95 vs 51,42 ms) |
| `--version` entrelacé | 55,13 ms | 56,79 ms | +3,0 % (+1,67 ms), bruit |
| `-p "dis bonjour"` (fail-fast `127.0.0.1:1`, n=50 séq.) | 3039 ms | 3201 ms | +5 % (chemin headless agent, pas un CLI court) |

Le −41 % initial opposait first-paint HEAD à agent-ready main. À métriques égales : first-paint **−31 %**, agent-ready **+10 %**.

Corrections code :

1. Marqueur historique `ui-render` restauré (alias de `agent-ready-render`).
2. Log « Agent ready in Xms after the first TUI frame » mesuré depuis `ui-first-render`, plus depuis `STARTUP_TIME`.
3. `initializeRenderers()` **rejette** en cas d’échec, pose `areSpecializedRenderersDegraded()`, `logger.warn` + `cli.warn` + bandeau TUI. Test : `tests/renderers/startup.test.ts`.
4. Splash documenté (CHANGELOG Unreleased). Désactivation automatisation : `CODEBUDDY_NO_LOADING_SCREEN=1` ou `--no-loading-screen`. Tests : `tests/ui/loading-screen.test.ts`.

Vérifs ST3b : `npx tsc --noEmit` exit 0 ; vitest `tests/ui` + `tests/renderers/startup.test.ts` 164 passed ; eslint 0 error sur les fichiers touchés ; `git diff --check` exit 0.

Pas de `gh pr ready` (sortie de draft = Fable).