### PR TITLE
test: durcir checkpoint-resume + help-output (flakes macOS 23/08) — aide racine vidée naturellement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3832,4 +3832,22 @@ addLazyCommand(
   },
 );
 
-program.parse();
+function isRootHelpRequest(argv: readonly string[]): boolean {
+  const args = argv.slice(2);
+  if (!args.some((arg) => arg === '--help' || arg === '-h')) {
+    return false;
+  }
+
+  const commandNames = new Set(program.commands.map((command) => command.name()));
+  const { operands } = program.parseOptions(args);
+  return !operands.some((operand) => commandNames.has(operand));
+}
+
+// Commander writes help and immediately calls process.exit(). The root help is
+// larger than a macOS pipe buffer, so a slow reader can lose the queued suffix.
+// It is fully registered here: write it once and let Node drain stdout naturally.
+if (isRootHelpRequest(process.argv)) {
+  program.outputHelp();
+} else {
+  program.parse();
+}

--- a/tests/agent/autonomous/checkpoint-resume.test.ts
+++ b/tests/agent/autonomous/checkpoint-resume.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -249,10 +249,18 @@ describe('runner checkpoint resume', () => {
       runsDir: path.join(tempRoot, 'runs'),
     }));
 
-    const events = (await fs.readFile(report.observability!.eventsPath, 'utf8'))
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line) as { data: { stepId?: string }; type: string });
+    let events: Array<{ data: { stepId?: string }; type: string }> = [];
+    await vi.waitFor(async () => {
+      events = (await fs.readFile(report.observability!.eventsPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as { data: { stepId?: string }; type: string });
+      expect(events.some((event) => event.type === 'run_end')).toBe(true);
+    }, {
+      timeout: 5_000,
+      interval: 5,
+    });
+
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({
         data: expect.objectContaining({ stepId: 'resume-decomposed-checkpoint' }),

--- a/tests/cli/help-output.test.ts
+++ b/tests/cli/help-output.test.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 
+const CLI_TIMEOUT_MS = 30_000;
+
 function runCli(args: string[]): Promise<{
   exitCode: number | null;
   stdout: string;
@@ -27,26 +29,63 @@ function runCli(args: string[]): Promise<{
 
     let stdout = '';
     let stderr = '';
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(
+        `CLI timed out after ${CLI_TIMEOUT_MS}ms: ${args.join(' ')}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      ));
+    }, CLI_TIMEOUT_MS);
+
     child.stdout.on('data', chunk => {
       stdout += chunk;
     });
     child.stderr.on('data', chunk => {
       stderr += chunk;
     });
-    child.on('error', reject);
-    child.on('close', exitCode => {
+    child.once('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', exitCode => {
+      clearTimeout(timeout);
       resolve({ exitCode, stdout, stderr });
     });
   });
 }
 
+let rootHelpPromise: ReturnType<typeof runCli> | undefined;
+
+function runRootHelp(): ReturnType<typeof runCli> {
+  rootHelpPromise ??= runCli(['--help']);
+  return rootHelpPromise;
+}
+
+function getCommandsBlock(stdout: string): string {
+  const marker = '\nCommands:\n';
+  const start = stdout.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  return stdout.slice(start + marker.length);
+}
+
 describe('CLI help output', () => {
   it('shows the canonical headless output flag and hides the legacy alias', async () => {
-    const result = await runCli(['--help']);
+    const result = await runRootHelp();
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('--output-format <format>');
     expect(result.stdout).not.toMatch(/^\s+--output <format>/m);
-  }, 30_000);
+  }, CLI_TIMEOUT_MS + 5_000);
+
+  it('flushes the complete root command block before exiting', async () => {
+    const result = await runRootHelp();
+    const commands = getCommandsBlock(result.stdout);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(commands).toMatch(/^\s+dev\s/m);
+    expect(commands).toMatch(/^\s+research\s/m);
+    expect(commands).toMatch(/^\s+completions\s/m);
+    expect(result.stdout.endsWith('\n')).toBe(true);
+  }, CLI_TIMEOUT_MS + 5_000);
 });


### PR DESCRIPTION
Lot CB-flakes6 (moteur sol, vérifié par Fable 5). Deux flakes vus ce soir sur macOS Node 20 (PR #136 et #140, docs-only) :

- `tests/cli/help-output.test.ts` › core profile : **stdout coupé en plein milieu de `try` avec code 0, avant la ligne `dev`** — Commander écrit l'aide puis appelle `process.exit()` immédiatement ; sur macOS le pipe est asynchrone et le suffixe en file d'attente est perdu si le lecteur est lent. Correctif à la source (`src/index.ts`) : pour la demande d'aide racine, `program.outputHelp()` une fois et sortie naturelle (Node vide stdout) au lieu de `parse()` → `exit`. Test : harness borné/réutilisé, assertions sur le bloc `Commands:`.
- `tests/agent/autonomous/checkpoint-resume.test.ts` : JSONL lu avant le flush de `run_end` → attente bornée de l'événement `run_end`.

Preuves : 5×5 verts sur chaque fichier (sol) + rejoués par Fable ; `tsc` 0 ; lint 0 erreur ; `git diff --check` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)