### PR TITLE
fix(cowork): stager le binding better-sqlite3 Electron avant le pre-build-check

### DIFF
--- a/cowork/package.json
+++ b/cowork/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "npm run download:node && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
     "dev:with-python": "npm run download:node && npm run prepare:python && npm run prepare:python:skills && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
-    "build": "npm run download:node && npm run prepare:gui-tools && npm run prepare:python:all && npm run prepare:python:skills && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && npm run build:tray-icon && tsc && vite build && npm run prepare:core-runtime && node scripts/pre-build-check.js && electron-builder",
+    "build": "npm run download:node && npm run prepare:gui-tools && npm run prepare:python:all && npm run prepare:python:skills && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && npm run build:tray-icon && tsc && vite build && npm run rebuild && npm run prepare:core-runtime && node scripts/pre-build-check.js && electron-builder",
     "build:e2e": "vite build",
     "build:win": "node scripts/build-windows.js",
     "build:tray-icon": "node scripts/build-tray-icon.js",

--- a/cowork/scripts/prepare-core-runtime.js
+++ b/cowork/scripts/prepare-core-runtime.js
@@ -412,9 +412,11 @@ function prepareCoreRuntime(options = {}) {
   }
 
   // The root install is compiled for the host Node ABI. Embedded mode runs in
-  // Electron, so use Cowork's postinstall-rebuilt package for this ABI-sensitive
-  // native dependency. Its JS API is backward-compatible with core usage.
-  if (options.useCoworkNativeOverrides !== false && packagePaths.includes('node_modules/better-sqlite3')) {
+  // Electron, so always stage Cowork's postinstall-rebuilt package for this
+  // ABI-sensitive dependency. better-sqlite3 is optional in the core manifest,
+  // but mandatory for Cowork, so it may not be present in packagePaths.
+  const nativeOverrides = [];
+  if (options.useCoworkNativeOverrides !== false) {
     const sqliteSource = path.join(coworkRoot, 'node_modules', 'better-sqlite3');
     const sqliteBinding = path.join(sqliteSource, 'build', 'Release', 'better_sqlite3.node');
     if (!fs.existsSync(sqliteBinding)) {
@@ -423,6 +425,7 @@ function prepareCoreRuntime(options = {}) {
       );
     }
     replacePackage(runtimeRoot, 'better-sqlite3', sqliteSource);
+    nativeOverrides.push('better-sqlite3');
   }
 
   const manifest = {
@@ -431,10 +434,7 @@ function prepareCoreRuntime(options = {}) {
     arch,
     includeRootOptional,
     packageCount: packagePaths.length,
-    nativeOverrides:
-      options.useCoworkNativeOverrides === false || !packagePaths.includes('node_modules/better-sqlite3')
-        ? []
-        : ['better-sqlite3'],
+    nativeOverrides,
   };
   fs.writeFileSync(
     path.join(runtimeRoot, 'codebuddy-runtime.json'),

--- a/cowork/src/tests/prepare-core-runtime.test.ts
+++ b/cowork/src/tests/prepare-core-runtime.test.ts
@@ -453,4 +453,70 @@ describe('prepareCoreRuntime', () => {
       ),
     ).toBe('electron-abi');
   });
+
+  it('stages Cowork SQLite when the core declares it as optional', () => {
+    const root = temporaryRoot();
+    const coreRoot = path.join(root, 'core');
+    const coworkRoot = path.join(root, 'cowork');
+    const runtimeRoot = path.join(coworkRoot, '.bundle-resources', 'core-runtime');
+    writeFile(
+      path.join(coreRoot, 'package.json'),
+      JSON.stringify({
+        name: '@phuetz/code-buddy',
+        version: '1.0.0',
+        description: 'Optional SQLite runtime fixture',
+        optionalDependencies: { 'better-sqlite3': '1.0.0' },
+      }),
+    );
+    writeFile(
+      path.join(coreRoot, 'dist', 'desktop', 'codebuddy-engine-adapter.js'),
+      'export class CodeBuddyEngineAdapter {}',
+    );
+    writePackage(coreRoot, 'node_modules/better-sqlite3', { version: 'node-build' });
+    writeFile(
+      path.join(
+        coreRoot,
+        'node_modules',
+        'better-sqlite3',
+        'build',
+        'Release',
+        'better_sqlite3.node',
+      ),
+      'node-abi',
+    );
+    writePackage(coworkRoot, 'node_modules/better-sqlite3', { version: 'electron-build' });
+    writeFile(
+      path.join(
+        coworkRoot,
+        'node_modules',
+        'better-sqlite3',
+        'build',
+        'Release',
+        'better_sqlite3.node',
+      ),
+      'electron-abi',
+    );
+    writeCoreRuntimeManifest(coreRoot, {
+      name: '@phuetz/code-buddy',
+      version: '1.0.0',
+      description: 'Optional SQLite runtime fixture',
+    });
+
+    const result = prepareCoreRuntime({ coreRoot, coworkRoot, runtimeRoot });
+
+    expect(result.manifest.nativeOverrides).toEqual(['better-sqlite3']);
+    expect(
+      fs.readFileSync(
+        path.join(
+          runtimeRoot,
+          'node_modules',
+          'better-sqlite3',
+          'build',
+          'Release',
+          'better_sqlite3.node',
+        ),
+        'utf8',
+      ),
+    ).toBe('electron-abi');
+  });
 });

--- a/cowork/tests/core-runtime-packaging.test.ts
+++ b/cowork/tests/core-runtime-packaging.test.ts
@@ -53,6 +53,10 @@ describe('Code Buddy core runtime packaging', () => {
     expect(packageJson.scripts?.['prepare:core-runtime']).toBe(
       'node scripts/prepare-core-runtime.js',
     );
+    expect(build.indexOf('npm run rebuild')).toBeGreaterThan(-1);
+    expect(build.indexOf('npm run rebuild')).toBeLessThan(
+      build.indexOf('npm run prepare:core-runtime'),
+    );
     expect(build.indexOf('npm run prepare:core-runtime')).toBeGreaterThan(-1);
     expect(build.indexOf('npm run prepare:core-runtime')).toBeLessThan(
       build.indexOf('node scripts/pre-build-check.js'),
@@ -64,9 +68,12 @@ describe('Code Buddy core runtime packaging', () => {
       path.join(coworkRoot, '..', 'scripts', 'build-all.js'),
       'utf8',
     );
+    const rebuild = buildAll.indexOf("['run', 'rebuild']");
     const prepare = buildAll.indexOf("['scripts/prepare-core-runtime.js']");
     const precheck = buildAll.indexOf("['scripts/pre-build-check.js']");
     const builder = buildAll.indexOf("['electron-builder', '--config'");
+    expect(rebuild).toBeGreaterThan(-1);
+    expect(rebuild).toBeLessThan(prepare);
     expect(prepare).toBeGreaterThan(-1);
     expect(precheck).toBeGreaterThan(prepare);
     expect(builder).toBeGreaterThan(precheck);

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -49,6 +49,10 @@ if (existsSync(coworkDir)) {
   // ─── Step 3: Package installer (optional) ────────────────────────────────
   if (pack) {
     console.log('\n═══ Step 3/3: Packaging installer ═══');
+    // The embedded runtime and the Cowork main process both load
+    // better-sqlite3 from Electron. Rebuild it before staging the runtime so
+    // the packaging path has the same ABI guarantee as `cowork npm run build`.
+    run(npm, ['run', 'rebuild'], coworkDir);
     // The embedded core lives outside app.asar at resources/dist. Stage its
     // production dependency closure beside it before electron-builder runs;
     // otherwise bare imports such as `chalk` cannot resolve in production.


### PR DESCRIPTION
Lot CW3 (luna, vérifié par Fable 5). Le packaging electron-builder avortait au pré-check « staged Electron-native SQLite binding » : le binding rebuilt pour Electron n'était pas copié dans .bundle-resources/core-runtime. Correctif `770c3e6b` : staging systématique du binding rebuilt AVANT `pre-build-check`, dans les deux workflows. Preuves : vitest ciblé 3 fichiers/39 tests verts ; séquence réelle `vite build` + `prepare:core-runtime` + `node scripts/pre-build-check.js` → **15 passed, 0 failed** (avant : 14/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)